### PR TITLE
feat(app): wire GitHub webhook gateway to worker

### DIFF
--- a/src/app/gateway/__init__.py
+++ b/src/app/gateway/__init__.py
@@ -1,21 +1,27 @@
 """Webhook receiver and event normalizer.
 
-Entry point for the ``qaestro-gateway`` console script.
+Implementation lives in focused modules under this package. ``__init__`` only
+re-exports the public gateway API and console-script entrypoint.
 """
 
 from __future__ import annotations
 
-import sys
+from ..jobs import EnqueueQueue, EventJob, InMemoryJobQueue, JobQueue
+from .entrypoint import main
+from .github import GitHubWebhookGateway, WebhookRequest, WebhookResponse
+from .server import WebhookHandler, create_github_webhook_server, make_github_webhook_handler, serve_github_webhook
 
-from ...shared import get_logger, setup_logging
-
-logger = get_logger(__name__)
-
-
-def main() -> None:
-    """Start the gateway HTTP server."""
-    setup_logging()
-    logger.info("qaestro-gateway starting")
-    # TODO(step-1): wire up actual ASGI/webhook server
-    logger.info("qaestro-gateway ready — no handler configured yet, exiting")
-    sys.exit(0)
+__all__ = [
+    "EnqueueQueue",
+    "EventJob",
+    "GitHubWebhookGateway",
+    "InMemoryJobQueue",
+    "JobQueue",
+    "WebhookHandler",
+    "WebhookRequest",
+    "WebhookResponse",
+    "create_github_webhook_server",
+    "main",
+    "make_github_webhook_handler",
+    "serve_github_webhook",
+]

--- a/src/app/gateway/entrypoint.py
+++ b/src/app/gateway/entrypoint.py
@@ -1,0 +1,27 @@
+"""Console entrypoint for the GitHub webhook gateway."""
+
+from __future__ import annotations
+
+import sys
+
+from src.app.gateway.github import GitHubWebhookGateway
+from src.app.gateway.server import serve_github_webhook
+from src.app.jobs import InMemoryJobQueue
+from src.shared import get_logger, load_config, setup_logging
+
+logger = get_logger(__name__)
+
+
+def main() -> None:
+    """Start the gateway HTTP server."""
+    cfg = load_config()
+    setup_logging(level=cfg.log_level, fmt=cfg.log_format)
+    logger.info("qaestro-gateway starting")
+    queue = InMemoryJobQueue()
+    # Step 2 local wiring only: this in-process queue proves the gateway
+    # enqueue contract, but production must replace it with a durable/shared
+    # queue consumed by ``qaestro-worker``.
+    gateway = GitHubWebhookGateway(secret=cfg.github_webhook_secret, queue=queue)
+    logger.info("qaestro-gateway serving GitHub webhook endpoint")
+    serve_github_webhook(gateway, host=cfg.gateway_host, port=cfg.gateway_port)
+    sys.exit(0)

