### PR TITLE
feat(runtime): add PR workflow triage depth

### DIFF
--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from src.core.contracts import QAReport
+
+if TYPE_CHECKING:
+    from src.runtime.orchestrator.pr_triage import PRWorkflowTriage
 
 
 @dataclass(frozen=True)
@@ -23,7 +27,13 @@ class GitHubPRCommentRenderer:
     risk, choose validation actions, or call GitHub.
     """
 
-    def render(self, report: QAReport, *, correlation_id: str) -> PRCommentPayload:
+    def render(
+        self,
+        report: QAReport,
+        *,
+        correlation_id: str,
+        triage: PRWorkflowTriage | None = None,
+    ) -> PRCommentPayload:
         if report.pr_number is None:
             raise ValueError("PR comment renderer requires report.pr_number")
 
@@ -35,6 +45,7 @@ class GitHubPRCommentRenderer:
                 f"Pull request: `#{report.pr_number}`",
                 f"Event: `{report.event_id}`",
                 f"Overall risk: **{report.impact.overall_risk.value.upper()}**",
+                *_triage_lines(triage),
                 "",
                 "### Change Summary",
                 report.summary_markdown or report.impact.summary,
@@ -63,6 +74,17 @@ class GitHubPRCommentRenderer:
             pr_number=report.pr_number,
             body=body,
         )
+
+
+def _triage_lines(triage: PRWorkflowTriage | None) -> list[str]:
+    if triage is None:
+        return []
+    allowed = ", ".join(stage.value for stage in triage.allowed_stages) or "none"
+    return [
+        f"Workflow depth: **{triage.depth.value.upper()}**",
+        f"Triage rationale: {triage.rationale}",
+        f"Allowed stages after triage: `{allowed}`",
+    ]
 
 
 def _diff_stat_lines(report: QAReport) -> list[str]:

--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from src.core.contracts import QAReport
 
 if TYPE_CHECKING:
-    from src.runtime.orchestrator.pr_triage import PRWorkflowTriage
+    from src.runtime.orchestrator.pr_triage import PRWorkflowDepth, PRWorkflowTriage
 
 
 @dataclass(frozen=True)
@@ -44,7 +44,7 @@ class GitHubPRCommentRenderer:
                 f"Repository: `{report.repo_full_name}`",
                 f"Pull request: `#{report.pr_number}`",
                 f"Event: `{report.event_id}`",
-                f"Overall risk: **{report.impact.overall_risk.value.upper()}**",
+                f"Overall risk: **{_overall_risk_label(report, triage)}**",
                 *_triage_lines(triage),
                 "",
                 "### Change Summary",
@@ -83,8 +83,22 @@ def _triage_lines(triage: PRWorkflowTriage | None) -> list[str]:
     return [
         f"Workflow depth: **{triage.depth.value.upper()}**",
         f"Triage rationale: {triage.rationale}",
-        f"Allowed stages after triage: `{allowed}`",
+        f"Triaged analysis/validation stages: `{allowed}`",
     ]
+
+
+def _overall_risk_label(report: QAReport, triage: PRWorkflowTriage | None) -> str:
+    if triage is not None and _is_triage_only_depth(triage.depth):
+        return "NOT ASSESSED"
+    return report.impact.overall_risk.value.upper()
+
+
+def _is_triage_only_depth(depth: PRWorkflowDepth) -> bool:
+    # Import only when needed to avoid a runtime import cycle between renderer
+    # and orchestrator modules.
+    from src.runtime.orchestrator.pr_triage import PRWorkflowDepth
+
+    return depth in {PRWorkflowDepth.NOOP, PRWorkflowDepth.LIGHTWEIGHT}
 
 
 def _diff_stat_lines(report: QAReport) -> list[str]:

--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from src.core.contracts import QAReport
 
 if TYPE_CHECKING:
-    from src.runtime.orchestrator.pr_triage import PRWorkflowDepth, PRWorkflowTriage
+    from src.runtime.orchestrator.pr_triage import PRWorkflowTriage
 
 
 @dataclass(frozen=True)
@@ -88,17 +88,8 @@ def _triage_lines(triage: PRWorkflowTriage | None) -> list[str]:
 
 
 def _overall_risk_label(report: QAReport, triage: PRWorkflowTriage | None) -> str:
-    if triage is not None and _is_triage_only_depth(triage.depth):
-        return "NOT ASSESSED"
-    return report.impact.overall_risk.value.upper()
-
-
-def _is_triage_only_depth(depth: PRWorkflowDepth) -> bool:
-    # Import only when needed to avoid a runtime import cycle between renderer
-    # and orchestrator modules.
-    from src.runtime.orchestrator.pr_triage import PRWorkflowDepth
-
-    return depth in {PRWorkflowDepth.NOOP, PRWorkflowDepth.LIGHTWEIGHT}
+    del triage
+    return report.impact.overall_risk.value.replace("_", " ").upper()
 
 
 def _diff_stat_lines(report: QAReport) -> list[str]:

--- a/src/app/worker/runner.py
+++ b/src/app/worker/runner.py
@@ -164,7 +164,8 @@ class Worker:
                 lambda: self._orchestrator.run(job.event),
                 timeout_seconds=context.timeout_seconds,
             )
-            self._output_poster.post_comment(result.comment_payload, correlation_id=job.correlation_id)
+            if result.comment_payload is not None:
+                self._output_poster.post_comment(result.comment_payload, correlation_id=job.correlation_id)
             return result
         return self._run_pipeline(job, context)
 
@@ -174,7 +175,8 @@ class Worker:
         # later milestones.
         _ = context.agent_runner
         result = self._orchestrator.run(job.event)
-        self._output_poster.post_comment(result.comment_payload, correlation_id=job.correlation_id)
+        if result.comment_payload is not None:
+            self._output_poster.post_comment(result.comment_payload, correlation_id=job.correlation_id)
         return result
 
 

--- a/src/core/analyzer/rules.py
+++ b/src/core/analyzer/rules.py
@@ -142,7 +142,13 @@ def _area_description(path_group: str, files: tuple[PRFileDiff, ...]) -> str:
 
 def _max_risk(risks: Iterable[RiskLevel], *, default: RiskLevel) -> RiskLevel:
     """Return the highest risk while keeping empty inputs deterministic."""
-    order = {RiskLevel.LOW: 0, RiskLevel.MEDIUM: 1, RiskLevel.HIGH: 2, RiskLevel.CRITICAL: 3}
+    order = {
+        RiskLevel.NOT_ASSESSED: -1,
+        RiskLevel.LOW: 0,
+        RiskLevel.MEDIUM: 1,
+        RiskLevel.HIGH: 2,
+        RiskLevel.CRITICAL: 3,
+    }
     risk_values = tuple(risks)
     if not risk_values:
         return default

--- a/src/core/contracts/domain.py
+++ b/src/core/contracts/domain.py
@@ -14,6 +14,7 @@ from enum import Enum, unique
 class RiskLevel(Enum):
     """Risk classification for a code change."""
 
+    NOT_ASSESSED = "not_assessed"
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"

--- a/src/runtime/orchestrator/__init__.py
+++ b/src/runtime/orchestrator/__init__.py
@@ -11,6 +11,7 @@ from .ci_workflow import CIWorkflowOrchestrator
 from .dispatcher import EventOrchestrator
 from .pr_context import EventPRContextProvider, PRContextProvider
 from .pr_event_stubs import PRCommentWorkflowOrchestrator, PRReviewWorkflowOrchestrator
+from .pr_triage import PRWorkflowDepth, PRWorkflowTriage, RuleBasedPRWorkflowTriageClassifier
 from .pr_workflow import PRWorkflowOrchestrator, StubPRRuntimeValidator
 from .tool_context import ToolRuntimePRContextProvider
 from .tool_output import ToolRuntimePRCommentPoster
@@ -18,6 +19,7 @@ from .types import (
     PRBehaviourAnalyzer,
     PRRuntimeValidator,
     PRStrategyEngine,
+    PRTriageClassifier,
     PRWorkflowDraft,
     PRWorkflowRenderer,
     PRWorkflowResult,
@@ -36,10 +38,14 @@ __all__ = [
     "PRReviewWorkflowOrchestrator",
     "PRRuntimeValidator",
     "PRStrategyEngine",
+    "PRTriageClassifier",
+    "PRWorkflowDepth",
     "PRWorkflowDraft",
     "PRWorkflowOrchestrator",
     "PRWorkflowRenderer",
     "PRWorkflowResult",
+    "PRWorkflowTriage",
+    "RuleBasedPRWorkflowTriageClassifier",
     "ShouldValidate",
     "StubPRRuntimeValidator",
     "ToolRuntimePRCommentPoster",

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -82,7 +82,7 @@ class RuleBasedPRWorkflowTriageClassifier:
 
 
 _LOW_SIGNAL_ROOT_FILES = {"readme.md", "changelog.md", "license", "notice"}
-_LOW_SIGNAL_DIRS = {"docs", ".github"}
+_LOW_SIGNAL_DIRS = {"docs"}
 _DEEP_SIGNAL_TOKENS = (
     "api",
     "auth",
@@ -102,7 +102,7 @@ _GENERATED_PATH_PARTS = {"generated", "dist", "build"}
 def _is_lightweight_change(context: PRAnalysisContext) -> bool:
     """Return true for tiny low-signal changes safe for summary-only output."""
     if not context.files:
-        return True
+        return False
     changed_lines = sum(file.additions + file.deletions for file in context.files)
     if changed_lines > 30 or len(context.files) > 5:
         return False

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -22,9 +22,11 @@ class PRWorkflowDepth(StrEnum):
 class PRWorkflowTriage:
     """Audit record describing why a PR uses a given workflow depth.
 
