### PR TITLE
feat: Step 1 — Contracts, Event Types, and Replay Tests

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,12 +62,18 @@ GitHub App, Slack/Teams는 서로 다른 trigger source. 이들을 공통 이벤
 **이벤트 타입:**
 
 ```
-PROpened { repo, diff, author, ... }
-PRCommented { repo, pr, author, body, ... }
-PRReviewed { repo, pr, reviewer, verdict, comments, ... }
-CICompleted { repo, pr, results, ... }
-ChatMention { channel, thread, mentionType, ... }
+PROpened    { meta: EventMeta, repo, pr_number, title, author, base_branch, head_branch,
+              diff_url, files_changed: [FileChange], ... }
+PRUpdated   { meta: EventMeta, repo, pr_number, ... }          # PROpened와 같은 필드 (synchronize/edited/reopened)
+PRCommented { meta: EventMeta, repo, pr_number, author, body, comment_id, ... }
+PRReviewed  { meta: EventMeta, repo, pr_number, reviewer, state, body, ... }   # state: approved/changes_requested/commented
+CICompleted { meta: EventMeta, repo, pr_number, commit_sha, conclusion, failed_jobs, ... }
+ChatMention { meta: EventMeta, platform, channel_id, channel_name, author, message, ... }
 ```
+
+모든 이벤트는 공통 `EventMeta`(`event_id`, `event_type`, `correlation_id`, `timestamp`, `source`)를 포함한다. 실제 계약의 repo 필드명은 `repo_full_name`이며, 위 표기는 개요 용도의 shorthand.
+
+`FileChange`는 경량 메타데이터(`path`, `status`, `additions`, `deletions`, `previous_filename`)만 보유. 실제 diff 텍스트와 파일 내용은 이벤트에 싣지 않고, runtime에서 별도 fetch 레이어(`GET /repos/{owner}/{repo}/pulls/{number}/files` 등)로 조회한다. 이벤트가 작을수록 queue·persist·replay 비용이 낮아지기 때문.
 
 `ChatMention`은 개발자가 `@devclaw`를 태그했을 때 발생. 쓰레드 전체를 읽고 변경 의도/맥락을 파악하며, 태그 시 요약 메시지가 함께 있으면 보조 맥락으로 활용한다.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -19,6 +19,15 @@
   - **전략 정밀도** — 범용 제안 → repo 히스토리 기반 맞춤 제안
   - **자율성 수준** — 제안만 → 테스트 코드 자동 생성/수정
 
+### PRClosed 이벤트
+
+- 현재 이벤트 스키마에 `PRClosed`가 없음 (`EventType`에도 해당 멤버 부재)
+- 필요해질 수 있는 시나리오:
+  - **merged vs closed 구분** (`action=closed` + `merged=true/false`) — merged PR의 QA 리포트를 Knowledge Store에 영구 저장할지 결정
+  - **진행 중 validation 취소** — PR이 닫히면 running job 중단, 임시 artifact 정리
+  - **correlation_id 수명 관리** — 종료 시점에 리소스 정리
+- 결정 보류: Step 2 orchestrator + Knowledge Store 설계가 확정된 뒤에 추가 (그 때 `merged: bool` 필드와 함께)
+
 ### MVP 성공 지표
 
 - Agent의 Risk 판단 정확도를 어떻게 측정할 것인지

--- a/docs/MODULE_REQUIREMENTS.md
+++ b/docs/MODULE_REQUIREMENTS.md
@@ -77,7 +77,7 @@ devclaw를 구현할 때 참고할 수 있는 모듈 단위 요구사항 문서.
 
 **필수 요구사항**
 
-- `PROpened`, `PRCommented`, `PRReviewed`, `CICompleted`, `ChatMention` 이벤트 타입 정의
+- `PROpened`, `PRUpdated`, `PRCommented`, `PRReviewed`, `CICompleted`, `ChatMention` 이벤트 타입 정의
 - risk level, validation result, strategy result, renderer payload를 위한 기본 타입 정의
 - provider별 payload가 아니라 시스템 내부 표준 타입을 기준으로 삼을 것
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -122,7 +122,7 @@ adapters.knowledge  → core.knowledge, shared
 
 ### `core/`
 
-- `core/contracts`: `PROpened`, `PRCommented`, `PRReviewed`, `CICompleted`, `ChatMention` 같은 공통 이벤트 스키마와 domain type
+- `core/contracts`: `PROpened`, `PRUpdated`, `PRCommented`, `PRReviewed`, `CICompleted`, `ChatMention` 같은 공통 이벤트 스키마와 domain type
 - `core/analyzer`: diff 분석, 영향 범위 추정, 리스크 분류
 - `core/strategy`: Behaviour Checklist 생성, 검증 전략 선택, 누락 테스트 제안
 - `core/knowledge`: 고객 QA 지식 자산 접근을 위한 port, query model, in-memory mock

--- a/src/app/gateway/__init__.py
+++ b/src/app/gateway/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import sys
 
-from src.shared import get_logger, setup_logging
+from ...shared import get_logger, setup_logging
 
 logger = get_logger(__name__)
 

--- a/src/app/worker/__init__.py
+++ b/src/app/worker/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import sys
 
-from src.shared import get_logger, setup_logging
+from ...shared import get_logger, setup_logging
 
 logger = get_logger(__name__)
 

--- a/src/core/contracts/__init__.py
+++ b/src/core/contracts/__init__.py
@@ -7,7 +7,8 @@ This package re-exports every public type so consumers can write::
 
 from __future__ import annotations
 