--- a/src/app/gateway/github.py
+++ b/src/app/gateway/github.py
@@ -1,0 +1,89 @@
+"""GitHub webhook gateway request handling."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from src.adapters.connectors.github import verify_signature
+from src.core.contracts import Event
+from src.core.contracts.parsers import (
+    parse_github_ci_event,
+    parse_github_comment_event,
+    parse_github_pr_event,
+    parse_github_pr_review_event,
+)
+from src.shared import new_correlation_id, set_correlation_id
+
+from ..jobs import EnqueueQueue, EventJob
+
+
+@dataclass(frozen=True)
+class WebhookRequest:
+    """Raw webhook request data needed by the gateway."""
+
+    headers: dict[str, str]
+    body: bytes
+
+
+@dataclass(frozen=True)
+class WebhookResponse:
+    """Small transport-agnostic response returned by the gateway."""
+
+    status: int
+    message: str = ""
+    correlation_id: str = ""
+
+
+class GitHubWebhookGateway:
+    """Verify, normalize, and enqueue GitHub webhook deliveries."""
+
+    def __init__(self, *, secret: str, queue: EnqueueQueue) -> None:
+        self._secret = secret
+        self._queue = queue
+
+    def handle(self, request: WebhookRequest) -> WebhookResponse:
+        headers = _normalise_headers(request.headers)
+        signature = headers.get("x-hub-signature-256")
+        if not verify_signature(self._secret, request.body, signature):
+            return WebhookResponse(status=401, message="invalid signature")
+
+        correlation_id = _correlation_id(headers)
+        set_correlation_id(correlation_id)
+
+        try:
+            payload = json.loads(request.body.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return WebhookResponse(status=400, message="invalid json", correlation_id=correlation_id)
+
+        if not isinstance(payload, dict):
+            return WebhookResponse(status=400, message="payload must be a JSON object", correlation_id=correlation_id)
+
+        event = _parse_event(headers.get("x-github-event", ""), payload, correlation_id)
+        if event is None:
+            return WebhookResponse(status=204, correlation_id=correlation_id)
+
+        self._queue.enqueue(EventJob(event=event, correlation_id=correlation_id))
+        return WebhookResponse(status=202, message="enqueued", correlation_id=correlation_id)
+
+
+def _normalise_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {key.lower(): value for key, value in headers.items()}
+
+
+def _correlation_id(headers: dict[str, str]) -> str:
+    return headers.get("x-github-delivery") or new_correlation_id()
+
+
+def _parse_event(event_name: str, payload: dict[str, Any], correlation_id: str) -> Event | None:
+    action = str(payload.get("action", ""))
+    if event_name == "pull_request":
+        return parse_github_pr_event(payload, action=action, correlation_id=correlation_id)
+    if event_name == "workflow_run":
+        return parse_github_ci_event(payload, correlation_id=correlation_id)
+    if event_name == "pull_request_review":
+        return parse_github_pr_review_event(payload, correlation_id=correlation_id)
+    if event_name in {"issue_comment", "pull_request_review_comment"}:
+        return parse_github_comment_event(payload, correlation_id=correlation_id)
+    return None

--- a/src/app/gateway/server.py
+++ b/src/app/gateway/server.py
@@ -1,0 +1,70 @@
+"""Stdlib HTTP endpoint for GitHub webhooks."""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Protocol
+
+from .github import WebhookRequest, WebhookResponse
+
+_GITHUB_WEBHOOK_PATH = "/webhooks/github"
+
+
+class WebhookHandler(Protocol):
+    """Gateway surface required by the HTTP transport."""
+
+    def handle(self, request: WebhookRequest) -> WebhookResponse: ...
+
+
+def make_github_webhook_handler(gateway: WebhookHandler) -> type[BaseHTTPRequestHandler]:
+    """Build a request handler bound to a configured gateway instance."""
+
+    class GitHubWebhookHTTPHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            if self.path != _GITHUB_WEBHOOK_PATH:
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            response = gateway.handle(
+                WebhookRequest(
+                    headers={key: value for key, value in self.headers.items()},
+                    body=body,
+                )
+            )
+            self.send_response(response.status)
+            if response.correlation_id:
+                self.send_header("X-Qaestro-Correlation-Id", response.correlation_id)
+            self.end_headers()
+            if response.message and response.status not in {204, 304}:
+                self.wfile.write(response.message.encode("utf-8"))
+
+        def log_message(self, format: str, *args: object) -> None:
+            # Suppress stdlib access-log writes. Application logging should be
+            # attached around the transport when deployment wiring is added.
+            return None
+
+    return GitHubWebhookHTTPHandler
+
+
+def create_github_webhook_server(
+    gateway: WebhookHandler,
+    *,
+    host: str,
+    port: int,
+) -> ThreadingHTTPServer:
+    """Create a stdlib HTTP server exposing ``POST /webhooks/github``."""
+
+    return ThreadingHTTPServer((host, port), make_github_webhook_handler(gateway))
+
+
+def serve_github_webhook(gateway: WebhookHandler, *, host: str, port: int) -> None:
+    """Serve the GitHub webhook endpoint until interrupted."""
+
+    server = create_github_webhook_server(gateway, host=host, port=port)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()

--- a/src/app/jobs.py
+++ b/src/app/jobs.py
@@ -1,0 +1,58 @@
+"""Shared application job contracts used by gateway and worker."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.core.contracts import Event
+
+
+@dataclass(frozen=True)
+class EventJob:
+    """Retryable worker input created from a normalized event.
+
+    The gateway stores normalized events in this small envelope so retry logic
+    can preserve correlation id and event metadata without depending on raw
+    provider payloads.
+    """
+
+    event: Event
+    correlation_id: str
+
+
+class EnqueueQueue(Protocol):
+    """Minimal enqueue-only queue surface required by the gateway."""
+
+    def enqueue(self, job: EventJob) -> None: ...
+
+
+class JobQueue(EnqueueQueue, Protocol):
+    """Queue contract shared by gateway and worker.
+
+    The in-memory implementation below is deliberately simple. Durable queue
+    providers can replace it later as long as they preserve this enqueue/dequeue
+    contract.
+    """
+
+    def dequeue(self) -> EventJob | None: ...
+
+
+class InMemoryJobQueue:
+    """FIFO queue for tests, local development, and Step 2 single-process wiring."""
+
+    def __init__(self, jobs: Iterable[EventJob] = ()) -> None:
+        self._jobs: deque[EventJob] = deque(jobs)
+
+    def enqueue(self, job: EventJob) -> None:
+        self._jobs.append(job)
+
+    def dequeue(self) -> EventJob | None:
+        if not self._jobs:
+            return None
+        return self._jobs.popleft()
+
+    def __len__(self) -> int:
+        return len(self._jobs)