-    Step 3.5 keeps this classifier deterministic as a policy seam. Later Agent
-    Framework integration can replace the classifier while preserving this
-    bounded workflow contract and stage allowlist result.
+    Step 3.5 keeps this classifier deterministic as a temporary policy seam.
+    This must be replaced by Agent Framework + repo knowledge/instruction based
+    classification while preserving this bounded workflow contract and stage
+    allowlist result. Programmatic path/token heuristics are not expected to be
+    the final PR intent/depth decision model.
     """
 
     depth: PRWorkflowDepth
@@ -54,8 +56,8 @@ class RuleBasedPRWorkflowTriageClassifier:
     This is intentionally conservative and portable. It only chooses a
     lightweight path for very small, low-signal documentation/metadata changes,
     escalates obvious high-impact signals to deep, and otherwise preserves the
-    normal Step 3 analysis path. It is a seam for a future prompt/agent- and
-    repo-knowledge-based classifier, not the final workflow judgment model.
+    normal Step 3 analysis path. It is only a temporary seam and must be replaced
+    by Agent Framework + repo-knowledge/instruction based classification.
     """
 
     def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage:

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -122,8 +123,11 @@ def _contains_deep_signal(context: PRAnalysisContext) -> bool:
     haystacks = [context.title, context.body, context.unified_diff]
     haystacks.extend(file.path for file in context.files)
     haystacks.extend(file.patch or "" for file in context.files)