-from src.core.contracts.domain import (
+from .domain import (
+    ActionType,
     BehaviourImpact,
     ImpactArea,
     QAReport,
@@ -17,19 +18,21 @@ from src.core.contracts.domain import (
     ValidationOutcome,
     ValidationResult,
 )
-from src.core.contracts.events import (
+from .events import (
     ChatMention,
     CICompleted,
     Event,
     EventMeta,
+    EventSource,
     EventType,
     FileChange,
     PRCommented,
+    PREvent,
     PROpened,
     PRReviewed,
     PRUpdated,
 )
-from src.core.contracts.parsers import (
+from .parsers import (
     parse_github_ci_event,
     parse_github_comment_event,
     parse_github_pr_event,
@@ -37,15 +40,18 @@ from src.core.contracts.parsers import (
 )
 
 __all__ = [
+    "ActionType",
     "BehaviourImpact",
     "CICompleted",
     "ChatMention",
     "Event",
     "EventMeta",
+    "EventSource",
     "EventType",
     "FileChange",
     "ImpactArea",
     "PRCommented",
+    "PREvent",
     "PROpened",
     "PRReviewed",
     "PRUpdated",

--- a/src/core/contracts/__init__.py
+++ b/src/core/contracts/__init__.py
@@ -1,1 +1,62 @@
-"""Shared event types and domain models."""
+"""Shared event types and domain models.
+
+This package re-exports every public type so consumers can write::
+
+    from src.core.contracts import PROpened, RiskLevel, QAReport
+"""
+
+from __future__ import annotations
+
+from src.core.contracts.domain import (
+    BehaviourImpact,
+    ImpactArea,
+    QAReport,
+    RiskLevel,
+    StrategyAction,
+    StrategyResult,
+    ValidationOutcome,
+    ValidationResult,
+)
+from src.core.contracts.events import (
+    ChatMention,
+    CICompleted,
+    Event,
+    EventMeta,
+    EventType,
+    FileChange,
+    PRCommented,
+    PROpened,
+    PRReviewed,
+    PRUpdated,
+)
+from src.core.contracts.parsers import (
+    parse_github_ci_event,
+    parse_github_comment_event,
+    parse_github_pr_event,
+    parse_github_pr_review_event,
+)
+
+__all__ = [
+    "BehaviourImpact",
+    "CICompleted",
+    "ChatMention",
+    "Event",
+    "EventMeta",
+    "EventType",
+    "FileChange",
+    "ImpactArea",
+    "PRCommented",
+    "PROpened",
+    "PRReviewed",
+    "PRUpdated",
+    "QAReport",
+    "RiskLevel",
+    "StrategyAction",
+    "StrategyResult",
+    "ValidationOutcome",
+    "ValidationResult",
+    "parse_github_ci_event",
+    "parse_github_comment_event",
+    "parse_github_pr_event",
+    "parse_github_pr_review_event",
+]

--- a/src/core/contracts/domain.py
+++ b/src/core/contracts/domain.py
@@ -1,0 +1,95 @@
+"""Domain types for devclaw's core analysis pipeline.
+
+These types represent the outputs of the Behaviour Analyzer, Strategy Engine,
+Validator, and the final QA Report.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, unique
+
+
+@unique
+class RiskLevel(Enum):
+    """Risk classification for a code change."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass(frozen=True)
+class ImpactArea:
+    """An area of the system impacted by a change."""
+
+    module: str
+    description: str
+    risk_level: RiskLevel
+    affected_files: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BehaviourImpact:
+    """Output of the Behaviour Analyzer."""
+
+    summary: str
+    areas: tuple[ImpactArea, ...]
+    overall_risk: RiskLevel
+    raw_diff_stats: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StrategyAction:
+    """A single validation action recommended by the Strategy Engine."""
+
+    action_type: str
+    description: str
+    target: str
+    priority: int = 0
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class StrategyResult:
+    """Output of the Strategy Engine."""
+
+    actions: tuple[StrategyAction, ...]
+    reasoning: str
+    confidence: float
+    knowledge_refs: tuple[str, ...] = ()
+
+
+@unique
+class ValidationOutcome(Enum):
+    """Outcome of a single validation action."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Result of a single validation action."""
+
+    action: StrategyAction
+    outcome: ValidationOutcome
+    details: str = ""
+    duration_seconds: float = 0.0
+    artifacts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class QAReport:
+    """Final output — the full report for a PR/event."""
+
+    event_id: str
+    repo_full_name: str
+    pr_number: int | None
+    impact: BehaviourImpact
+    strategy: StrategyResult
+    validations: tuple[ValidationResult, ...]
+    summary_markdown: str

--- a/src/core/contracts/domain.py
+++ b/src/core/contracts/domain.py
@@ -20,9 +20,41 @@ class RiskLevel(Enum):
     CRITICAL = "critical"
 
 
+@unique
+class ActionType(Enum):
+    """Known validation-action categories emitted by the Strategy Engine.
+
+    The ``CUSTOM`` member is an intentional escape hatch: the engine is
+    LLM-driven and may legitimately propose action shapes we have not
+    enumerated yet.  When :attr:`StrategyAction.action_type` is
+    :attr:`CUSTOM`, consumers should fall back to :attr:`StrategyAction.description`
+    for human-readable intent and to :attr:`StrategyAction.target` for the
+    concrete object the action operates on.
+
+    Prefer adding a new enum member over emitting ``CUSTOM`` when a category
+    starts showing up consistently.
+    """
+
+    RUN_TESTS = "run_tests"
+    RUN_LINTER = "run_linter"
+    TYPE_CHECK = "type_check"
+    CHECK_SECURITY = "check_security"
+    VERIFY_API_CONTRACT = "verify_api_contract"
+    SMOKE_TEST = "smoke_test"
+    CUSTOM = "custom"  # escape hatch — see class docstring
+
+
 @dataclass(frozen=True)
 class ImpactArea:
-    """An area of the system impacted by a change."""
+    """An area of the analysed project that is touched by a change.
+
+    ``module`` refers to a logical module of the **target project being
+    analysed** (e.g. ``"auth"``, ``"payments"``, ``"api.v2"``) — not to
+    devclaw's own internal modules.  The Behaviour Analyzer is responsible
+    for mapping changed file paths to module names; when the target
+    project lacks a stable module taxonomy (or renames modules), the
+    Analyzer should fall back to directory-prefix names or file paths.
+    """
 
     module: str
     description: str
@@ -32,7 +64,13 @@ class ImpactArea:
 
 @dataclass(frozen=True)
 class BehaviourImpact:
-    """Output of the Behaviour Analyzer."""
+    """Output of the Behaviour Analyzer.
+
+    ``raw_diff_stats`` is an open-ended dict so the Analyzer can attach
+    whatever numeric stats it finds useful without a schema change.
+    Typical keys: ``"additions"``, ``"deletions"``, ``"files_changed"``,
+    ``"files_added"``, ``"files_modified"``, ``"files_removed"``.
+    """
 
     summary: str
     areas: tuple[ImpactArea, ...]
@@ -42,9 +80,37 @@ class BehaviourImpact:
 
 @dataclass(frozen=True)
 class StrategyAction:
-    """A single validation action recommended by the Strategy Engine."""
+    """A single validation action recommended by the Strategy Engine.
 
-    action_type: str
+    Field conventions:
+
+    * ``action_type`` — the category of the action.  See :class:`ActionType`
+      for the known enum values plus the ``CUSTOM`` escape hatch.
+    * ``target`` — the concrete object the action operates on.  Its
+      format depends on ``action_type``:
+
+        ======================  ===============================================
+        action_type             target format
+        ======================  ===============================================
+        RUN_TESTS               test file path or directory (e.g. ``tests/``)
+        RUN_LINTER              source directory (e.g. ``src/``)
+        TYPE_CHECK              source directory or package name
+        CHECK_SECURITY          ``path:line`` or a source file
+        VERIFY_API_CONTRACT     HTTP method + route (e.g. ``POST /api/login``)
+        SMOKE_TEST              endpoint URL or scenario id
+        CUSTOM                  free-form — see ``description``
+        ======================  ===============================================
+
+    * ``priority`` — **higher integer = more urgent.**  Recommended scale:
+      ``0`` (default/normal), ``1-2`` (elevated), ``3`` (high),
+      ``4+`` (critical / must-run).  There is no hard upper bound; consumers
+      should sort by this field descending.
+    * ``rationale`` — natural-language reason the engine picked this action.
+      Crucial for auditability of LLM decisions; may be empty for
+      deterministic rules.
+    """
+
+    action_type: ActionType
     description: str
     target: str
     priority: int = 0

--- a/src/core/contracts/events.py
+++ b/src/core/contracts/events.py
@@ -1,0 +1,137 @@
+"""Event types for devclaw's event-driven architecture.
+
+All events are frozen dataclasses representing normalized webhook payloads
+from GitHub, Slack, Teams, and other integration sources.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum, unique
+
+
+@unique
+class EventType(Enum):
+    """Discriminator for all event kinds flowing through the system."""
+
+    PR_OPENED = "pr_opened"
+    PR_UPDATED = "pr_updated"
+    PR_COMMENTED = "pr_commented"
+    PR_REVIEWED = "pr_reviewed"
+    CI_COMPLETED = "ci_completed"
+    CHAT_MENTION = "chat_mention"
+
+
+@dataclass(frozen=True)
+class EventMeta:
+    """Common metadata attached to every event."""
+
+    event_id: str
+    event_type: EventType
+    correlation_id: str
+    timestamp: datetime
+    source: str
+
+
+@dataclass(frozen=True)
+class FileChange:
+    """A single file changed in a pull request."""
+
+    path: str
+    status: str  # "added", "modified", "removed", "renamed"
+    additions: int = 0
+    deletions: int = 0
+    patch: str = ""
+
+
+@dataclass(frozen=True)
+class PROpened:
+    """A pull request was opened."""
+
+    meta: EventMeta
+    repo_full_name: str
+    pr_number: int
+    title: str
+    body: str
+    author: str
+    base_branch: str
+    head_branch: str
+    diff_url: str
+    files_changed: tuple[FileChange, ...] = ()
+
+
+@dataclass(frozen=True)
+class PRUpdated:
+    """A pull request was updated (new commits pushed, rebased, etc.)."""
+
+    meta: EventMeta
+    repo_full_name: str
+    pr_number: int
+    title: str
+    body: str
+    author: str
+    base_branch: str
+    head_branch: str
+    diff_url: str
+    files_changed: tuple[FileChange, ...] = ()
+
+
+@dataclass(frozen=True)
+class PRCommented:
+    """A comment was posted on a pull request."""
+
+    meta: EventMeta
+    repo_full_name: str
+    pr_number: int
+    comment_id: int
+    author: str
+    body: str
+    is_review_comment: bool = False
+    path: str = ""
+    line: int | None = None
+
+
+@dataclass(frozen=True)
+class PRReviewed:
+    """A pull request review was submitted."""
+
+    meta: EventMeta
+    repo_full_name: str
+    pr_number: int
+    reviewer: str
+    state: str  # "approved", "changes_requested", "commented"
+    body: str = ""
+
+
+@dataclass(frozen=True)
+class CICompleted:
+    """A CI workflow run completed."""
+
+    meta: EventMeta
+    repo_full_name: str
+    pr_number: int | None
+    commit_sha: str
+    workflow_name: str
+    conclusion: str  # "success", "failure", "cancelled", "timed_out"
+    run_url: str
+    failed_jobs: tuple[str, ...] = ()
+    logs_url: str = ""
+
+
+@dataclass(frozen=True)
+class ChatMention:
+    """The bot was mentioned in a chat channel."""
+
+    meta: EventMeta
+    platform: str  # "slack", "teams"
+    channel_id: str
+    channel_name: str
+    author: str
+    message: str
+    thread_id: str = ""
+    referenced_pr: int | None = None
+
+
+# Union of all concrete event types
+Event = PROpened | PRUpdated | PRCommented | PRReviewed | CICompleted | ChatMention

--- a/src/core/contracts/events.py
+++ b/src/core/contracts/events.py
@@ -23,6 +23,20 @@ class EventType(Enum):
     CHAT_MENTION = "chat_mention"
 
 
+@unique
+class EventSource(Enum):
+    """Originating system of an event.
+
+    Constrained to a known set so typos in parser/test code fail loudly.
+    Extend this enum when adding a new integration (e.g. GitLab, Bitbucket).
+    """
+
+    GITHUB = "github"
+    SLACK = "slack"
+    TEAMS = "teams"
+    REPLAY = "replay"  # replayed from a recorded fixture — useful for tests and backfill
+
+
 @dataclass(frozen=True)
 class EventMeta:
     """Common metadata attached to every event."""
@@ -31,50 +45,61 @@ class EventMeta:
     event_type: EventType
     correlation_id: str
     timestamp: datetime
-    source: str
+    source: EventSource
 
 
 @dataclass(frozen=True)
 class FileChange:
-    """A single file changed in a pull request."""
+    """A single file changed in a pull request.
+
+    Lightweight metadata only — the actual diff text (``patch``) and the
+    full file contents are NOT carried on the event.  They are fetched
+    on-demand by a separate fetch layer (see Step 2) because:
+
+    * Webhook payloads don't include per-file diffs anyway — they must be
+      pulled from ``GET /repos/{owner}/{repo}/pulls/{num}/files``.
+    * Events may be persisted / queued / replayed, so keeping them small
+      avoids bloating the transport and storage.
+    """
 
     path: str
     status: str  # "added", "modified", "removed", "renamed"
     additions: int = 0
     deletions: int = 0
-    patch: str = ""
+    previous_filename: str = ""  # populated when status == "renamed"
 
 
 @dataclass(frozen=True)
-class PROpened:
+class PREvent:
+    """Base fields shared by every PR-state event.
+
+    Concrete subclasses (:class:`PROpened`, :class:`PRUpdated`, ...) carry
+    the exact same structural fields today; the distinction is purely
+    semantic and flows through :attr:`EventMeta.event_type`.  Keeping them
+    as separate types preserves pattern-matching ergonomics while the base
+    class removes field duplication.
+    """
+
+    meta: EventMeta
+    repo_full_name: str
+    pr_number: int
+    title: str
+    body: str
+    author: str
+    base_branch: str
+    head_branch: str
+    diff_url: str
+    files_changed: tuple[FileChange, ...] = ()
+
+
+@dataclass(frozen=True)
+class PROpened(PREvent):
     """A pull request was opened."""
 
-    meta: EventMeta
-    repo_full_name: str
-    pr_number: int
-    title: str
-    body: str
-    author: str
-    base_branch: str
-    head_branch: str
-    diff_url: str
-    files_changed: tuple[FileChange, ...] = ()
-
 
 @dataclass(frozen=True)
-class PRUpdated:
+class PRUpdated(PREvent):
     """A pull request was updated (new commits pushed, rebased, etc.)."""
-
-    meta: EventMeta
-    repo_full_name: str
-    pr_number: int
-    title: str
-    body: str
-    author: str
-    base_branch: str
-    head_branch: str
-    diff_url: str
-    files_changed: tuple[FileChange, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -106,7 +131,12 @@ class PRReviewed:
 
 @dataclass(frozen=True)
 class CICompleted:
-    """A CI workflow run completed."""
+    """A CI workflow run completed.
+
+    ``failed_jobs`` is populated by the fetch layer (Step 2) — the raw
+    ``workflow_run`` webhook does not include per-job results; they must
+    be fetched via ``GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs``.
+    """
 
     meta: EventMeta
     repo_full_name: str
@@ -122,6 +152,9 @@ class CICompleted:
 @dataclass(frozen=True)
 class ChatMention:
     """The bot was mentioned in a chat channel."""
+
+    # TODO(Step 6): add `parse_slack_mention_event` / `parse_teams_mention_event`
+    # parsers to accompany this type.
 
     meta: EventMeta
     platform: str  # "slack", "teams"

--- a/src/core/contracts/parsers.py
+++ b/src/core/contracts/parsers.py
@@ -1,0 +1,236 @@
+"""Parsers that convert raw webhook JSON payloads into normalised event types.
+
+Each parser is tolerant of missing fields, falling back to sensible defaults
+so that incomplete or evolving webhook schemas don't cause hard failures.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from src.core.contracts.events import (
+    CICompleted,
+    EventMeta,
+    EventType,
+    FileChange,
+    PRCommented,
+    PROpened,
+    PRReviewed,
+    PRUpdated,
+)
+
+
+def _get(d: dict[str, Any], *keys: str, default: Any = "") -> Any:
+    """Safely traverse nested dicts, returning *default* on any missing key."""
+    current: Any = d
+    for key in keys:
+        if isinstance(current, dict):
+            current = current.get(key, default)
+        else:
+            return default
+    return current
+
+
+def _parse_files(files: list[dict[str, Any]]) -> tuple[FileChange, ...]:
+    """Convert a list of GitHub file-change dicts to FileChange tuples."""
+    return tuple(
+        FileChange(
+            path=f.get("filename", ""),
+            status=f.get("status", "modified"),
+            additions=int(f.get("additions", 0)),
+            deletions=int(f.get("deletions", 0)),
+            patch=f.get("patch", ""),
+        )
+        for f in files
+    )
+
+
+def _now() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Pull-request events
+# ---------------------------------------------------------------------------
+
+
+def parse_github_pr_event(
+    payload: dict[str, Any],
+    action: str,
+    correlation_id: str,
+) -> PROpened | PRUpdated | None:
+    """Parse a GitHub ``pull_request`` webhook payload.
+
+    Returns :class:`PROpened` for ``"opened"`` actions and :class:`PRUpdated`
+    for ``"synchronize"`` (and similar update actions).  Returns ``None`` for
+    actions we don't handle.
+    """
+    pr: dict[str, Any] = payload.get("pull_request", {})
+    repo: dict[str, Any] = payload.get("repository", {})
+
+    if action == "opened":
+        event_type = EventType.PR_OPENED
+    elif action in {"synchronize", "edited", "reopened"}:
+        event_type = EventType.PR_UPDATED
+    else:
+        return None
+
+    meta = EventMeta(
+        event_id=str(uuid.uuid4()),
+        event_type=event_type,
+        correlation_id=correlation_id,
+        timestamp=_now(),
+        source="github",
+    )
+
+    files_raw: list[dict[str, Any]] = payload.get("files", [])
+    files_changed = _parse_files(files_raw)
+
+    common_kwargs: dict[str, Any] = {
+        "meta": meta,
+        "repo_full_name": repo.get("full_name", ""),
+        "pr_number": int(pr.get("number", 0)),
+        "title": pr.get("title", ""),
+        "body": pr.get("body", "") or "",
+        "author": _get(pr, "user", "login"),
+        "base_branch": _get(pr, "base", "ref"),
+        "head_branch": _get(pr, "head", "ref"),
+        "diff_url": pr.get("diff_url", ""),
+        "files_changed": files_changed,
+    }
+
+    if event_type == EventType.PR_OPENED:
+        return PROpened(**common_kwargs)
+    return PRUpdated(**common_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# CI events
+# ---------------------------------------------------------------------------
+
+
+def parse_github_ci_event(
+    payload: dict[str, Any],
+    correlation_id: str,
+) -> CICompleted | None:
+    """Parse a GitHub ``workflow_run`` webhook payload.
+
+    Returns ``None`` when the workflow has not yet completed.
+    """
+    wf: dict[str, Any] = payload.get("workflow_run", {})
+    repo: dict[str, Any] = payload.get("repository", {})
+
+    conclusion = wf.get("conclusion", "")
+    if not conclusion:
+        return None
+
+    # Determine associated PR number (if any)
+    pr_numbers: list[dict[str, Any]] = wf.get("pull_requests", [])
+    pr_number: int | None = int(pr_numbers[0]["number"]) if pr_numbers else None
+
+    failed_jobs: list[str] = [j.get("name", "") for j in payload.get("failed_jobs", []) if j.get("name")]
+
+    meta = EventMeta(
+        event_id=str(uuid.uuid4()),
+        event_type=EventType.CI_COMPLETED,
+        correlation_id=correlation_id,
+        timestamp=_now(),
+        source="github",
+    )
+
+    return CICompleted(
+        meta=meta,
+        repo_full_name=repo.get("full_name", ""),
+        pr_number=pr_number,
+        commit_sha=_get(wf, "head_sha"),
+        workflow_name=wf.get("name", ""),
+        conclusion=conclusion,
+        run_url=wf.get("html_url", ""),
+        failed_jobs=tuple(failed_jobs),
+        logs_url=wf.get("logs_url", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR review events
+# ---------------------------------------------------------------------------
+
+
+def parse_github_pr_review_event(
+    payload: dict[str, Any],
+    correlation_id: str,
+) -> PRReviewed | None:
+    """Parse a GitHub ``pull_request_review`` webhook payload."""
+    review: dict[str, Any] = payload.get("review", {})
+    pr: dict[str, Any] = payload.get("pull_request", {})
+    repo: dict[str, Any] = payload.get("repository", {})
+
+    state_raw = review.get("state", "")
+    if not state_raw:
+        return None
+
+    meta = EventMeta(
+        event_id=str(uuid.uuid4()),
+        event_type=EventType.PR_REVIEWED,
+        correlation_id=correlation_id,
+        timestamp=_now(),
+        source="github",
+    )
+
+    return PRReviewed(
+        meta=meta,
+        repo_full_name=repo.get("full_name", ""),
+        pr_number=int(pr.get("number", 0)),
+        reviewer=_get(review, "user", "login"),
+        state=state_raw.lower(),
+        body=review.get("body", "") or "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comment events
+# ---------------------------------------------------------------------------
+
+
+def parse_github_comment_event(
+    payload: dict[str, Any],
+    correlation_id: str,
+) -> PRCommented | None:
+    """Parse a GitHub ``issue_comment`` or ``pull_request_review_comment`` webhook payload."""
+    comment: dict[str, Any] = payload.get("comment", {})
+    repo: dict[str, Any] = payload.get("repository", {})
+
+    # Determine PR number — either from pull_request or issue
+    pr_number = 0
+    if "pull_request" in payload:
+        pr_number = int(payload["pull_request"].get("number", 0))
+    elif "issue" in payload:
+        pr_number = int(payload["issue"].get("number", 0))
+
+    if not comment:
+        return None
+
+    is_review_comment = "pull_request_review_id" in comment
+
+    meta = EventMeta(
+        event_id=str(uuid.uuid4()),
+        event_type=EventType.PR_COMMENTED,
+        correlation_id=correlation_id,
+        timestamp=_now(),
+        source="github",
+    )
+
+    return PRCommented(
+        meta=meta,
+        repo_full_name=repo.get("full_name", ""),
+        pr_number=pr_number,
+        comment_id=int(comment.get("id", 0)),
+        author=_get(comment, "user", "login"),
+        body=comment.get("body", "") or "",
+        is_review_comment=is_review_comment,
+        path=comment.get("path", "") or "",
+        line=comment.get("line"),
+    )

--- a/src/core/contracts/parsers.py
+++ b/src/core/contracts/parsers.py
@@ -2,6 +2,16 @@
 
 Each parser is tolerant of missing fields, falling back to sensible defaults
 so that incomplete or evolving webhook schemas don't cause hard failures.
+
+These parsers intentionally produce **lightweight** events:
+
+* ``FileChange`` carries only per-file metadata (path, status, line counts).
+  Actual diff text and file contents are NOT attached — they are fetched
+  on-demand by the Step 2 fetch layer.
+* ``CICompleted.failed_jobs`` is populated from a synthetic ``failed_jobs``
+  key if present (used by test fixtures).  In production the real
+  ``workflow_run`` webhook has no such field; the fetch layer must
+  enrich the event from ``GET /repos/.../actions/runs/{id}/jobs``.
 """
 
 from __future__ import annotations
@@ -10,9 +20,10 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from src.core.contracts.events import (
+from .events import (
     CICompleted,
     EventMeta,
+    EventSource,
     EventType,
     FileChange,
     PRCommented,
@@ -34,14 +45,20 @@ def _get(d: dict[str, Any], *keys: str, default: Any = "") -> Any:
 
 
 def _parse_files(files: list[dict[str, Any]]) -> tuple[FileChange, ...]:
-    """Convert a list of GitHub file-change dicts to FileChange tuples."""
+    """Convert a list of GitHub file-change dicts to FileChange tuples.
+
+    Note: real ``pull_request`` webhook payloads don't include this array —
+    it must be fetched separately. Parsers accept it here so test fixtures
+    and the future fetch layer can feed pre-enriched payloads through the
+    same code path.
+    """
     return tuple(
         FileChange(
             path=f.get("filename", ""),
             status=f.get("status", "modified"),
             additions=int(f.get("additions", 0)),
             deletions=int(f.get("deletions", 0)),
-            patch=f.get("patch", ""),
+            previous_filename=f.get("previous_filename", "") or "",
         )
         for f in files
     )
@@ -83,7 +100,7 @@ def parse_github_pr_event(
         event_type=event_type,
         correlation_id=correlation_id,
         timestamp=_now(),
-        source="github",
+        source=EventSource.GITHUB,
     )
 
     files_raw: list[dict[str, Any]] = payload.get("files", [])
@@ -129,7 +146,7 @@ def parse_github_ci_event(
 
     # Determine associated PR number (if any)
     pr_numbers: list[dict[str, Any]] = wf.get("pull_requests", [])
-    pr_number: int | None = int(pr_numbers[0]["number"]) if pr_numbers else None
+    pr_number: int | None = int(pr_numbers[0].get("number", 0)) if pr_numbers else None
 
     failed_jobs: list[str] = [j.get("name", "") for j in payload.get("failed_jobs", []) if j.get("name")]
 
@@ -138,7 +155,7 @@ def parse_github_ci_event(
         event_type=EventType.CI_COMPLETED,
         correlation_id=correlation_id,
         timestamp=_now(),
-        source="github",
+        source=EventSource.GITHUB,
     )
 
     return CICompleted(
@@ -177,7 +194,7 @@ def parse_github_pr_review_event(
         event_type=EventType.PR_REVIEWED,
         correlation_id=correlation_id,
         timestamp=_now(),
-        source="github",
+        source=EventSource.GITHUB,
     )
 
     return PRReviewed(
@@ -203,12 +220,26 @@ def parse_github_comment_event(
     comment: dict[str, Any] = payload.get("comment", {})
     repo: dict[str, Any] = payload.get("repository", {})
 
-    # Determine PR number — either from pull_request or issue
+    # Determine PR number — distinguish between PR comments and issue comments.
+    # GitHub's ``issue_comment`` webhook fires for BOTH issues and PRs.  We only
+    # want to emit ``PRCommented`` for actual PR conversations; plain-issue
+    # comments are out of scope for devclaw and must be dropped.
+    #
+    # Disambiguation rules:
+    # * ``payload["pull_request"]`` present  → PR review-comment payload
+    # * ``payload["issue"]["pull_request"]`` present → issue_comment on a PR
+    #   (GitHub injects this nested object when the issue is a PR)
+    # * otherwise the comment belongs to a plain issue — return ``None``
     pr_number = 0
     if "pull_request" in payload:
         pr_number = int(payload["pull_request"].get("number", 0))
     elif "issue" in payload:
-        pr_number = int(payload["issue"].get("number", 0))
+        issue: dict[str, Any] = payload.get("issue", {})
+        if not issue.get("pull_request"):
+            return None
+        pr_number = int(issue.get("number", 0))
+    else:
+        return None
 
     if not comment:
         return None
@@ -220,8 +251,11 @@ def parse_github_comment_event(
         event_type=EventType.PR_COMMENTED,
         correlation_id=correlation_id,
         timestamp=_now(),
-        source="github",
+        source=EventSource.GITHUB,
     )
+
+    raw_line = comment.get("line")
+    line: int | None = int(raw_line) if raw_line is not None else None
 
     return PRCommented(
         meta=meta,
@@ -232,5 +266,5 @@ def parse_github_comment_event(
         body=comment.get("body", "") or "",
         is_review_comment=is_review_comment,
         path=comment.get("path", "") or "",
-        line=comment.get("line"),
+        line=line,
     )

--- a/tests/fixtures/github_ci_completed_failure.json
+++ b/tests/fixtures/github_ci_completed_failure.json
@@ -1,0 +1,71 @@
+{
+  "action": "completed",
+  "workflow_run": {
+    "id": 5551234999,
+    "name": "CI Pipeline",
+    "head_branch": "feat/auth-middleware",
+    "head_sha": "fed321cba987654",
+    "status": "completed",
+    "conclusion": "failure",
+    "html_url": "https://github.com/acme-corp/web-api/actions/runs/5551234999",
+    "logs_url": "https://api.github.com/repos/acme-corp/web-api/actions/runs/5551234999/logs",
+    "run_number": 43,
+    "event": "pull_request",
+    "created_at": "2025-01-15T12:10:00Z",
+    "updated_at": "2025-01-15T12:25:00Z",
+    "run_attempt": 1,
+    "pull_requests": [
+      {
+        "number": 123,
+        "head": {
+          "ref": "feat/auth-middleware",
+          "sha": "fed321cba987654"
+        },
+        "base": {
+          "ref": "main",
+          "sha": "abc123def456789"
+        }
+      }
+    ],
+    "actor": {
+      "login": "jane-dev",
+      "id": 12345
+    },
+    "workflow_id": 9876
+  },
+  "repository": {
+    "id": 999888,
+    "full_name": "acme-corp/web-api",
+    "name": "web-api",
+    "owner": {
+      "login": "acme-corp",
+      "id": 777666
+    },
+    "private": true,
+    "html_url": "https://github.com/acme-corp/web-api",
+    "default_branch": "main"
+  },
+  "sender": {
+    "login": "github-actions[bot]",
+    "id": 41898282,
+    "type": "Bot"
+  },
+  "failed_jobs": [
+    {
+      "id": 111222333,
+      "name": "test-integration",
+      "status": "completed",
+      "conclusion": "failure",
+      "started_at": "2025-01-15T12:12:00Z",
+      "completed_at": "2025-01-15T12:20:00Z"
+    },
+    {
+      "id": 111222444,
+      "name": "lint-typecheck",
+      "status": "completed",
+      "conclusion": "failure",
+      "started_at": "2025-01-15T12:11:00Z",
+      "completed_at": "2025-01-15T12:15:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/github_ci_completed_success.json
+++ b/tests/fixtures/github_ci_completed_success.json
@@ -1,0 +1,53 @@
+{
+  "action": "completed",
+  "workflow_run": {
+    "id": 5551234567,
+    "name": "CI Pipeline",
+    "head_branch": "feat/auth-middleware",
+    "head_sha": "fed321cba987654",
+    "status": "completed",
+    "conclusion": "success",
+    "html_url": "https://github.com/acme-corp/web-api/actions/runs/5551234567",
+    "logs_url": "https://api.github.com/repos/acme-corp/web-api/actions/runs/5551234567/logs",
+    "run_number": 42,
+    "event": "pull_request",
+    "created_at": "2025-01-15T11:50:00Z",
+    "updated_at": "2025-01-15T12:05:00Z",
+    "run_attempt": 1,
+    "pull_requests": [
+      {
+        "number": 123,
+        "head": {
+          "ref": "feat/auth-middleware",
+          "sha": "fed321cba987654"
+        },
+        "base": {
+          "ref": "main",
+          "sha": "abc123def456789"
+        }
+      }
+    ],
+    "actor": {
+      "login": "jane-dev",
+      "id": 12345
+    },
+    "workflow_id": 9876
+  },
+  "repository": {
+    "id": 999888,
+    "full_name": "acme-corp/web-api",
+    "name": "web-api",
+    "owner": {
+      "login": "acme-corp",
+      "id": 777666
+    },
+    "private": true,
+    "html_url": "https://github.com/acme-corp/web-api",
+    "default_branch": "main"
+  },
+  "sender": {
+    "login": "github-actions[bot]",
+    "id": 41898282,
+    "type": "Bot"
+  }
+}

--- a/tests/fixtures/github_pr_comment.json
+++ b/tests/fixtures/github_pr_comment.json
@@ -1,0 +1,48 @@
+{
+  "action": "created",
+  "issue": {
+    "number": 123,
+    "title": "feat: add user authentication middleware",
+    "state": "open",
+    "user": {
+      "login": "jane-dev",
+      "id": 12345
+    },
+    "pull_request": {
+      "url": "https://api.github.com/repos/acme-corp/web-api/pulls/123",
+      "html_url": "https://github.com/acme-corp/web-api/pull/123",
+      "diff_url": "https://github.com/acme-corp/web-api/pull/123.diff"
+    },
+    "html_url": "https://github.com/acme-corp/web-api/pull/123"
+  },
+  "comment": {
+    "id": 444555666,
+    "user": {
+      "login": "bob-qa",
+      "id": 54321,
+      "type": "User"
+    },
+    "body": "Could we also add rate limiting to the auth middleware? I think it would be good to prevent brute-force attacks on the token endpoint.",
+    "created_at": "2025-01-15T13:00:00Z",
+    "updated_at": "2025-01-15T13:00:00Z",
+    "html_url": "https://github.com/acme-corp/web-api/pull/123#issuecomment-444555666",
+    "author_association": "COLLABORATOR"
+  },
+  "repository": {
+    "id": 999888,
+    "full_name": "acme-corp/web-api",
+    "name": "web-api",
+    "owner": {
+      "login": "acme-corp",
+      "id": 777666
+    },
+    "private": true,
+    "html_url": "https://github.com/acme-corp/web-api",
+    "default_branch": "main"
+  },
+  "sender": {
+    "login": "bob-qa",
+    "id": 54321,
+    "type": "User"
+  }
+}

--- a/tests/fixtures/github_pr_opened.json
+++ b/tests/fixtures/github_pr_opened.json
@@ -1,0 +1,84 @@
+{
+  "action": "opened",
+  "number": 123,
+  "pull_request": {
+    "number": 123,
+    "title": "feat: add user authentication middleware",
+    "body": "This PR introduces JWT-based authentication middleware for the web API.\n\n## Changes\n- Added `auth_middleware.py` with token validation\n- Updated `app.py` to register the middleware\n- Added unit tests for token parsing\n\nCloses #42",
+    "state": "open",
+    "user": {
+      "login": "jane-dev",
+      "id": 12345,
+      "avatar_url": "https://avatars.githubusercontent.com/u/12345?v=4",
+      "type": "User"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "abc123def456789",
+      "repo": {
+        "full_name": "acme-corp/web-api"
+      }
+    },
+    "head": {
+      "ref": "feat/auth-middleware",
+      "sha": "def789abc123456",
+      "repo": {
+        "full_name": "acme-corp/web-api"
+      }
+    },
+    "diff_url": "https://github.com/acme-corp/web-api/pull/123.diff",
+    "html_url": "https://github.com/acme-corp/web-api/pull/123",
+    "created_at": "2025-01-15T10:30:00Z",
+    "updated_at": "2025-01-15T10:30:00Z",
+    "mergeable": true,
+    "additions": 142,
+    "deletions": 3,
+    "changed_files": 3
+  },
+  "repository": {
+    "id": 999888,
+    "full_name": "acme-corp/web-api",
+    "name": "web-api",
+    "owner": {
+      "login": "acme-corp",
+      "id": 777666
+    },
+    "private": true,
+    "html_url": "https://github.com/acme-corp/web-api",
+    "default_branch": "main"
+  },
+  "sender": {
+    "login": "jane-dev",
+    "id": 12345,
+    "type": "User"
+  },
+  "files": [
+    {
+      "sha": "a1b2c3d4e5f6",
+      "filename": "src/middleware/auth_middleware.py",
+      "status": "added",
+      "additions": 95,
+      "deletions": 0,
+      "changes": 95,
+      "patch": "@@ -0,0 +1,95 @@\n+import jwt\n+from typing import Optional\n+\n+class AuthMiddleware:\n+    def __init__(self, secret: str):\n+        self.secret = secret"
+    },
+    {
+      "sha": "b2c3d4e5f6a1",
+      "filename": "src/app.py",
+      "status": "modified",
+      "additions": 12,
+      "deletions": 3,
+      "changes": 15,
+      "patch": "@@ -10,6 +10,15 @@\n from src.middleware.auth_middleware import AuthMiddleware\n+\n+app.add_middleware(AuthMiddleware(secret=config.JWT_SECRET))"
+    },
+    {
+      "sha": "c3d4e5f6a1b2",
+      "filename": "tests/test_auth_middleware.py",
+      "status": "added",
+      "additions": 35,
+      "deletions": 0,
+      "changes": 35,
+      "patch": "@@ -0,0 +1,35 @@\n+import pytest\n+from src.middleware.auth_middleware import AuthMiddleware"
+    }
+  ]
+}

--- a/tests/fixtures/github_pr_review_approved.json
+++ b/tests/fixtures/github_pr_review_approved.json
@@ -1,0 +1,53 @@
+{
+  "action": "submitted",
+  "review": {
+    "id": 7778889990,
+    "user": {
+      "login": "senior-reviewer",
+      "id": 67890,
+      "type": "User"
+    },
+    "body": "LGTM! The auth middleware looks solid. Nice handling of the token expiry edge case.",
+    "state": "approved",
+    "html_url": "https://github.com/acme-corp/web-api/pull/123#pullrequestreview-7778889990",
+    "submitted_at": "2025-01-15T14:00:00Z",
+    "commit_id": "fed321cba987654",
+    "author_association": "MEMBER"
+  },
+  "pull_request": {
+    "number": 123,
+    "title": "feat: add user authentication middleware",
+    "body": "This PR introduces JWT-based authentication middleware.",
+    "state": "open",
+    "user": {
+      "login": "jane-dev",
+      "id": 12345
+    },
+    "base": {
+      "ref": "main",
+      "sha": "abc123def456789"
+    },
+    "head": {
+      "ref": "feat/auth-middleware",
+      "sha": "fed321cba987654"
+    },
+    "html_url": "https://github.com/acme-corp/web-api/pull/123"
+  },
+  "repository": {
+    "id": 999888,
+    "full_name": "acme-corp/web-api",
+    "name": "web-api",
+    "owner": {
+      "login": "acme-corp",
+      "id": 777666
+    },
+    "private": true,
+    "html_url": "https://github.com/acme-corp/web-api",
+    "default_branch": "main"
+  },
+  "sender": {
+    "login": "senior-reviewer",
+    "id": 67890,
+    "type": "User"
+  }
+}

--- a/tests/fixtures/github_pr_synchronize.json
+++ b/tests/fixtures/github_pr_synchronize.json
@@ -1,0 +1,68 @@
+{
+  "action": "synchronize",
+  "number": 123,
+  "before": "def789abc123456",
+  "after": "fed321cba987654",
+  "pull_request": {
+    "number": 123,
+    "title": "feat: add user authentication middleware",
+    "body": "This PR introduces JWT-based authentication middleware for the web API.\n\n## Changes\n- Added `auth_middleware.py` with token validation\n- Updated `app.py` to register the middleware\n- Added unit tests for token parsing\n- Fixed token expiry edge case\n\nCloses #42",
+    "state": "open",
+    "user": {
+      "login": "jane-dev",
+      "id": 12345,
+      "avatar_url": "https://avatars.githubusercontent.com/u/12345?v=4",
+      "type": "User"
+    },
+    "base": {
+      "ref": "main",
+      "sha": "abc123def456789",
+      "repo": {
+        "full_name": "acme-corp/web-api"
+      }
+    },
+    "head": {
+      "ref": "feat/auth-middleware",
+      "sha": "fed321cba987654",
+      "repo": {
+        "full_name": "acme-corp/web-api"
+      }
+    },
+    "diff_url": "https://github.com/acme-corp/web-api/pull/123.diff",
+    "html_url": "https://github.com/acme-corp/web-api/pull/123",
+    "created_at": "2025-01-15T10:30:00Z",
+    "updated_at": "2025-01-15T11:45:00Z",
+    "mergeable": true,
+    "additions": 160,
+    "deletions": 5,
+    "changed_files": 4
+  },
+  "repository": {
+    "id": 999888,
+    "full_name": "acme-corp/web-api",
+    "name": "web-api",
+    "owner": {
+      "login": "acme-corp",
+      "id": 777666
+    },
+    "private": true,
+    "html_url": "https://github.com/acme-corp/web-api",
+    "default_branch": "main"
+  },
+  "sender": {
+    "login": "jane-dev",
+    "id": 12345,
+    "type": "User"
+  },
+  "files": [
+    {
+      "sha": "a1b2c3d4e5f6",
+      "filename": "src/middleware/auth_middleware.py",
+      "status": "modified",
+      "additions": 18,
+      "deletions": 2,
+      "changes": 20,
+      "patch": "@@ -45,8 +45,24 @@\n     def validate_token(self, token: str) -> bool:\n-        decoded = jwt.decode(token, self.secret)\n-        return decoded is not None\n+        try:\n+            decoded = jwt.decode(token, self.secret, algorithms=['HS256'])\n+            return decoded.get('exp', 0) > time.time()\n+        except jwt.ExpiredSignatureError:\n+            return False"
+    }
+  ]
+}

--- a/tests/replay/__init__.py
+++ b/tests/replay/__init__.py
@@ -1,0 +1,1 @@
+"""Replay tests — load real-ish GitHub webhook fixtures and parse them."""

--- a/tests/replay/test_replay_github.py
+++ b/tests/replay/test_replay_github.py
@@ -1,0 +1,121 @@
+"""Replay tests that load GitHub webhook fixture files and run them through the parsers.
+
+Each test loads a JSON fixture, feeds it through the appropriate parser,
+and asserts the resulting event object has the expected shape and values.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from src.core.contracts.events import (
+    CICompleted,
+    EventType,
+    PRCommented,
+    PROpened,
+    PRReviewed,
+    PRUpdated,
+)
+from src.core.contracts.parsers import (
+    parse_github_ci_event,
+    parse_github_comment_event,
+    parse_github_pr_event,
+    parse_github_pr_review_event,
+)
+
+FIXTURES = pathlib.Path(__file__).parent.parent / "fixtures"
+
+
+class TestGitHubPRReplay:
+    """Replay GitHub pull_request webhook payloads."""
+
+    def test_pr_opened(self):
+        payload = json.loads((FIXTURES / "github_pr_opened.json").read_text())
+        event = parse_github_pr_event(payload, action="opened", correlation_id="test-001")
+        assert event is not None
+        assert isinstance(event, PROpened)
+        assert event.meta.event_type == EventType.PR_OPENED
+        assert event.meta.source == "github"
+        assert event.meta.correlation_id == "test-001"
+        assert event.pr_number == 123
+        assert event.repo_full_name == "acme-corp/web-api"
+        assert event.author == "jane-dev"
+        assert event.base_branch == "main"
+        assert event.head_branch == "feat/auth-middleware"
+        assert len(event.files_changed) == 3
+        assert event.files_changed[0].path == "src/middleware/auth_middleware.py"
+        assert event.files_changed[0].status == "added"
+
+    def test_pr_updated(self):
+        payload = json.loads((FIXTURES / "github_pr_synchronize.json").read_text())
+        event = parse_github_pr_event(payload, action="synchronize", correlation_id="test-002")
+        assert event is not None
+        assert isinstance(event, PRUpdated)
+        assert event.meta.event_type == EventType.PR_UPDATED
+        assert event.pr_number == 123
+        assert event.repo_full_name == "acme-corp/web-api"
+        assert len(event.files_changed) == 1
+
+    def test_unhandled_action_returns_none(self):
+        payload = json.loads((FIXTURES / "github_pr_opened.json").read_text())
+        event = parse_github_pr_event(payload, action="labeled", correlation_id="test-skip")
+        assert event is None
+
+
+class TestGitHubCIReplay:
+    """Replay GitHub workflow_run webhook payloads."""
+
+    def test_ci_success(self):
+        payload = json.loads((FIXTURES / "github_ci_completed_success.json").read_text())
+        event = parse_github_ci_event(payload, correlation_id="test-003")
+        assert event is not None
+        assert isinstance(event, CICompleted)
+        assert event.meta.event_type == EventType.CI_COMPLETED
+        assert event.conclusion == "success"
+        assert event.pr_number == 123
+        assert event.repo_full_name == "acme-corp/web-api"
+        assert event.workflow_name == "CI Pipeline"
+        assert len(event.failed_jobs) == 0
+
+    def test_ci_failure(self):
+        payload = json.loads((FIXTURES / "github_ci_completed_failure.json").read_text())
+        event = parse_github_ci_event(payload, correlation_id="test-004")
+        assert event is not None
+        assert isinstance(event, CICompleted)
+        assert event.conclusion == "failure"
+        assert len(event.failed_jobs) == 2
+        assert "test-integration" in event.failed_jobs
+        assert "lint-typecheck" in event.failed_jobs
+
+
+class TestGitHubReviewReplay:
+    """Replay GitHub pull_request_review webhook payloads."""
+
+    def test_review_approved(self):
+        payload = json.loads((FIXTURES / "github_pr_review_approved.json").read_text())
+        event = parse_github_pr_review_event(payload, correlation_id="test-005")
+        assert event is not None
+        assert isinstance(event, PRReviewed)
+        assert event.meta.event_type == EventType.PR_REVIEWED
+        assert event.reviewer == "senior-reviewer"
+        assert event.state == "approved"
+        assert event.pr_number == 123
+        assert event.repo_full_name == "acme-corp/web-api"
+        assert "LGTM" in event.body
+
+
+class TestGitHubCommentReplay:
+    """Replay GitHub issue_comment webhook payloads."""
+
+    def test_comment(self):
+        payload = json.loads((FIXTURES / "github_pr_comment.json").read_text())
+        event = parse_github_comment_event(payload, correlation_id="test-006")
+        assert event is not None
+        assert isinstance(event, PRCommented)
+        assert event.meta.event_type == EventType.PR_COMMENTED
+        assert event.author == "bob-qa"
+        assert event.pr_number == 123
+        assert event.comment_id == 444555666
+        assert "rate limiting" in event.body
+        assert event.is_review_comment is False

--- a/tests/replay/test_replay_github.py
+++ b/tests/replay/test_replay_github.py
@@ -11,6 +11,7 @@ import pathlib
 
 from src.core.contracts.events import (
     CICompleted,
+    EventSource,
     EventType,
     PRCommented,
     PROpened,
@@ -36,7 +37,7 @@ class TestGitHubPRReplay:
         assert event is not None
         assert isinstance(event, PROpened)
         assert event.meta.event_type == EventType.PR_OPENED
-        assert event.meta.source == "github"
+        assert event.meta.source == EventSource.GITHUB
         assert event.meta.correlation_id == "test-001"
         assert event.pr_number == 123
         assert event.repo_full_name == "acme-corp/web-api"
@@ -59,8 +60,16 @@ class TestGitHubPRReplay:
 
     def test_unhandled_action_returns_none(self):
         payload = json.loads((FIXTURES / "github_pr_opened.json").read_text())
-        event = parse_github_pr_event(payload, action="labeled", correlation_id="test-skip")
-        assert event is None
+        for action in ("labeled", "closed", "assigned", "review_requested", "unlabeled"):
+            event = parse_github_pr_event(payload, action=action, correlation_id=f"test-skip-{action}")
+            assert event is None, f"action={action!r} should return None"
+
+    def test_empty_payload_does_not_crash(self):
+        event = parse_github_pr_event({}, action="opened", correlation_id="test-empty")
+        assert event is not None  # parsers are tolerant — returns PROpened with default values
+        assert event.pr_number == 0
+        assert event.repo_full_name == ""
+        assert event.files_changed == ()
 
 
 class TestGitHubCIReplay:
@@ -72,6 +81,7 @@ class TestGitHubCIReplay:
         assert event is not None
         assert isinstance(event, CICompleted)
         assert event.meta.event_type == EventType.CI_COMPLETED
+        assert event.meta.source == EventSource.GITHUB
         assert event.conclusion == "success"
         assert event.pr_number == 123
         assert event.repo_full_name == "acme-corp/web-api"
@@ -88,6 +98,11 @@ class TestGitHubCIReplay:
         assert "test-integration" in event.failed_jobs
         assert "lint-typecheck" in event.failed_jobs
 
+    def test_in_progress_workflow_returns_none(self):
+        """workflow_run without a conclusion (still running) should parse to None."""
+        payload = {"workflow_run": {"conclusion": None, "name": "CI"}}
+        assert parse_github_ci_event(payload, correlation_id="test-ci-none") is None
+
 
 class TestGitHubReviewReplay:
     """Replay GitHub pull_request_review webhook payloads."""
@@ -98,6 +113,7 @@ class TestGitHubReviewReplay:
         assert event is not None
         assert isinstance(event, PRReviewed)
         assert event.meta.event_type == EventType.PR_REVIEWED
+        assert event.meta.source == EventSource.GITHUB
         assert event.reviewer == "senior-reviewer"
         assert event.state == "approved"
         assert event.pr_number == 123
@@ -119,3 +135,26 @@ class TestGitHubCommentReplay:
         assert event.comment_id == 444555666
         assert "rate limiting" in event.body
         assert event.is_review_comment is False
+
+    def test_empty_comment_returns_none(self):
+        assert parse_github_comment_event({}, correlation_id="test-empty") is None
+
+    def test_plain_issue_comment_is_dropped(self):
+        """issue_comment webhook fires for plain issues too — those must be filtered out."""
+        # Simulate an issue_comment payload where the issue is NOT a PR
+        # (no ``issue.pull_request`` object injected by GitHub).
+        payload = {
+            "action": "created",
+            "issue": {
+                "number": 77,
+                "title": "Bug: login button misaligned",
+                # NOTE: no "pull_request" key here — this is a plain issue
+            },
+            "comment": {
+                "id": 999,
+                "user": {"login": "random-user"},
+                "body": "Still happening on Chrome 120",
+            },
+            "repository": {"full_name": "acme-corp/web-api"},
+        }
+        assert parse_github_comment_event(payload, correlation_id="test-issue-only") is None

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,431 @@
+"""Unit tests for core contract types — events and domain models.
+
+Verifies immutability (frozen), enum correctness, default values,
+and the Event union type alias.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+
+import pytest
+
+from src.core.contracts.domain import (
+    BehaviourImpact,
+    ImpactArea,
+    QAReport,
+    RiskLevel,
+    StrategyAction,
+    StrategyResult,
+    ValidationOutcome,
+    ValidationResult,
+)
+from src.core.contracts.events import (
+    ChatMention,
+    CICompleted,
+    Event,
+    EventMeta,
+    EventType,
+    FileChange,
+    PRCommented,
+    PROpened,
+    PRReviewed,
+    PRUpdated,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_meta(event_type: EventType = EventType.PR_OPENED) -> EventMeta:
+    return EventMeta(
+        event_id="evt-001",
+        event_type=event_type,
+        correlation_id="corr-001",
+        timestamp=datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC),
+        source="github",
+    )
+
+
+# ---------------------------------------------------------------------------
+# EventType enum
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypeEnum:
+    """EventType enum values and membership."""
+
+    def test_values(self):
+        assert EventType.PR_OPENED.value == "pr_opened"
+        assert EventType.PR_UPDATED.value == "pr_updated"
+        assert EventType.PR_COMMENTED.value == "pr_commented"
+        assert EventType.PR_REVIEWED.value == "pr_reviewed"
+        assert EventType.CI_COMPLETED.value == "ci_completed"
+        assert EventType.CHAT_MENTION.value == "chat_mention"
+
+    def test_member_count(self):
+        assert len(EventType) == 6
+
+    def test_unique_values(self):
+        values = [e.value for e in EventType]
+        assert len(values) == len(set(values))
+
+
+# ---------------------------------------------------------------------------
+# EventMeta
+# ---------------------------------------------------------------------------
+
+
+class TestEventMeta:
+    """EventMeta is frozen and carries correct fields."""
+
+    def test_fields(self):
+        meta = _make_meta()
+        assert meta.event_id == "evt-001"
+        assert meta.event_type == EventType.PR_OPENED
+        assert meta.correlation_id == "corr-001"
+        assert meta.source == "github"
+
+    def test_frozen(self):
+        meta = _make_meta()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            meta.event_id = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# FileChange
+# ---------------------------------------------------------------------------
+
+
+class TestFileChange:
+    """FileChange defaults and immutability."""
+
+    def test_defaults(self):
+        fc = FileChange(path="src/main.py", status="modified")
+        assert fc.additions == 0
+        assert fc.deletions == 0
+        assert fc.patch == ""
+
+    def test_frozen(self):
+        fc = FileChange(path="a.py", status="added")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            fc.path = "b.py"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# PR events
+# ---------------------------------------------------------------------------
+
+
+class TestPROpened:
+    """PROpened construction and immutability."""
+
+    def test_construction(self):
+        fc = FileChange(path="x.py", status="added", additions=10)
+        pr = PROpened(
+            meta=_make_meta(EventType.PR_OPENED),
+            repo_full_name="acme-corp/web-api",
+            pr_number=42,
+            title="feat: stuff",
+            body="Does things",
+            author="alice",
+            base_branch="main",
+            head_branch="feat/stuff",
+            diff_url="https://example.com/diff",
+            files_changed=(fc,),
+        )
+        assert pr.pr_number == 42
+        assert len(pr.files_changed) == 1
+        assert pr.files_changed[0].path == "x.py"
+
+    def test_default_files_changed(self):
+        pr = PROpened(
+            meta=_make_meta(),
+            repo_full_name="o/r",
+            pr_number=1,
+            title="t",
+            body="b",
+            author="a",
+            base_branch="main",
+            head_branch="dev",
+            diff_url="",
+        )
+        assert pr.files_changed == ()
+
+    def test_frozen(self):
+        pr = PROpened(
+            meta=_make_meta(),
+            repo_full_name="o/r",
+            pr_number=1,
+            title="t",
+            body="b",
+            author="a",
+            base_branch="main",
+            head_branch="dev",
+            diff_url="",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            pr.pr_number = 999  # type: ignore[misc]
+
+
+class TestPRUpdated:
+    """PRUpdated mirrors PROpened structure."""
+
+    def test_construction(self):
+        pr = PRUpdated(
+            meta=_make_meta(EventType.PR_UPDATED),
+            repo_full_name="o/r",
+            pr_number=7,
+            title="fix: bug",
+            body="",
+            author="bob",
+            base_branch="main",
+            head_branch="fix/bug",
+            diff_url="",
+        )
+        assert pr.meta.event_type == EventType.PR_UPDATED
+
+
+class TestPRCommented:
+    """PRCommented defaults and construction."""
+
+    def test_defaults(self):
+        c = PRCommented(
+            meta=_make_meta(EventType.PR_COMMENTED),
+            repo_full_name="o/r",
+            pr_number=1,
+            comment_id=555,
+            author="charlie",
+            body="Looks good",
+        )
+        assert c.is_review_comment is False
+        assert c.path == ""
+        assert c.line is None
+
+
+class TestPRReviewed:
+    """PRReviewed construction."""
+
+    def test_construction(self):
+        r = PRReviewed(
+            meta=_make_meta(EventType.PR_REVIEWED),
+            repo_full_name="o/r",
+            pr_number=1,
+            reviewer="dana",
+            state="approved",
+        )
+        assert r.body == ""
+        assert r.state == "approved"
+
+
+# ---------------------------------------------------------------------------
+# CI event
+# ---------------------------------------------------------------------------
+
+
+class TestCICompleted:
+    """CICompleted defaults and construction."""
+
+    def test_success(self):
+        ci = CICompleted(
+            meta=_make_meta(EventType.CI_COMPLETED),
+            repo_full_name="o/r",
+            pr_number=42,
+            commit_sha="abc123",
+            workflow_name="CI",
+            conclusion="success",
+            run_url="https://example.com/run/1",
+        )
+        assert ci.failed_jobs == ()
+        assert ci.logs_url == ""
+
+    def test_failure(self):
+        ci = CICompleted(
+            meta=_make_meta(EventType.CI_COMPLETED),
+            repo_full_name="o/r",
+            pr_number=None,
+            commit_sha="def456",
+            workflow_name="CI",
+            conclusion="failure",
+            run_url="https://example.com/run/2",
+            failed_jobs=("build", "test"),
+        )
+        assert ci.pr_number is None
+        assert len(ci.failed_jobs) == 2
+
+    def test_frozen(self):
+        ci = CICompleted(
+            meta=_make_meta(EventType.CI_COMPLETED),
+            repo_full_name="o/r",
+            pr_number=1,
+            commit_sha="x",
+            workflow_name="CI",
+            conclusion="success",
+            run_url="",
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ci.conclusion = "failure"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Chat event
+# ---------------------------------------------------------------------------
+
+
+class TestChatMention:
+    """ChatMention defaults."""
+
+    def test_defaults(self):
+        cm = ChatMention(
+            meta=_make_meta(EventType.CHAT_MENTION),
+            platform="slack",
+            channel_id="C123",
+            channel_name="engineering",
+            author="eve",
+            message="@devclaw check PR 42",
+        )
+        assert cm.thread_id == ""
+        assert cm.referenced_pr is None
+
+
+# ---------------------------------------------------------------------------
+# Event union type alias
+# ---------------------------------------------------------------------------
+
+
+class TestEventUnion:
+    """The Event type alias covers all concrete event types."""
+
+    def test_pr_opened_is_event(self):
+        pr = PROpened(
+            meta=_make_meta(),
+            repo_full_name="o/r",
+            pr_number=1,
+            title="t",
+            body="",
+            author="a",
+            base_branch="main",
+            head_branch="dev",
+            diff_url="",
+        )
+        # This is a structural check — the union type is just a type alias,
+        # so we verify each concrete type is in the union's __args__
+        event_types = Event.__args__ if hasattr(Event, "__args__") else []  # type: ignore[union-attr]
+        assert PROpened in event_types
+        assert PRUpdated in event_types
+        assert PRCommented in event_types
+        assert PRReviewed in event_types
+        assert CICompleted in event_types
+        assert ChatMention in event_types
+        assert isinstance(pr, PROpened)
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+class TestRiskLevel:
+    """RiskLevel enum."""
+
+    def test_values(self):
+        assert RiskLevel.LOW.value == "low"
+        assert RiskLevel.MEDIUM.value == "medium"
+        assert RiskLevel.HIGH.value == "high"
+        assert RiskLevel.CRITICAL.value == "critical"
+
+    def test_member_count(self):
+        assert len(RiskLevel) == 4
+
+
+class TestValidationOutcome:
+    """ValidationOutcome enum."""
+
+    def test_values(self):
+        assert ValidationOutcome.PASS.value == "pass"
+        assert ValidationOutcome.FAIL.value == "fail"
+        assert ValidationOutcome.ERROR.value == "error"
+        assert ValidationOutcome.SKIPPED.value == "skipped"
+
+
+class TestImpactArea:
+    """ImpactArea construction and defaults."""
+
+    def test_defaults(self):
+        ia = ImpactArea(module="auth", description="Authentication module", risk_level=RiskLevel.HIGH)
+        assert ia.affected_files == ()
+
+    def test_frozen(self):
+        ia = ImpactArea(module="auth", description="d", risk_level=RiskLevel.LOW)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ia.module = "payments"  # type: ignore[misc]
+
+
+class TestBehaviourImpact:
+    """BehaviourImpact — default dict factory."""
+
+    def test_default_stats(self):
+        bi = BehaviourImpact(summary="s", areas=(), overall_risk=RiskLevel.LOW)
+        assert bi.raw_diff_stats == {}
+
+    def test_with_stats(self):
+        bi = BehaviourImpact(
+            summary="s",
+            areas=(),
+            overall_risk=RiskLevel.MEDIUM,
+            raw_diff_stats={"additions": 42, "deletions": 10},
+        )
+        assert bi.raw_diff_stats["additions"] == 42
+
+
+class TestStrategyAction:
+    """StrategyAction defaults."""
+
+    def test_defaults(self):
+        sa = StrategyAction(action_type="test", description="Run unit tests", target="tests/")
+        assert sa.priority == 0
+        assert sa.rationale == ""
+
+
+class TestStrategyResult:
+    """StrategyResult defaults."""
+
+    def test_defaults(self):
+        sr = StrategyResult(actions=(), reasoning="No changes detected", confidence=1.0)
+        assert sr.knowledge_refs == ()
+
+
+class TestValidationResult:
+    """ValidationResult defaults."""
+
+    def test_defaults(self):
+        action = StrategyAction(action_type="test", description="d", target="t")
+        vr = ValidationResult(action=action, outcome=ValidationOutcome.PASS)
+        assert vr.details == ""
+        assert vr.duration_seconds == 0.0
+        assert vr.artifacts == ()
+
+
+class TestQAReport:
+    """QAReport full construction."""
+
+    def test_full_report(self):
+        area = ImpactArea(module="auth", description="Auth changes", risk_level=RiskLevel.HIGH)
+        impact = BehaviourImpact(summary="Auth middleware added", areas=(area,), overall_risk=RiskLevel.HIGH)
+        action = StrategyAction(action_type="test", description="Run auth tests", target="tests/test_auth.py")
+        strategy = StrategyResult(actions=(action,), reasoning="New auth code needs testing", confidence=0.9)
+        validation = ValidationResult(action=action, outcome=ValidationOutcome.PASS, duration_seconds=1.5)
+        report = QAReport(
+            event_id="evt-001",
+            repo_full_name="acme-corp/web-api",
+            pr_number=123,
+            impact=impact,
+            strategy=strategy,
+            validations=(validation,),
+            summary_markdown="## QA Report\n\nAll checks passed.",
+        )
+        assert report.pr_number == 123
+        assert len(report.validations) == 1
+        assert report.validations[0].outcome == ValidationOutcome.PASS

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 import pytest
 
 from src.core.contracts.domain import (
+    ActionType,
     BehaviourImpact,
     ImpactArea,
     QAReport,
@@ -26,9 +27,11 @@ from src.core.contracts.events import (
     CICompleted,
     Event,
     EventMeta,
+    EventSource,
     EventType,
     FileChange,
     PRCommented,
+    PREvent,
     PROpened,
     PRReviewed,
     PRUpdated,
@@ -45,7 +48,7 @@ def _make_meta(event_type: EventType = EventType.PR_OPENED) -> EventMeta:
         event_type=event_type,
         correlation_id="corr-001",
         timestamp=datetime(2025, 1, 15, 10, 30, 0, tzinfo=UTC),
-        source="github",
+        source=EventSource.GITHUB,
     )
 
 
@@ -74,6 +77,25 @@ class TestEventTypeEnum:
 
 
 # ---------------------------------------------------------------------------
+# EventSource enum
+# ---------------------------------------------------------------------------
+
+
+class TestEventSourceEnum:
+    """EventSource enum — constrained source origins."""
+
+    def test_values(self):
+        assert EventSource.GITHUB.value == "github"
+        assert EventSource.SLACK.value == "slack"
+        assert EventSource.TEAMS.value == "teams"
+        assert EventSource.REPLAY.value == "replay"
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(ValueError):
+            EventSource("gitlab")
+
+
+# ---------------------------------------------------------------------------
 # EventMeta
 # ---------------------------------------------------------------------------
 
@@ -86,7 +108,7 @@ class TestEventMeta:
         assert meta.event_id == "evt-001"
         assert meta.event_type == EventType.PR_OPENED
         assert meta.correlation_id == "corr-001"
-        assert meta.source == "github"
+        assert meta.source == EventSource.GITHUB
 
     def test_frozen(self):
         meta = _make_meta()
@@ -106,7 +128,20 @@ class TestFileChange:
         fc = FileChange(path="src/main.py", status="modified")
         assert fc.additions == 0
         assert fc.deletions == 0
-        assert fc.patch == ""
+        assert fc.previous_filename == ""
+
+    def test_renamed_carries_previous_filename(self):
+        fc = FileChange(
+            path="src/new_name.py",
+            status="renamed",
+            previous_filename="src/old_name.py",
+        )
+        assert fc.previous_filename == "src/old_name.py"
+
+    def test_no_patch_field(self):
+        """Ensure FileChange stays lightweight — patch text is not carried."""
+        fields = {f.name for f in dataclasses.fields(FileChange)}
+        assert "patch" not in fields
 
     def test_frozen(self):
         fc = FileChange(path="a.py", status="added")
@@ -117,6 +152,52 @@ class TestFileChange:
 # ---------------------------------------------------------------------------
 # PR events
 # ---------------------------------------------------------------------------
+
+
+class TestPREventInheritance:
+    """PROpened and PRUpdated share the PREvent base."""
+
+    def test_pr_opened_is_pr_event(self):
+        pr = PROpened(
+            meta=_make_meta(),
+            repo_full_name="o/r",
+            pr_number=1,
+            title="t",
+            body="",
+            author="a",
+            base_branch="main",
+            head_branch="dev",
+            diff_url="",
+        )
+        assert isinstance(pr, PREvent)
+
+    def test_pr_updated_is_pr_event(self):
+        pr = PRUpdated(
+            meta=_make_meta(EventType.PR_UPDATED),
+            repo_full_name="o/r",
+            pr_number=1,
+            title="t",
+            body="",
+            author="a",
+            base_branch="main",
+            head_branch="dev",
+            diff_url="",
+        )
+        assert isinstance(pr, PREvent)
+
+    def test_distinct_types(self):
+        po = PROpened(
+            meta=_make_meta(),
+            repo_full_name="o/r",
+            pr_number=1,
+            title="t",
+            body="",
+            author="a",
+            base_branch="main",
+            head_branch="dev",
+            diff_url="",
+        )
+        assert not isinstance(po, PRUpdated)
 
 
 class TestPROpened:
@@ -340,6 +421,25 @@ class TestRiskLevel:
         assert len(RiskLevel) == 4
 
 
+class TestActionType:
+    """ActionType enum — known categories plus CUSTOM escape hatch."""
+
+    def test_known_values(self):
+        assert ActionType.RUN_TESTS.value == "run_tests"
+        assert ActionType.RUN_LINTER.value == "run_linter"
+        assert ActionType.TYPE_CHECK.value == "type_check"
+        assert ActionType.CHECK_SECURITY.value == "check_security"
+        assert ActionType.VERIFY_API_CONTRACT.value == "verify_api_contract"
+        assert ActionType.SMOKE_TEST.value == "smoke_test"
+
+    def test_custom_escape_hatch(self):
+        assert ActionType.CUSTOM.value == "custom"
+
+    def test_unknown_value_raises(self):
+        with pytest.raises(ValueError):
+            ActionType("not_a_real_action")
+
+
 class TestValidationOutcome:
     """ValidationOutcome enum."""
 
@@ -381,12 +481,23 @@ class TestBehaviourImpact:
 
 
 class TestStrategyAction:
-    """StrategyAction defaults."""
+    """StrategyAction defaults and ActionType usage."""
 
     def test_defaults(self):
-        sa = StrategyAction(action_type="test", description="Run unit tests", target="tests/")
+        sa = StrategyAction(action_type=ActionType.RUN_TESTS, description="Run unit tests", target="tests/")
         assert sa.priority == 0
         assert sa.rationale == ""
+        assert sa.action_type is ActionType.RUN_TESTS
+
+    def test_custom_action(self):
+        """CUSTOM is a valid escape hatch for engine-proposed novel actions."""
+        sa = StrategyAction(
+            action_type=ActionType.CUSTOM,
+            description="Run a custom migration-safety probe",
+            target="scripts/check_migration.py",
+            rationale="DB schema change detected; no standard action fits",
+        )
+        assert sa.action_type is ActionType.CUSTOM
 
 
 class TestStrategyResult:
@@ -401,7 +512,7 @@ class TestValidationResult:
     """ValidationResult defaults."""
 
     def test_defaults(self):
-        action = StrategyAction(action_type="test", description="d", target="t")
+        action = StrategyAction(action_type=ActionType.RUN_TESTS, description="d", target="t")
         vr = ValidationResult(action=action, outcome=ValidationOutcome.PASS)
         assert vr.details == ""
         assert vr.duration_seconds == 0.0
@@ -414,7 +525,11 @@ class TestQAReport:
     def test_full_report(self):
         area = ImpactArea(module="auth", description="Auth changes", risk_level=RiskLevel.HIGH)
         impact = BehaviourImpact(summary="Auth middleware added", areas=(area,), overall_risk=RiskLevel.HIGH)
-        action = StrategyAction(action_type="test", description="Run auth tests", target="tests/test_auth.py")
+        action = StrategyAction(
+            action_type=ActionType.RUN_TESTS,
+            description="Run auth tests",
+            target="tests/test_auth.py",
+        )
         strategy = StrategyResult(actions=(action,), reasoning="New auth code needs testing", confidence=0.9)
         validation = ValidationResult(action=action, outcome=ValidationOutcome.PASS, duration_seconds=1.5)
         report = QAReport(


### PR DESCRIPTION
## Step 1 — Contracts & Replay

[MODULE_REQUIREMENTS.md](https://github.com/Kimcheolhui/devclaw/blob/main/docs/MODULE_REQUIREMENTS.md) Step 1 구현. 이벤트/도메인 타입 정의 + GitHub webhook 파서 + replay 테스트 기반.

### 변경 요약

- **`src/core/contracts/events.py`** — `EventType`, `EventSource`, `EventMeta`, `FileChange`, `PREvent` 베이스 + `PROpened`/`PRUpdated`/`PRCommented`/`PRReviewed`/`CICompleted`/`ChatMention`
- **`src/core/contracts/domain.py`** — `RiskLevel`, `ActionType`, `BehaviourImpact`, `StrategyResult`, `ValidationResult`, `QAReport`
- **`src/core/contracts/parsers.py`** — GitHub `pull_request` / `workflow_run` / `pull_request_review` / `issue_comment` webhook 파서
- **`tests/fixtures/`** — GitHub webhook payload 6종
- **`tests/replay/`, `tests/test_contracts.py`** — replay 10 + 타입 40
- `src/` 내부 import 상대경로로 통일, `docs/ARCHITECTURE.md`·`MODULE_REQUIREMENTS.md` 이벤트 목록 동기화

### 주요 설계 결정

- **stdlib only** — `dataclass(frozen=True)` + `tuple`. Pydantic 미사용
- **경량 이벤트** — 파일 내용·diff는 이벤트에 싣지 않고 runtime fetch (Step 2)
- **`ActionType.CUSTOM`** — LLM Strategy Engine이 enum 밖 액션을 제안할 수 있는 escape hatch
- 자세한 rationale은 각 모듈 docstring 참고

### 검증

- ✅ ruff / mypy clean
- ✅ pytest **60 passed** (replay 10 + contracts 40 + shared 8 + entrypoints 2)

Closes #21, #22, #23

---
🤖 *Created by Hermes Agent*