--- a/src/app/worker/__init__.py
+++ b/src/app/worker/__init__.py
@@ -1,21 +1,30 @@
 """Background job execution and Agent Framework runner host.
 
-Entry point for the ``qaestro-worker`` console script.
+Implementation lives in focused modules under this package. ``__init__`` only
+re-exports the public worker API and console-script entrypoint.
 """
 
 from __future__ import annotations
 
-import sys
+from ..jobs import EnqueueQueue, EventJob, InMemoryJobQueue, JobQueue
+from .entrypoint import main
+from .github import GitHubCommentPoster, GitHubIssueCommentClient
+from .runner import CommentPoster, NoopCommentPoster, Orchestrator, Worker
+from .types import WorkerExecution, WorkerExecutionContext, WorkerStatus
 
-from ...shared import get_logger, setup_logging
-
-logger = get_logger(__name__)
-
-
-def main() -> None:
-    """Start the worker process."""
-    setup_logging()
-    logger.info("qaestro-worker starting")
-    # TODO(step-1): wire up actual task queue / runner
-    logger.info("qaestro-worker ready — no runner configured yet, exiting")
-    sys.exit(0)
+__all__ = [
+    "CommentPoster",
+    "EnqueueQueue",
+    "EventJob",
+    "GitHubCommentPoster",
+    "GitHubIssueCommentClient",
+    "InMemoryJobQueue",
+    "JobQueue",
+    "NoopCommentPoster",
+    "Orchestrator",
+    "Worker",
+    "WorkerExecution",
+    "WorkerExecutionContext",
+    "WorkerStatus",
+    "main",
+]

--- a/src/app/worker/entrypoint.py
+++ b/src/app/worker/entrypoint.py
@@ -1,0 +1,20 @@
+"""Console entrypoint for the background worker."""
+
+from __future__ import annotations
+
+import sys
+
+from src.shared import get_logger, setup_logging
+
+logger = get_logger(__name__)
+
+
+def main() -> None:
+    """Start the worker process."""
+    setup_logging()
+    logger.info("qaestro-worker starting")
+    # TODO(Step 2 deployment wiring): connect this entrypoint to a durable queue
+    # and GitHub App credentials. Unit-tested worker orchestration lives in
+    # ``runner.py`` and is intentionally side-effect free by default.
+    logger.info("qaestro-worker ready — no durable queue configured yet, exiting")
+    sys.exit(0)