-    lowered = "\n".join(haystacks).lower()
-    return any(token in lowered for token in _DEEP_SIGNAL_TOKENS)
+    # Temporary seam hygiene only: match whole path/text tokens so short signals
+    # like "api" and "auth" do not fire on unrelated words such as "capital"
+    # or "author". This is not a permanent programmatic PR-depth classifier.
+    observed_tokens = set(re.split(r"[^a-z0-9]+", "\n".join(haystacks).lower()))
+    return any(token in observed_tokens for token in _DEEP_SIGNAL_TOKENS)
 
 
 def _is_low_signal_file(path: str) -> bool:

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -1,0 +1,138 @@
+"""PR workflow triage and depth-selection policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from src.core.analyzer import PRAnalysisContext, PRFileStatus
+from src.runtime.stages import WorkflowStage
+
+
+class PRWorkflowDepth(StrEnum):
+    """Workflow depth selected after PR context acquisition."""
+
+    NOOP = "noop"
+    LIGHTWEIGHT = "lightweight"
+    NORMAL = "normal"
+    DEEP = "deep"
+
+
+@dataclass(frozen=True)
+class PRWorkflowTriage:
+    """Audit record describing why a PR uses a given workflow depth.
+
+    Step 3.5 keeps this classifier deterministic as a policy seam. Later Agent
+    Framework integration can replace the classifier while preserving this
+    bounded workflow contract and stage allowlist result.
+    """
+
+    depth: PRWorkflowDepth
+    rationale: str
+    allowed_stages: tuple[WorkflowStage, ...]
+
+    @property
+    def runs_analysis(self) -> bool:
+        return WorkflowStage.ANALYZER in self.allowed_stages
+
+    @property
+    def runs_strategy(self) -> bool:
+        return WorkflowStage.STRATEGY in self.allowed_stages
+
+    @property
+    def allows_validation(self) -> bool:
+        return WorkflowStage.VALIDATOR in self.allowed_stages
+
+    @property
+    def renders_output(self) -> bool:
+        return self.depth is not PRWorkflowDepth.NOOP
+
+
+class RuleBasedPRWorkflowTriageClassifier:
+    """Deterministic placeholder for PR intent/depth classification.
+
+    This is intentionally conservative and portable. It only chooses a
+    lightweight path for very small, low-signal documentation/metadata changes,
+    escalates obvious high-impact signals to deep, and otherwise preserves the
+    normal Step 3 analysis path. It is a seam for a future prompt/agent- and
+    repo-knowledge-based classifier, not the final workflow judgment model.
+    """
+
+    def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage:
+        if _requires_deep_workflow(context):
+            return PRWorkflowTriage(
+                depth=PRWorkflowDepth.DEEP,
+                rationale="High-impact change signals require full analysis and validation.",
+                allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
+            )
+        if _is_lightweight_change(context):
+            return PRWorkflowTriage(
+                depth=PRWorkflowDepth.LIGHTWEIGHT,
+                rationale="Small low-signal documentation or metadata change; full analysis was skipped.",
+                allowed_stages=(),
+            )
+        return PRWorkflowTriage(
+            depth=PRWorkflowDepth.NORMAL,
+            rationale="Default PR workflow depth; run behaviour analysis and strategy planning.",
+            allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
+        )
+
+
+_LOW_SIGNAL_ROOT_FILES = {"readme.md", "changelog.md", "license", "notice"}
+_LOW_SIGNAL_DIRS = {"docs", ".github"}
+_DEEP_SIGNAL_TOKENS = (
+    "api",
+    "auth",
+    "authorization",
+    "breaking",
+    "deploy",
+    "deployment",
+    "migration",
+    "permission",
+    "runbook",
+    "secret",
+    "security",
+)
+_GENERATED_PATH_PARTS = {"generated", "dist", "build"}
+
+
+def _is_lightweight_change(context: PRAnalysisContext) -> bool:
+    """Return true for tiny low-signal changes safe for summary-only output."""
+    if not context.files:
+        return True
+    changed_lines = sum(file.additions + file.deletions for file in context.files)
+    if changed_lines > 30 or len(context.files) > 5:
+        return False
+    return all(_is_low_signal_file(file.path) for file in context.files) and not _contains_deep_signal(context)
+
+
+def _requires_deep_workflow(context: PRAnalysisContext) -> bool:
+    """Escalate obvious semantic or risky signals without path taxonomies."""
+    if any(file.status is PRFileStatus.REMOVED for file in context.files):
+        return True
+    changed_lines = sum(file.additions + file.deletions for file in context.files)
+    if changed_lines >= 250:
+        return True
+    return _contains_deep_signal(context)
+
+
+def _contains_deep_signal(context: PRAnalysisContext) -> bool:
+    haystacks = [context.title, context.body, context.unified_diff]
+    haystacks.extend(file.path for file in context.files)
+    haystacks.extend(file.patch or "" for file in context.files)
+    lowered = "\n".join(haystacks).lower()
+    return any(token in lowered for token in _DEEP_SIGNAL_TOKENS)
+
+
+def _is_low_signal_file(path: str) -> bool:
+    normalized = path.strip("/").lower()
+    if not normalized:
+        return True
+    parts = tuple(part for part in normalized.split("/") if part)
+    if not parts:
+        return True
+    if any(part in _GENERATED_PATH_PARTS for part in parts):
+        return True
+    if len(parts) == 1:
+        return parts[0] in _LOW_SIGNAL_ROOT_FILES or parts[0].endswith((".md", ".rst", ".txt"))
+    return parts[0] in _LOW_SIGNAL_DIRS

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -2,17 +2,30 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import cast
+
 from src.adapters.renderers import GitHubPRCommentRenderer, PRCommentPayload
-from src.core.analyzer import RuleBasedPRBehaviourAnalyzer
-from src.core.contracts import PREvent, QAReport, StrategyResult, ValidationOutcome, ValidationResult
+from src.core.analyzer import PRAnalysisContext, RuleBasedPRBehaviourAnalyzer
+from src.core.contracts import (
+    BehaviourImpact,
+    PREvent,
+    QAReport,
+    RiskLevel,
+    StrategyResult,
+    ValidationOutcome,
+    ValidationResult,
+)
 from src.core.strategy import RuleBasedPRStrategyEngine
 from src.runtime.stages import WorkflowStage
 
 from .pr_context import EventPRContextProvider, PRContextProvider
+from .pr_triage import PRWorkflowDepth, PRWorkflowTriage, RuleBasedPRWorkflowTriageClassifier
 from .types import (
     PRBehaviourAnalyzer,
     PRRuntimeValidator,
     PRStrategyEngine,
+    PRTriageClassifier,
     PRWorkflowDraft,
     PRWorkflowRenderer,
     PRWorkflowResult,
@@ -21,12 +34,13 @@ from .types import (
 
 
 class PRWorkflowOrchestrator:
-    """Coordinate context, analysis, strategy, validation, and rendering."""
+    """Coordinate PR context, triage, analysis, strategy, validation, and rendering."""
 
     def __init__(
         self,
         *,
         context_provider: PRContextProvider | None = None,
+        triage_classifier: PRTriageClassifier | Callable[[PRAnalysisContext], PRWorkflowTriage] | None = None,
         analyzer: PRBehaviourAnalyzer | None = None,
         strategy_engine: PRStrategyEngine | None = None,
         validator: PRRuntimeValidator | None = None,
@@ -34,6 +48,7 @@ class PRWorkflowOrchestrator:
         should_validate: ShouldValidate | None = None,
     ) -> None:
         self._context_provider = context_provider or EventPRContextProvider()
+        self._triage_classifier = _as_triage_classifier(triage_classifier or RuleBasedPRWorkflowTriageClassifier())
         self._analyzer = analyzer or RuleBasedPRBehaviourAnalyzer()
         self._strategy_engine = strategy_engine or RuleBasedPRStrategyEngine()
         self._validator = validator or StubPRRuntimeValidator()
@@ -41,25 +56,57 @@ class PRWorkflowOrchestrator:
         self._should_validate = should_validate or (lambda event, impact, strategy: True)
 
     def run(self, event: PREvent) -> PRWorkflowResult:
-        """Run the deterministic Step 3 PR workflow for one normalized event."""
+        """Run the bounded PR workflow for one normalized event."""
         stages: list[WorkflowStage] = []
 
         stages.append(WorkflowStage.CONTEXT)
         context = self._context_provider.load(event)
 
+        stages.append(WorkflowStage.TRIAGE)
+        triage = self._triage_classifier.classify(context)
+
+        if triage.depth is PRWorkflowDepth.NOOP:
+            report = _triage_only_report(event, context, triage)
+            return PRWorkflowResult(
+                event=event,
+                report=report,
+                triage=triage,
+                comment_payload=None,
+                stage_order=tuple(stages),
+            )
+
+        if not triage.runs_analysis:
+            report = _triage_only_report(event, context, triage)
+            stage_order = (*stages, WorkflowStage.RENDERER)
+            draft = PRWorkflowDraft(event=event, report=report, triage=triage, stage_order=stage_order)
+            comment_payload = self._renderer.render(draft)
+            return PRWorkflowResult(
+                event=event,
+                report=report,
+                triage=triage,
+                comment_payload=comment_payload,
+                stage_order=stage_order,
+            )
+
         stages.append(WorkflowStage.ANALYZER)
         impact = self._analyzer.analyze(context)
 
-        stages.append(WorkflowStage.STRATEGY)
-        strategy = self._strategy_engine.plan(
-            repo_full_name=context.repo_full_name,
-            pr_number=context.pr_number,
-            title=context.title,
-            impact=impact,
-        )
+        strategy: StrategyResult
+        if triage.runs_strategy:
+            stages.append(WorkflowStage.STRATEGY)
+            strategy = self._strategy_engine.plan(
+                repo_full_name=context.repo_full_name,
+                pr_number=context.pr_number,
+                title=context.title,
+                impact=impact,
+            )
+        else:
+            strategy = _empty_strategy(triage)
 
         validations: tuple[ValidationResult, ...]
-        if self._should_validate(event, impact, strategy):
+        if triage.allows_validation and (
+            triage.depth is PRWorkflowDepth.DEEP or self._should_validate(event, impact, strategy)
+        ):
             stages.append(WorkflowStage.VALIDATOR)
             validations = self._validator.validate(strategy)
         else:
@@ -75,11 +122,12 @@ class PRWorkflowOrchestrator:
             summary_markdown=impact.summary,
         )
         stage_order = (*stages, WorkflowStage.RENDERER)
-        draft = PRWorkflowDraft(event=event, report=report, stage_order=stage_order)
+        draft = PRWorkflowDraft(event=event, report=report, triage=triage, stage_order=stage_order)
         comment_payload = self._renderer.render(draft)
         return PRWorkflowResult(
             event=event,
             report=report,
+            triage=triage,
             comment_payload=comment_payload,
             stage_order=stage_order,
         )
@@ -92,7 +140,7 @@ class _DefaultDraftRenderer:
         self._renderer = GitHubPRCommentRenderer()
 
     def render(self, draft: PRWorkflowDraft) -> PRCommentPayload:
-        return self._renderer.render(draft.report, correlation_id=draft.correlation_id)
+        return self._renderer.render(draft.report, correlation_id=draft.correlation_id, triage=draft.triage)
 
 
 class StubPRRuntimeValidator:
@@ -112,3 +160,60 @@ class StubPRRuntimeValidator:
             )
             for action in strategy.actions
         )
+
+
+class _CallableTriageClassifier:
+    """Adapter that lets tests and future runners inject a simple callable."""
+
+    def __init__(self, classify: Callable[[PRAnalysisContext], PRWorkflowTriage]) -> None:
+        self._classify = classify
+
+    def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage:
+        return self._classify(context)
+
+
+def _as_triage_classifier(
+    classifier: PRTriageClassifier | Callable[[PRAnalysisContext], PRWorkflowTriage],
+) -> PRTriageClassifier:
+    if hasattr(classifier, "classify"):
+        return cast(PRTriageClassifier, classifier)
+    return _CallableTriageClassifier(classifier)
+
+
+def _triage_only_report(event: PREvent, context: PRAnalysisContext, triage: PRWorkflowTriage) -> QAReport:
+    """Build an auditable no-op/lightweight report without full analysis output."""
+    impact = BehaviourImpact(
+        summary=triage.rationale,
+        areas=(),
+        # Stub-only neutral risk: lightweight/no-op triage intentionally avoids
+        # full behaviour risk evaluation, so this must not be read as a real
+        # risk decision for the PR.
+        overall_risk=RiskLevel.LOW,
+        raw_diff_stats={
+            "files_changed": len(context.files),
+            "additions": sum(file.additions for file in context.files),
+            "deletions": sum(file.deletions for file in context.files),
+        },
+    )
+    return QAReport(
+        event_id=event.meta.event_id,
+        repo_full_name=context.repo_full_name,
+        pr_number=context.pr_number,
+        impact=impact,
+        strategy=_empty_strategy(triage),
+        validations=(),
+        summary_markdown=_triage_summary(context, triage),
+    )
+
+
+def _empty_strategy(triage: PRWorkflowTriage) -> StrategyResult:
+    """Return explicit empty strategy output for skipped strategy paths."""
+    return StrategyResult(actions=(), reasoning=triage.rationale, confidence=0.0)
+
+
+def _triage_summary(context: PRAnalysisContext, triage: PRWorkflowTriage) -> str:
+    changed_paths = ", ".join(f"`{file.path}`" for file in context.files[:5]) or "no files"
+    return (
+        f"Workflow depth `{triage.depth.value}` selected after context triage; "
+        f"{triage.rationale} Changed files: {changed_paths}."
+    )

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -65,7 +65,7 @@ class PRWorkflowOrchestrator:
         stages.append(WorkflowStage.TRIAGE)
         triage = self._triage_classifier.classify(context)
 
-        if triage.depth is PRWorkflowDepth.NOOP:
+        if not triage.renders_output:
             report = _triage_only_report(event, context, triage)
             return PRWorkflowResult(
                 event=event,
@@ -175,9 +175,12 @@ class _CallableTriageClassifier:
 def _as_triage_classifier(
     classifier: PRTriageClassifier | Callable[[PRAnalysisContext], PRWorkflowTriage],
 ) -> PRTriageClassifier:
-    if hasattr(classifier, "classify"):
+    classify = getattr(classifier, "classify", None)
+    if callable(classify):
         return cast(PRTriageClassifier, classifier)
-    return _CallableTriageClassifier(classifier)
+    if callable(classifier):
+        return _CallableTriageClassifier(classifier)
+    raise TypeError("triage_classifier must be callable or expose a callable classify(context) method")
 
 
 def _triage_only_report(event: PREvent, context: PRAnalysisContext, triage: PRWorkflowTriage) -> QAReport:

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -188,10 +188,7 @@ def _triage_only_report(event: PREvent, context: PRAnalysisContext, triage: PRWo
     impact = BehaviourImpact(
         summary=triage.rationale,
         areas=(),
-        # Stub-only neutral risk: lightweight/no-op triage intentionally avoids
-        # full behaviour risk evaluation, so this must not be read as a real
-        # risk decision for the PR.
-        overall_risk=RiskLevel.LOW,
+        overall_risk=RiskLevel.NOT_ASSESSED,
         raw_diff_stats={
             "files_changed": len(context.files),
             "additions": sum(file.additions for file in context.files),

--- a/src/runtime/orchestrator/types.py
+++ b/src/runtime/orchestrator/types.py
@@ -11,6 +11,8 @@ from src.core.analyzer import PRAnalysisContext
 from src.core.contracts import BehaviourImpact, PREvent, QAReport, StrategyResult, ValidationResult
 from src.runtime.stages import WorkflowStage
 
+from .pr_triage import PRWorkflowTriage
+
 
 class UnsupportedEventError(RuntimeError):
     """Raised when an event has no supported workflow orchestration yet."""
@@ -27,6 +29,7 @@ class PRWorkflowDraft:
 
     event: PREvent
     report: QAReport
+    triage: PRWorkflowTriage
     stage_order: tuple[WorkflowStage, ...]
 
     @property
@@ -52,7 +55,8 @@ class PRWorkflowResult:
 
     event: PREvent
     report: QAReport
-    comment_payload: PRCommentPayload
+    triage: PRWorkflowTriage
+    comment_payload: PRCommentPayload | None
     stage_order: tuple[WorkflowStage, ...]
 
     @property
@@ -101,6 +105,12 @@ class PRRuntimeValidator(Protocol):
     """Validate planned PR workflow strategy actions."""
 
     def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]: ...
+
+
+class PRTriageClassifier(Protocol):
+    """Choose workflow depth after PR context acquisition."""
+
+    def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage: ...
 
 
 ShouldValidate = Callable[[PREvent, BehaviourImpact, StrategyResult], bool]

--- a/src/runtime/stages.py
+++ b/src/runtime/stages.py
@@ -9,6 +9,7 @@ class WorkflowStage(StrEnum):
     """Canonical stage names for qaestro's structured PR workflow."""
 
     CONTEXT = "context"
+    TRIAGE = "triage"
     ANALYZER = "analyzer"
     STRATEGY = "strategy"
     VALIDATOR = "validator"

--- a/tests/adapters/renderers/test_pr_comment.py
+++ b/tests/adapters/renderers/test_pr_comment.py
@@ -14,6 +14,8 @@ from src.core.contracts import (
     ValidationOutcome,
     ValidationResult,
 )
+from src.runtime.orchestrator import PRWorkflowDepth, PRWorkflowTriage
+from src.runtime.stages import WorkflowStage
 
 
 def _qa_report() -> QAReport:
@@ -105,3 +107,47 @@ def test_github_pr_comment_renderer_does_not_require_validation_results():
 
     assert "Validation not executed in this step" in payload.body
     assert payload.pr_number == 31
+
+
+def test_github_pr_comment_renderer_marks_triage_only_risk_as_not_assessed() -> None:
+    triage = PRWorkflowTriage(
+        depth=PRWorkflowDepth.LIGHTWEIGHT,
+        rationale="Small documentation update; full analysis was skipped.",
+        allowed_stages=(),
+    )
+    report = _qa_report()
+    report = QAReport(
+        event_id=report.event_id,
+        repo_full_name=report.repo_full_name,
+        pr_number=report.pr_number,
+        impact=BehaviourImpact(
+            summary=triage.rationale,
+            areas=(),
+            overall_risk=RiskLevel.LOW,
+            raw_diff_stats=report.impact.raw_diff_stats,
+        ),
+        strategy=StrategyResult(actions=(), reasoning=triage.rationale, confidence=0.0),
+        validations=(),
+        summary_markdown="Triage-only summary.",
+    )
+
+    payload = GitHubPRCommentRenderer().render(report, correlation_id="corr-triage", triage=triage)
+
+    assert "Overall risk: **NOT ASSESSED**" in payload.body
+    assert "Overall risk: **LOW**" not in payload.body
+    assert "Triaged analysis/validation stages: `none`" in payload.body
+    assert "Allowed stages after triage" not in payload.body
+
+
+def test_github_pr_comment_renderer_lists_triaged_execution_stages_precisely() -> None:
+    triage = PRWorkflowTriage(
+        depth=PRWorkflowDepth.DEEP,
+        rationale="High-impact change signals require full analysis and validation.",
+        allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
+    )
+
+    payload = GitHubPRCommentRenderer().render(_qa_report(), correlation_id="corr-deep", triage=triage)
+
+    assert "Overall risk: **MEDIUM**" in payload.body
+    assert "Triaged analysis/validation stages: `analyzer, strategy, validator`" in payload.body
+    assert "Allowed stages after triage" not in payload.body