--- a/src/app/worker/github.py
+++ b/src/app/worker/github.py
@@ -1,0 +1,34 @@
+"""GitHub comment posting adapter used by the worker."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from src.adapters.renderers import PRCommentPayload
+
+
+class GitHubIssueCommentClient(Protocol):
+    """Subset of GitHubClient used by the worker comment poster."""
+
+    def create_issue_comment(self, owner: str, repo: str, number: int, body: str) -> object: ...
+
+
+class GitHubCommentPoster:
+    """Post rendered PR comment payloads through :class:`GitHubClient`."""
+
+    def __init__(self, client: GitHubIssueCommentClient) -> None:
+        self._client = client
+
+    def post_comment(self, payload: PRCommentPayload) -> None:
+        owner, repo = _split_repo(payload.repo_full_name)
+        self._client.create_issue_comment(owner, repo, payload.pr_number, payload.body)
+
+
+def _split_repo(repo_full_name: str) -> tuple[str, str]:
+    try:
+        owner, repo = repo_full_name.split("/", 1)
+    except ValueError as exc:
+        raise ValueError(f"repo_full_name must be 'owner/repo', got {repo_full_name!r}") from exc
+    if not owner or not repo:
+        raise ValueError(f"repo_full_name must be 'owner/repo', got {repo_full_name!r}")
+    return owner, repo

--- a/src/app/worker/queue.py
+++ b/src/app/worker/queue.py
@@ -1,0 +1,12 @@
+"""In-memory job queue used by the Step 2 worker skeleton."""
+
+from __future__ import annotations
+
+from ..jobs import EnqueueQueue, EventJob, InMemoryJobQueue, JobQueue
+
+__all__ = [
+    "EnqueueQueue",
+    "EventJob",
+    "InMemoryJobQueue",
+    "JobQueue",
+]

--- a/src/app/worker/runner.py
+++ b/src/app/worker/runner.py
@@ -1,0 +1,146 @@
+"""Background worker execution loop."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from typing import Protocol
+
+from src.adapters.renderers import PRCommentPayload
+from src.core.contracts import Event
+from src.runtime.orchestrator import EventOrchestrator, PRWorkflowResult
+
+from ..jobs import EventJob, JobQueue
+from .types import WorkerExecution, WorkerExecutionContext, WorkerStatus
+
+
+class Orchestrator(Protocol):
+    """Minimal orchestrator surface required by the worker."""
+
+    def run(self, event: Event) -> PRWorkflowResult: ...
+
+
+class CommentPoster(Protocol):
+    """Posts rendered PR comment payloads to an external system."""
+
+    def post_comment(self, payload: PRCommentPayload) -> None: ...
+
+
+class NoopCommentPoster:
+    """Default poster used before a real GitHub client is wired.
+
+    This is a placeholder only: it makes the worker pipeline executable in Step 2
+    without external side effects. Production wiring should inject
+    ``GitHubCommentPoster`` from ``src.app.worker.github``.
+    """
+
+    def post_comment(self, payload: PRCommentPayload) -> None:
+        return None
+
+
+class Worker:
+    """Execute normalized event jobs through the orchestrator and output poster."""
+
+    def __init__(
+        self,
+        *,
+        orchestrator: Orchestrator | None = None,
+        comment_poster: CommentPoster | None = None,
+        max_attempts: int = 3,
+        timeout_seconds: float | None = None,
+        agent_runner: object | None = None,
+    ) -> None:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        self._orchestrator = orchestrator or EventOrchestrator()
+        self._comment_poster = comment_poster or NoopCommentPoster()
+        self._max_attempts = max_attempts
+        self._timeout_seconds = timeout_seconds
+        self._agent_runner = agent_runner
+
+    def process(self, job: EventJob) -> WorkerExecution:
+        last_error = ""
+        for attempt in range(1, self._max_attempts + 1):
+            context = WorkerExecutionContext(
+                correlation_id=job.correlation_id,
+                attempt=attempt,
+                max_attempts=self._max_attempts,
+                timeout_seconds=self._timeout_seconds,
+                agent_runner=self._agent_runner,
+            )
+            try:
+                result = self._run_once(job, context)
+            except Exception as exc:
+                last_error = str(exc)
+                if attempt == self._max_attempts:
+                    return WorkerExecution(
+                        correlation_id=job.correlation_id,
+                        status=WorkerStatus.FAILED,
+                        attempts=attempt,
+                        error=last_error,
+                    )
+                continue
+
+            return WorkerExecution(
+                correlation_id=job.correlation_id,
+                status=WorkerStatus.SUCCEEDED,
+                attempts=attempt,
+                result=result,
+            )
+
+        return WorkerExecution(
+            correlation_id=job.correlation_id,
+            status=WorkerStatus.FAILED,
+            attempts=self._max_attempts,
+            error=last_error,
+        )
+
+    def run_until_empty(self, queue: JobQueue) -> tuple[WorkerExecution, ...]:
+        results: list[WorkerExecution] = []
+        while (job := queue.dequeue()) is not None:
+            results.append(self.process(job))
+        return tuple(results)
+
+    def _run_once(self, job: EventJob, context: WorkerExecutionContext) -> PRWorkflowResult:
+        if context.timeout_seconds is not None:
+            # Timeout currently guards orchestrator execution. Posting remains
+            # synchronous so the Step 2 worker has a real timeout failure state
+            # without pretending to provide durable cancellation for all I/O yet.
+            result = _run_with_timeout(
+                lambda: self._orchestrator.run(job.event),
+                timeout_seconds=context.timeout_seconds,
+            )
+            self._comment_poster.post_comment(result.comment_payload)
+            return result
+        return self._run_pipeline(job, context)
+
+    def _run_pipeline(self, job: EventJob, context: WorkerExecutionContext) -> PRWorkflowResult:
+        # ``context`` is built here so Step 2 fixes the extension seam for
+        # Agent Framework integration, even though no runner is invoked until
+        # later milestones.
+        _ = context.agent_runner
+        result = self._orchestrator.run(job.event)
+        self._comment_poster.post_comment(result.comment_payload)
+        return result
+
+
+def _run_with_timeout(operation: Callable[[], PRWorkflowResult], *, timeout_seconds: float) -> PRWorkflowResult:
+    """Run one worker attempt with a basic timeout guard.
+
+    This deliberately uses a one-shot executor instead of durable cancellation.
+    It gives Step 2 a real timeout failure state; cooperative cancellation and
+    process-level isolation remain deployment concerns for the future runner.
+    """
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(operation)
+    timed_out = False
+    try:
+        return future.result(timeout=timeout_seconds)
+    except FutureTimeoutError as exc:
+        timed_out = True
+        future.cancel()
+        raise TimeoutError(f"worker attempt timed out after {timeout_seconds:g}s") from exc
+    finally:
+        executor.shutdown(wait=not timed_out, cancel_futures=timed_out)