--- a/tests/adapters/renderers/test_pr_comment.py
+++ b/tests/adapters/renderers/test_pr_comment.py
@@ -123,7 +123,7 @@ def test_github_pr_comment_renderer_marks_triage_only_risk_as_not_assessed() -> 
         impact=BehaviourImpact(
             summary=triage.rationale,
             areas=(),
-            overall_risk=RiskLevel.LOW,
+            overall_risk=RiskLevel.NOT_ASSESSED,
             raw_diff_stats=report.impact.raw_diff_stats,
         ),
         strategy=StrategyResult(actions=(), reasoning=triage.rationale, confidence=0.0),

--- a/tests/app/worker/test_worker.py
+++ b/tests/app/worker/test_worker.py
@@ -12,7 +12,7 @@ import pytest
 from src.adapters.renderers import PRCommentPayload
 from src.app.worker import EventJob, InMemoryJobQueue, MalformedEventJob, Worker, WorkerStatus
 from src.core.contracts import Event, EventMeta, EventSource, EventType, PROpened
-from src.runtime.orchestrator import PRWorkflowResult
+from src.runtime.orchestrator import PRWorkflowDepth, PRWorkflowResult, PRWorkflowTriage
 from src.runtime.stages import WorkflowStage
 
 
@@ -67,6 +67,11 @@ def _result(event: PROpened) -> PRWorkflowResult:
     return PRWorkflowResult(
         event=event,
         report=object(),  # type: ignore[arg-type]
+        triage=PRWorkflowTriage(
+            depth=PRWorkflowDepth.NORMAL,
+            rationale="worker test result",
+            allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
+        ),
         comment_payload=payload,
         stage_order=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.RENDERER),
     )

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -30,9 +30,11 @@ from src.runtime.orchestrator import (
     ChatWorkflowOrchestrator,
     CIWorkflowOrchestrator,
     EventOrchestrator,
+    PRWorkflowDepth,
     PRWorkflowDraft,
     PRWorkflowOrchestrator,
     PRWorkflowResult,
+    PRWorkflowTriage,
     UnsupportedEventError,
 )
 from src.runtime.stages import WorkflowStage