--- a/src/app/worker/types.py
+++ b/src/app/worker/types.py
@@ -1,0 +1,44 @@
+"""Worker job and execution result contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, unique
+from typing import Any
+
+from src.runtime.orchestrator import PRWorkflowResult
+
+
+@unique
+class WorkerStatus(Enum):
+    """Terminal state of one worker job execution."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class WorkerExecutionContext:
+    """Per-job execution context passed through worker internals.
+
+    ``agent_runner`` is intentionally opaque in Step 2. It is the extension slot
+    where the Microsoft Agent Framework runner can be attached later without
+    changing the queue/job contract.
+    """
+
+    correlation_id: str
+    attempt: int
+    max_attempts: int
+    timeout_seconds: float | None = None
+    agent_runner: Any | None = None
+
+
+@dataclass(frozen=True)
+class WorkerExecution:
+    """Result of processing one :class:`EventJob`."""
+
+    correlation_id: str
+    status: WorkerStatus
+    attempts: int
+    result: PRWorkflowResult | None = None
+    error: str = ""

--- a/tests/app/gateway/test_github_webhook.py
+++ b/tests/app/gateway/test_github_webhook.py
@@ -1,0 +1,120 @@
+"""Tests for GitHub webhook gateway normalization and enqueueing."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+from src.app.gateway import GitHubWebhookGateway, WebhookRequest
+from src.app.worker import EventJob
+from src.core.contracts import CICompleted, EventType, PROpened
+
+FIXTURES = Path(__file__).parents[2] / "fixtures"
+SECRET = "webhook-secret"
+
+
+class RecordingQueue:
+    def __init__(self) -> None:
+        self.jobs: list[EventJob] = []
+
+    def enqueue(self, job: EventJob) -> None:
+        self.jobs.append(job)
+
+
+def _body(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+def _signature(body: bytes, secret: str = SECRET) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _request(event_name: str, body: bytes, *, delivery: str = "delivery-001") -> WebhookRequest:
+    return WebhookRequest(
+        headers={
+            "X-GitHub-Event": event_name,
+            "X-GitHub-Delivery": delivery,
+            "X-Hub-Signature-256": _signature(body),
+        },
+        body=body,
+    )
+
+
+def test_valid_pull_request_opened_webhook_enqueues_normalized_pr_event() -> None:
+    queue = RecordingQueue()
+    gateway = GitHubWebhookGateway(secret=SECRET, queue=queue)
+    body = _body("github_pr_opened.json")
+
+    response = gateway.handle(_request("pull_request", body, delivery="delivery-pr-001"))
+
+    assert response.status == 202
+    assert len(queue.jobs) == 1
+    job = queue.jobs[0]
+    assert isinstance(job.event, PROpened)
+    assert job.event.meta.event_type == EventType.PR_OPENED
+    assert job.event.meta.correlation_id == "delivery-pr-001"
+    assert job.event.pr_number == 123
+    assert job.event.repo_full_name == "acme-corp/web-api"
+
+
+def test_valid_workflow_run_webhook_enqueues_normalized_ci_event() -> None:
+    queue = RecordingQueue()
+    gateway = GitHubWebhookGateway(secret=SECRET, queue=queue)
+    body = _body("github_ci_completed_success.json")
+
+    response = gateway.handle(_request("workflow_run", body, delivery="delivery-ci-001"))
+
+    assert response.status == 202
+    assert len(queue.jobs) == 1
+    job = queue.jobs[0]
+    assert isinstance(job.event, CICompleted)
+    assert job.event.meta.event_type == EventType.CI_COMPLETED
+    assert job.event.meta.correlation_id == "delivery-ci-001"
+    assert job.event.workflow_name == "CI Pipeline"
+
+
+def test_invalid_signature_rejects_without_enqueueing() -> None:
+    queue = RecordingQueue()
+    gateway = GitHubWebhookGateway(secret=SECRET, queue=queue)
+    body = _body("github_pr_opened.json")
+    request = WebhookRequest(
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "delivery-bad",
+            "X-Hub-Signature-256": "sha256=bad",
+        },
+        body=body,
+    )
+
+    response = gateway.handle(request)
+
+    assert response.status == 401
+    assert queue.jobs == []
+
+
+def test_unhandled_webhook_action_is_accepted_without_enqueueing() -> None:
+    queue = RecordingQueue()
+    gateway = GitHubWebhookGateway(secret=SECRET, queue=queue)
+    payload = json.loads(_body("github_pr_opened.json"))
+    payload["action"] = "labeled"
+    body = json.dumps(payload).encode("utf-8")
+
+    response = gateway.handle(_request("pull_request", body, delivery="delivery-ignored"))
+
+    assert response.status == 204
+    assert response.message == ""
+    assert queue.jobs == []
+
+
+def test_malformed_json_returns_bad_request_without_enqueueing() -> None:
+    queue = RecordingQueue()
+    gateway = GitHubWebhookGateway(secret=SECRET, queue=queue)
+    body = b"{not-json"
+
+    response = gateway.handle(_request("pull_request", body))
+
+    assert response.status == 400
+    assert queue.jobs == []

--- a/tests/app/gateway/test_server.py
+++ b/tests/app/gateway/test_server.py
@@ -1,0 +1,66 @@
+"""Tests for stdlib GitHub webhook HTTP endpoint wiring."""
+
+from __future__ import annotations
+
+from http.client import HTTPConnection
+from threading import Thread
+
+from src.app.gateway import create_github_webhook_server
+from src.app.gateway.github import WebhookResponse
+
+
+class RecordingGateway:
+    def __init__(self, response: WebhookResponse | None = None) -> None:
+        self.calls: list[tuple[dict[str, str], bytes]] = []
+        self._response = response or WebhookResponse(status=202, message="ok", correlation_id="corr-http")
+
+    def handle(self, request):
+        self.calls.append((request.headers, request.body))
+        return self._response
+
+
+def test_github_webhook_server_exposes_post_endpoint() -> None:
+    gateway = RecordingGateway()
+    server = create_github_webhook_server(gateway, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        conn.request(
+            "POST",
+            "/webhooks/github",
+            body=b'{"ok": true}',
+            headers={"X-GitHub-Event": "pull_request"},
+        )
+        response = conn.getresponse()
+        body = response.read()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 202
+    assert response.getheader("X-Qaestro-Correlation-Id") == "corr-http"
+    assert body == b"ok"
+    assert gateway.calls[0][0]["X-GitHub-Event"] == "pull_request"
+    assert gateway.calls[0][1] == b'{"ok": true}'
+
+
+def test_github_webhook_server_does_not_write_body_for_no_content_response() -> None:
+    gateway = RecordingGateway(WebhookResponse(status=204, message="ignored", correlation_id="corr-http"))
+    server = create_github_webhook_server(gateway, host="127.0.0.1", port=0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        conn = HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        conn.request("POST", "/webhooks/github", body=b'{"ok": true}')
+        response = conn.getresponse()
+        body = response.read()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 204
+    assert response.getheader("X-Qaestro-Correlation-Id") == "corr-http"
+    assert body == b""

--- a/tests/app/test_gateway_worker_e2e.py
+++ b/tests/app/test_gateway_worker_e2e.py
@@ -1,0 +1,57 @@
+"""End-to-end app-layer tests for webhook enqueueing and worker processing."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from pathlib import Path
+
+from src.adapters.renderers import PRCommentPayload
+from src.app.gateway import GitHubWebhookGateway, WebhookRequest
+from src.app.jobs import InMemoryJobQueue
+from src.app.worker import Worker, WorkerStatus
+
+FIXTURES = Path(__file__).parents[1] / "fixtures"
+SECRET = "test-secret"
+
+
+class RecordingCommentPoster:
+    def __init__(self) -> None:
+        self.payloads: list[PRCommentPayload] = []
+
+    def post_comment(self, payload: PRCommentPayload) -> None:
+        self.payloads.append(payload)
+
+
+def _signature(body: bytes) -> str:
+    digest = hmac.new(SECRET.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def test_github_webhook_job_runs_through_worker_and_posts_comment() -> None:
+    body = (FIXTURES / "github_pr_opened.json").read_bytes()
+    queue = InMemoryJobQueue()
+    gateway = GitHubWebhookGateway(secret=SECRET, queue=queue)
+    poster = RecordingCommentPoster()
+    worker = Worker(comment_poster=poster)
+
+    response = gateway.handle(
+        WebhookRequest(
+            headers={
+                "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": "delivery-e2e-001",
+                "X-Hub-Signature-256": _signature(body),
+            },
+            body=body,
+        )
+    )
+    executions = worker.run_until_empty(queue)
+
+    assert response.status == 202
+    assert len(executions) == 1
+    assert executions[0].status == WorkerStatus.SUCCEEDED
+    assert executions[0].correlation_id == "delivery-e2e-001"
+    assert len(poster.payloads) == 1
+    assert poster.payloads[0].repo_full_name == "acme-corp/web-api"
+    assert poster.payloads[0].pr_number == 123
+    assert queue.dequeue() is None

--- a/tests/app/worker/test_github.py
+++ b/tests/app/worker/test_github.py
@@ -1,0 +1,35 @@
+"""Tests for GitHub worker comment posting adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.adapters.renderers import PRCommentPayload
+from src.app.worker import GitHubCommentPoster
+
+
+class RecordingGitHubClient:
+    def __init__(self) -> None:
+        self.comments: list[tuple[str, str, int, str]] = []
+
+    def create_issue_comment(self, owner: str, repo: str, number: int, body: str) -> None:
+        self.comments.append((owner, repo, number, body))
+
+
+def test_github_comment_poster_posts_pr_comment_payload() -> None:
+    client = RecordingGitHubClient()
+    poster = GitHubCommentPoster(client)
+    payload = PRCommentPayload(repo_full_name="Kimcheolhui/qaestro", pr_number=32, body="hello")
+
+    poster.post_comment(payload)
+
+    assert client.comments == [("Kimcheolhui", "qaestro", 32, "hello")]
+
+
+def test_github_comment_poster_rejects_invalid_repo_full_name() -> None:
+    client = RecordingGitHubClient()
+    poster = GitHubCommentPoster(client)
+    payload = PRCommentPayload(repo_full_name="invalid", pr_number=32, body="hello")
+
+    with pytest.raises(ValueError, match="repo_full_name"):
+        poster.post_comment(payload)

--- a/tests/app/worker/test_worker.py
+++ b/tests/app/worker/test_worker.py
@@ -1,0 +1,163 @@
+"""Tests for background worker job execution."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+
+from src.adapters.renderers import PRCommentPayload
+from src.app.worker import EventJob, InMemoryJobQueue, Worker, WorkerStatus
+from src.core.contracts import Event, EventMeta, EventSource, EventType, PROpened
+from src.runtime.orchestrator import PRWorkflowResult
+
+
+def _event() -> PROpened:
+    return PROpened(
+        meta=EventMeta(
+            event_id="evt-worker-001",
+            event_type=EventType.PR_OPENED,
+            correlation_id="corr-worker-001",
+            timestamp=datetime(2026, 4, 25, 12, 0, tzinfo=UTC),
+            source=EventSource.GITHUB,
+        ),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=32,
+        title="feat: worker",
+        body="",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/worker",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/32.diff",
+    )
+
+
+class RecordingOrchestrator:
+    def __init__(self, result: PRWorkflowResult) -> None:
+        self.events: list[PROpened] = []
+        self._result = result
+
+    def run(self, event: Event) -> PRWorkflowResult:
+        assert isinstance(event, PROpened)
+        self.events.append(event)
+        return self._result
+
+
+class RecordingCommentPoster:
+    def __init__(self) -> None:
+        self.payloads: list[PRCommentPayload] = []
+
+    def post_comment(self, payload: PRCommentPayload) -> None:
+        self.payloads.append(payload)
+
+
+def _result(event: PROpened) -> PRWorkflowResult:
+    payload = PRCommentPayload(
+        repo_full_name=event.repo_full_name,
+        pr_number=event.pr_number,
+        body="worker output",
+    )
+    # The worker only needs the event and rendered payload. The report is kept
+    # opaque here because report construction belongs to the orchestrator.
+    return PRWorkflowResult(
+        event=event,
+        report=object(),  # type: ignore[arg-type]
+        comment_payload=payload,
+        stage_order=("analyzer", "strategy", "renderer"),
+    )
+
+
+def test_worker_processes_single_event_and_posts_comment() -> None:
+    event = _event()
+    orchestrator = RecordingOrchestrator(_result(event))
+    poster = RecordingCommentPoster()
+    worker = Worker(orchestrator=orchestrator, comment_poster=poster)
+
+    result = worker.process(EventJob(event=event, correlation_id=event.meta.correlation_id))
+
+    assert result.status == WorkerStatus.SUCCEEDED
+    assert result.correlation_id == "corr-worker-001"
+    assert orchestrator.events == [event]
+    assert poster.payloads == [orchestrator._result.comment_payload]
+
+
+def test_worker_retries_transient_failure_and_reports_attempt_count() -> None:
+    event = _event()
+    result = _result(event)
+
+    class FlakyOrchestrator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run(self, event: Event) -> PRWorkflowResult:
+            assert isinstance(event, PROpened)
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary failure")
+            return result
+
+    orchestrator = FlakyOrchestrator()
+    poster = RecordingCommentPoster()
+    worker = Worker(orchestrator=orchestrator, comment_poster=poster, max_attempts=2)
+
+    execution = worker.process(EventJob(event=event, correlation_id=event.meta.correlation_id))
+
+    assert execution.status == WorkerStatus.SUCCEEDED
+    assert execution.attempts == 2
+    assert poster.payloads == [result.comment_payload]
+
+
+def test_worker_reports_failure_after_retries_exhausted() -> None:
+    event = _event()
+
+    class FailingOrchestrator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run(self, event: Event) -> PRWorkflowResult:
+            assert isinstance(event, PROpened)
+            self.calls += 1
+            raise RuntimeError("boom")
+
+    orchestrator = FailingOrchestrator()
+    poster = RecordingCommentPoster()
+    worker = Worker(orchestrator=orchestrator, comment_poster=poster, max_attempts=2)
+
+    execution = worker.process(EventJob(event=event, correlation_id=event.meta.correlation_id))
+
+    assert execution.status == WorkerStatus.FAILED
+    assert execution.attempts == 2
+    assert execution.error == "boom"
+    assert poster.payloads == []
+
+
+def test_worker_enforces_timeout_per_attempt() -> None:
+    event = _event()
+
+    class SlowOrchestrator:
+        def run(self, event: Event) -> PRWorkflowResult:
+            assert isinstance(event, PROpened)
+            time.sleep(0.05)
+            return _result(event)
+
+    poster = RecordingCommentPoster()
+    worker = Worker(orchestrator=SlowOrchestrator(), comment_poster=poster, max_attempts=1, timeout_seconds=0.01)
+
+    start = time.monotonic()
+    execution = worker.process(EventJob(event=event, correlation_id=event.meta.correlation_id))
+    elapsed = time.monotonic() - start
+
+    assert execution.status == WorkerStatus.FAILED
+    assert execution.attempts == 1
+    assert "timed out" in execution.error
+    assert elapsed < 0.04
+    assert poster.payloads == []
+
+
+def test_queue_runs_until_empty_in_fifo_order() -> None:
+    first = EventJob(event=_event(), correlation_id="first")
+    second = EventJob(event=_event(), correlation_id="second")
+    queue = InMemoryJobQueue([first, second])
+
+    assert queue.dequeue() is first
+    assert queue.dequeue() is second
+    assert queue.dequeue() is None


### PR DESCRIPTION
## Summary
- Adds a GitHub webhook gateway for `POST /webhooks/github`, HMAC signature verification, correlation id propagation, and normalized event enqueueing.
- Adds shared `EventJob` / queue contracts in `src/app/jobs.py` so gateway and worker do not depend on each other directly.
- Adds the background worker execution loop with retry, timeout failure state, execution context, and rendered PR comment posting via `GitHubCommentPoster`.
- Adds app-layer tests covering gateway normalization, HTTP endpoint wiring, worker retry/failure/timeout behavior, GitHub comment posting, and webhook → queue → worker E2E flow.

## Test Plan
- `uv run pytest tests/ -q`
- `uv run mypy src/`
- `uv run mypy tests/app/gateway/test_github_webhook.py tests/app/gateway/test_server.py tests/app/worker/test_worker.py tests/app/worker/test_github.py tests/app/test_gateway_worker_e2e.py`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv lock --check`

Closes #24
Closes #25

---
🤖 *Created by Hermes Agent*