@@ -130,11 +132,13 @@ def test_event_orchestrator_dispatches_pr_events_to_pr_sub_orchestrator():
     assert result.correlation_id == "corr-001"
     assert result.stage_order == (
         WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
         WorkflowStage.ANALYZER,
         WorkflowStage.STRATEGY,
         WorkflowStage.VALIDATOR,
         WorkflowStage.RENDERER,
     )
+    assert result.comment_payload is not None
     assert result.comment_payload.repo_full_name == "Kimcheolhui/qaestro"
     assert result.comment_payload.pr_number == 31
 
@@ -175,6 +179,7 @@ def test_pr_workflow_orchestrator_runs_stub_flow_and_renders_pr_comment_payload(
     assert result.correlation_id == "corr-001"
     assert result.stage_order == (
         WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
         WorkflowStage.ANALYZER,
         WorkflowStage.STRATEGY,
         WorkflowStage.VALIDATOR,
@@ -183,6 +188,7 @@ def test_pr_workflow_orchestrator_runs_stub_flow_and_renders_pr_comment_payload(
     assert result.impact.summary.startswith("PR #31 (feat: add connector) changes 2 files")
     assert result.strategy.reasoning.startswith("High risk")
     assert len(result.validations) == 3
+    assert result.comment_payload is not None
     assert result.comment_payload.repo_full_name == "Kimcheolhui/qaestro"
     assert result.comment_payload.pr_number == 31
     assert "feat: add connector" in result.comment_payload.body
@@ -210,24 +216,117 @@ def test_pr_workflow_orchestrator_passes_draft_to_injected_renderer():
     assert len(renderer.calls) == 1
     assert renderer.calls[0].event is result.event
     assert renderer.calls[0].report == result.report
+    assert renderer.calls[0].triage == result.triage
     assert renderer.calls[0].correlation_id == result.correlation_id
     assert not hasattr(renderer.calls[0], "comment_payload")
+    assert result.comment_payload is not None
     assert result.comment_payload.body == "custom renderer output"
 
 
 def test_pr_workflow_orchestrator_can_skip_validation_via_policy_hook():
-    orchestrator = PRWorkflowOrchestrator(should_validate=lambda event, impact, strategy: False)
+    normal_triage = PRWorkflowTriage(
+        depth=PRWorkflowDepth.NORMAL,
+        rationale="Normal analysis can still skip validation by policy.",
+        allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
+    )
+    orchestrator = PRWorkflowOrchestrator(
+        triage_classifier=lambda context: normal_triage,
+        should_validate=lambda event, impact, strategy: False,
+    )
 
     result = orchestrator.run(_pr_opened_event())
 
     assert result.validations == ()
     assert result.stage_order == (
         WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
         WorkflowStage.ANALYZER,
         WorkflowStage.STRATEGY,
         WorkflowStage.RENDERER,
     )
+    assert result.comment_payload is not None
     assert "Validation not executed" in result.comment_payload.body
+
+
+def test_pr_workflow_orchestrator_can_emit_lightweight_triage_output_without_full_analysis() -> None:
+    event = PROpened(
+        meta=_event_meta("evt-docs", EventType.PR_OPENED, "corr-docs"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=43,
+        title="docs: update contributor guide",
+        body="Clarifies wording only.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="docs/contributor-guide",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/43.diff",
+        files_changed=(FileChange(path="docs/CONTRIBUTING.md", status="modified", additions=3, deletions=1),),
+    )
+
+    orchestrator = PRWorkflowOrchestrator()
+    result = orchestrator.run(event)
+
+    assert result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
+    assert result.stage_order == (WorkflowStage.CONTEXT, WorkflowStage.TRIAGE, WorkflowStage.RENDERER)
+    assert result.impact.areas == ()
+    assert result.strategy.actions == ()
+    assert result.validations == ()
+    assert result.comment_payload is not None
+    assert "Workflow depth: **LIGHTWEIGHT**" in result.comment_payload.body
+    assert "full analysis was skipped" in result.comment_payload.body
+    assert "docs/CONTRIBUTING.md" in result.comment_payload.body
+
+
+def test_pr_workflow_orchestrator_uses_deep_triage_to_force_validation() -> None:
+    class RecordingValidator:
+        def __init__(self) -> None:
+            self.calls: list[StrategyResult] = []
+
+        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+            self.calls.append(strategy)
+            return ()
+
+    validator = RecordingValidator()
+    triage = PRWorkflowTriage(
+        depth=PRWorkflowDepth.DEEP,
+        rationale="High-impact security runbook change requires deep validation.",
+        allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
+    )
+    orchestrator = PRWorkflowOrchestrator(
+        triage_classifier=lambda context: triage,
+        should_validate=lambda event, impact, strategy: False,
+        validator=validator,
+    )
+
+    result = orchestrator.run(_pr_opened_event())
+
+    assert result.triage == triage
+    assert validator.calls == [result.strategy]
+    assert result.stage_order == (
+        WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
+        WorkflowStage.ANALYZER,
+        WorkflowStage.STRATEGY,
+        WorkflowStage.VALIDATOR,
+        WorkflowStage.RENDERER,
+    )
+    assert result.comment_payload is not None
+    assert "Workflow depth: **DEEP**" in result.comment_payload.body
+
+
+def test_pr_workflow_orchestrator_can_return_noop_triage_result() -> None:
+    triage = PRWorkflowTriage(
+        depth=PRWorkflowDepth.NOOP,
+        rationale="Generated metadata change does not need qaestro analysis.",
+        allowed_stages=(),
+    )
+    orchestrator = PRWorkflowOrchestrator(triage_classifier=lambda context: triage)
+
+    result = orchestrator.run(_pr_opened_event())
+
+    assert result.triage == triage
+    assert result.stage_order == (WorkflowStage.CONTEXT, WorkflowStage.TRIAGE)
+    assert result.comment_payload is None
+    assert result.impact.summary == "Generated metadata change does not need qaestro analysis."
 
 
 def test_pr_workflow_orchestrator_accepts_replaceable_components():
@@ -301,6 +400,7 @@ def test_pr_workflow_orchestrator_accepts_replaceable_components():
     assert result.strategy.reasoning == "custom strategy"
     assert result.stage_order == (
         WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
         WorkflowStage.ANALYZER,
         WorkflowStage.STRATEGY,
         WorkflowStage.VALIDATOR,

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -279,6 +279,43 @@ def test_pr_workflow_orchestrator_can_emit_lightweight_triage_output_without_ful
     assert "full analysis was skipped" in result.comment_payload.body
     assert "docs/CONTRIBUTING.md" in result.comment_payload.body
 
+    assert result.impact.overall_risk is RiskLevel.NOT_ASSESSED
+
+
+def test_rule_based_triage_does_not_default_github_config_or_empty_files_to_lightweight() -> None:
+    workflow_event = PROpened(
+        meta=_event_meta("evt-workflow", EventType.PR_OPENED, "corr-workflow"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=46,
+        title="ci: update python matrix",
+        body="Updates GitHub Actions CI configuration.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="ci/python-matrix",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/46.diff",
+        files_changed=(FileChange(path=".github/workflows/ci.yml", status="modified", additions=2, deletions=1),),
+    )
+    empty_files_event = PROpened(
+        meta=_event_meta("evt-empty-files", EventType.PR_OPENED, "corr-empty-files"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=47,
+        title="chore: update metadata",
+        body="File list is unavailable in this event context.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="chore/metadata",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/47.diff",
+        files_changed=(),
+    )
+
+    workflow_result = PRWorkflowOrchestrator().run(workflow_event)
+    empty_files_result = PRWorkflowOrchestrator().run(empty_files_event)
+
+    assert workflow_result.triage.depth is PRWorkflowDepth.NORMAL
+    assert WorkflowStage.ANALYZER in workflow_result.stage_order
+    assert empty_files_result.triage.depth is PRWorkflowDepth.NORMAL
+    assert WorkflowStage.ANALYZER in empty_files_result.stage_order
+
 
 def test_pr_workflow_orchestrator_rejects_classifier_with_non_callable_classify_attribute() -> None:
     class InvalidClassifier:

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -35,6 +35,7 @@ from src.runtime.orchestrator import (
     PRWorkflowOrchestrator,
     PRWorkflowResult,
     PRWorkflowTriage,
+    RuleBasedPRWorkflowTriageClassifier,
     UnsupportedEventError,
 )
 from src.runtime.stages import WorkflowStage
@@ -272,8 +273,83 @@ def test_pr_workflow_orchestrator_can_emit_lightweight_triage_output_without_ful
     assert result.validations == ()
     assert result.comment_payload is not None
     assert "Workflow depth: **LIGHTWEIGHT**" in result.comment_payload.body
+    assert "Overall risk: **NOT ASSESSED**" in result.comment_payload.body
+    assert "Triaged analysis/validation stages: `none`" in result.comment_payload.body
+    assert "Allowed stages after triage" not in result.comment_payload.body
     assert "full analysis was skipped" in result.comment_payload.body
     assert "docs/CONTRIBUTING.md" in result.comment_payload.body
+
+
+def test_pr_workflow_orchestrator_rejects_classifier_with_non_callable_classify_attribute() -> None:
+    class InvalidClassifier:
+        classify = "not callable"
+
+    with pytest.raises(TypeError, match="triage_classifier"):
+        PRWorkflowOrchestrator(triage_classifier=InvalidClassifier())  # type: ignore[arg-type]
+
+
+def test_rule_based_triage_deep_signal_matching_uses_token_boundaries() -> None:
+    classifier = RuleBasedPRWorkflowTriageClassifier()
+
+    false_positive_event = PROpened(
+        meta=_event_meta("evt-false-positive", EventType.PR_OPENED, "corr-false-positive"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=44,
+        title="docs: author capitalization cleanup",
+        body="Updates author names and capital letters only.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="docs/author-capitalization",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/44.diff",
+        files_changed=(
+            FileChange(
+                path="docs/author-capitalization.md",
+                status="modified",
+                additions=2,
+                deletions=1,
+            ),
+        ),
+    )
+    deep_signal_event = PROpened(
+        meta=_event_meta("evt-auth-docs", EventType.PR_OPENED, "corr-auth-docs"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=45,
+        title="docs: update auth runbook",
+        body="Documents the auth recovery runbook.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="docs/auth-runbook",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/45.diff",
+        files_changed=(
+            FileChange(
+                path="docs/auth-runbook.md",
+                status="modified",
+                additions=2,
+                deletions=1,
+            ),
+        ),
+    )
+
+    false_positive_result = PRWorkflowOrchestrator(triage_classifier=classifier).run(false_positive_event)
+    deep_signal_result = PRWorkflowOrchestrator(triage_classifier=classifier).run(deep_signal_event)
+
+    assert false_positive_result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
+    assert deep_signal_result.triage.depth is PRWorkflowDepth.DEEP
+
+
+def test_pr_workflow_orchestrator_uses_renders_output_contract_for_noop() -> None:
+    triage = PRWorkflowTriage(
+        depth=PRWorkflowDepth.NOOP,
+        rationale="Generated metadata change does not need qaestro analysis.",
+        allowed_stages=(WorkflowStage.RENDERER,),
+    )
+    orchestrator = PRWorkflowOrchestrator(triage_classifier=lambda context: triage)
+
+    result = orchestrator.run(_pr_opened_event())
+
+    assert triage.renders_output is False
+    assert result.stage_order == (WorkflowStage.CONTEXT, WorkflowStage.TRIAGE)
+    assert result.comment_payload is None
 
 
 def test_pr_workflow_orchestrator_uses_deep_triage_to_force_validation() -> None:

--- a/tests/runtime/test_pr_context_provider.py
+++ b/tests/runtime/test_pr_context_provider.py
@@ -95,4 +95,5 @@ def test_pr_workflow_uses_context_provider_instead_of_webhook_file_placeholders(
     assert result.impact.overall_risk is RiskLevel.LOW
     assert result.impact.areas[0].module == "src/api"
     assert "placeholder.txt" not in result.report.summary_markdown
+    assert result.comment_payload is not None
     assert "Behaviour Impact Report" in result.comment_payload.body

--- a/tests/runtime/test_workflow_stages.py
+++ b/tests/runtime/test_workflow_stages.py
@@ -40,6 +40,7 @@ def test_workflow_stage_enum_defines_runtime_stage_values() -> None:
     assert issubclass(WorkflowStage, StrEnum)
     assert tuple(stage.value for stage in WorkflowStage) == (
         "context",
+        "triage",
         "analyzer",
         "strategy",
         "validator",
@@ -64,6 +65,7 @@ def test_pr_workflow_reports_closed_stage_enum_order() -> None:
 
     assert result.stage_order == (
         WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
         WorkflowStage.ANALYZER,
         WorkflowStage.STRATEGY,
         WorkflowStage.VALIDATOR,

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -412,13 +412,14 @@ class TestRiskLevel:
     """RiskLevel enum."""
 
     def test_values(self):
+        assert RiskLevel.NOT_ASSESSED.value == "not_assessed"
         assert RiskLevel.LOW.value == "low"
         assert RiskLevel.MEDIUM.value == "medium"
         assert RiskLevel.HIGH.value == "high"
         assert RiskLevel.CRITICAL.value == "critical"
 
     def test_member_count(self):
-        assert len(RiskLevel) == 4
+        assert len(RiskLevel) == 5
 
 
 class TestActionType:


### PR DESCRIPTION
## Summary

Implements PR workflow triage as a bounded workflow-depth decision immediately after PR context acquisition.

Key changes:

- Adds `WorkflowStage.TRIAGE` and a `PRWorkflowTriage` audit record.
- Adds `PRWorkflowDepth` values: `noop`, `lightweight`, `normal`, and `deep`.
- Routes `PRWorkflowOrchestrator` through context → triage before analysis/strategy/validation.
- Supports triage-driven branching:
  - `NOOP`: context + triage only, no PR comment output.
  - `LIGHTWEIGHT`: skips full analysis/strategy/validation but emits an auditable summary comment.
  - `NORMAL`: preserves existing analysis/strategy/validation policy path.
  - `DEEP`: forces validation even when the normal validation policy hook would skip it.
- Adds a deterministic classifier only as a temporary seam. It must be replaced by Agent Framework + repo knowledge/instruction based classification; programmatic path/token heuristics are not the final PR intent/depth decision model.
- Renders triage depth/rationale/allowed stages in PR comments and makes the worker tolerate no-output no-op results.

## Verification

```text
uv run pytest tests/ -q
uv run mypy src/
uv run mypy tests/runtime/test_orchestrator.py tests/runtime/test_workflow_stages.py tests/runtime/test_pr_context_provider.py tests/app/worker/test_worker.py
uv run ruff check src/ tests/
uv run ruff format --check src/ tests/
uv lock --check
```

Additional follow-up verification after clarifying the classifier replacement requirement:

```text
uv run pytest tests/runtime/test_orchestrator.py tests/runtime/test_workflow_stages.py -q
uv run mypy src/
uv run ruff check src/runtime/orchestrator/pr_triage.py
uv run ruff format --check src/runtime/orchestrator/pr_triage.py
```

Closes #43

---
🤖 *Updated by Hermes Agent*
