### PR TITLE
feat: add PR aggregate readiness contracts

### DIFF
--- a/src/adapters/connectors/github/__init__.py
+++ b/src/adapters/connectors/github/__init__.py
@@ -19,12 +19,13 @@ from .auth import Clock, GitHubAppAuth, SystemClock
 from .client import GitHubClient
 from .errors import AuthError, GitHubError, NotFoundError, RateLimitError
 from .transport import FakeResponse, FakeTransport, HTTPResponse, HTTPTransport, UrllibTransport
-from .types import ActionsJobResult, CommentResult, FileDiff, PRMeta
+from .types import ActionsJobResult, CheckRunResult, CommentResult, FileDiff, PRMeta
 from .webhook import verify_signature
 
 __all__ = [
     "ActionsJobResult",
     "AuthError",
+    "CheckRunResult",
     "Clock",
     "CommentResult",
     "FakeResponse",

--- a/src/adapters/connectors/github/client.py
+++ b/src/adapters/connectors/github/client.py
@@ -26,7 +26,7 @@ from urllib.parse import quote, urlencode
 from .auth import GitHubAppAuth
 from .errors import AuthError, GitHubError, NotFoundError, RateLimitError
 from .transport import HTTPResponse, HTTPTransport, UrllibTransport
-from .types import ActionsJobResult, CommentResult, FileDiff, PRMeta
+from .types import ActionsJobResult, CheckRunResult, CommentResult, FileDiff, PRMeta
 
 # Page size for listing endpoints. Max allowed by GitHub is 100.
 _DEFAULT_PER_PAGE = 100
@@ -218,6 +218,38 @@ class GitHubClient:
                 break
         return results
 
+    def list_check_runs_for_ref(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        *,
+        per_page: int = _DEFAULT_PER_PAGE,
+    ) -> list[CheckRunResult]:
+        """List check runs for a commit ref, walking pagination eagerly."""
+        if not ref.strip():
+            raise ValueError("ref must not be empty")
+        if not 1 <= per_page <= 100:
+            raise ValueError("per_page must be between 1 and 100")
+
+        results: list[CheckRunResult] = []
+        encoded_ref = _segment(ref)
+        for page in range(1, _MAX_PAGES + 1):
+            query = urlencode({"per_page": per_page, "page": page})
+            path = f"/repos/{_segment(owner)}/{_segment(repo)}/commits/{encoded_ref}/check-runs?{query}"
+            resp = self._request("GET", path)
+            page_data = resp.json()
+            if not isinstance(page_data, dict) or not isinstance(page_data.get("check_runs"), list):
+                raise GitHubError("unexpected check-runs payload shape")
+            check_runs = page_data["check_runs"]
+            for item in check_runs:
+                if not isinstance(item, dict):
+                    raise GitHubError("unexpected check-runs payload shape")
+                results.append(_check_run_from_payload(item, default_head_sha=ref))
+            if len(check_runs) < per_page:
+                break
+        return results
+
     # ── Internal ──────────────────────────────────────────────────────
 
     def _request(
@@ -334,4 +366,14 @@ def _actions_job_from_payload(data: dict[str, Any]) -> ActionsJobResult:
         name=str(data.get("name", "")),
         conclusion=str(data.get("conclusion", "") or ""),
         html_url=str(data.get("html_url", "")),
+    )
+
+
+def _check_run_from_payload(data: dict[str, Any], *, default_head_sha: str) -> CheckRunResult:
+    return CheckRunResult(
+        name=str(data.get("name", "")),
+        status=str(data.get("status", "") or ""),
+        conclusion=str(data.get("conclusion", "") or ""),
+        html_url=str(data.get("html_url", "")),
+        head_sha=str(data.get("head_sha", "") or default_head_sha),
     )

--- a/src/adapters/connectors/github/types.py
+++ b/src/adapters/connectors/github/types.py
@@ -54,3 +54,14 @@ class ActionsJobResult:
     name: str
     conclusion: str
     html_url: str
+
+
+@dataclass(frozen=True)
+class CheckRunResult:
+    """Result summary for one check run on a commit ref."""
+
+    name: str
+    status: str
+    conclusion: str
+    html_url: str
+    head_sha: str

--- a/src/app/jobs.py
+++ b/src/app/jobs.py
@@ -357,6 +357,7 @@ def _pr_event_from_payload(kind: EventType, meta: EventMeta, data: Mapping[str, 
             _file_change_from_payload(file_data, f"files_changed[{index}]")
             for index, file_data in enumerate(file_values)
         ),
+        head_sha=_require_str(data.get("head_sha", ""), "head_sha"),
     )
 
 

--- a/src/app/worker/factory.py
+++ b/src/app/worker/factory.py
@@ -52,6 +52,7 @@ def _build_github_tool_runtime(client: GitHubClient) -> RegisteredToolRuntime:
                     "github.pr.files",
                     "github.pr.diff",
                     "github.actions.run.jobs",
+                    "github.checks.runs_for_ref",
                 ),
                 WorkflowStage.OUTPUT: ("github.pr.comment.create_or_update",),
             }

--- a/src/core/contracts/events.py
+++ b/src/core/contracts/events.py
@@ -90,6 +90,7 @@ class PREvent:
     head_branch: str
     diff_url: str
     files_changed: tuple[FileChange, ...] = ()
+    head_sha: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/core/contracts/parsers.py
+++ b/src/core/contracts/parsers.py
@@ -117,6 +117,7 @@ def parse_github_pr_event(
         "head_branch": _get(pr, "head", "ref"),
         "diff_url": pr.get("diff_url", ""),
         "files_changed": files_changed,
+        "head_sha": _get(pr, "head", "sha"),
     }
 
     if event_type == EventType.PR_OPENED:

--- a/src/runtime/orchestrator/__init__.py
+++ b/src/runtime/orchestrator/__init__.py
@@ -9,11 +9,28 @@ from __future__ import annotations
 from .chat_workflow import ChatWorkflowOrchestrator
 from .ci_workflow import CIContextProvider, CIWorkflowDepth, CIWorkflowOrchestrator, CIWorkflowResult
 from .dispatcher import EventOrchestrator
+from .pr_aggregate import (
+    CheckRunSnapshot,
+    CheckRunStatus,
+    InMemoryPRAggregateStore,
+    PRAggregateState,
+    PRRevisionState,
+    PRRevisionStatus,
+    ReviewReadiness,
+    ReviewReadinessState,
+    ReviewRun,
+    ReviewRunTrigger,
+)
 from .pr_context import EventPRContextProvider, PRContextProvider
 from .pr_event_stubs import PRCommentWorkflowOrchestrator, PRReviewWorkflowOrchestrator
 from .pr_triage import PRWorkflowDepth, PRWorkflowTriage, RuleBasedPRWorkflowTriageClassifier
 from .pr_workflow import PRWorkflowOrchestrator, StubPRRuntimeValidator
-from .tool_context import ToolRuntimeCIContextProvider, ToolRuntimePRContextProvider
+from .tool_context import (
+    PRCheckSnapshotProvider,
+    ToolRuntimeCIContextProvider,
+    ToolRuntimePRCheckSnapshotProvider,
+    ToolRuntimePRContextProvider,
+)
 from .tool_output import ToolRuntimePRCommentPoster
 from .types import (
     PRBehaviourAnalyzer,
@@ -33,12 +50,19 @@ __all__ = [
     "CIWorkflowOrchestrator",
     "CIWorkflowResult",
     "ChatWorkflowOrchestrator",
+    "CheckRunSnapshot",
+    "CheckRunStatus",
     "EventOrchestrator",
     "EventPRContextProvider",
+    "InMemoryPRAggregateStore",
+    "PRAggregateState",
     "PRBehaviourAnalyzer",
+    "PRCheckSnapshotProvider",
     "PRCommentWorkflowOrchestrator",
     "PRContextProvider",
     "PRReviewWorkflowOrchestrator",
+    "PRRevisionState",
+    "PRRevisionStatus",
     "PRRuntimeValidator",
     "PRStrategyEngine",
     "PRTriageClassifier",
@@ -48,10 +72,15 @@ __all__ = [
     "PRWorkflowRenderer",
     "PRWorkflowResult",
     "PRWorkflowTriage",
+    "ReviewReadiness",
+    "ReviewReadinessState",
+    "ReviewRun",
+    "ReviewRunTrigger",
     "RuleBasedPRWorkflowTriageClassifier",
     "ShouldValidate",
     "StubPRRuntimeValidator",
     "ToolRuntimeCIContextProvider",
+    "ToolRuntimePRCheckSnapshotProvider",
     "ToolRuntimePRCommentPoster",
     "ToolRuntimePRContextProvider",
     "UnsupportedEventError",

--- a/src/runtime/orchestrator/pr_aggregate.py
+++ b/src/runtime/orchestrator/pr_aggregate.py
@@ -1,0 +1,297 @@
+"""PR aggregate state and current-head review readiness contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+
+from src.adapters.connectors.github import CheckRunResult
+from src.core.contracts import CICompleted, PREvent
+
+
+class PRRevisionStatus(StrEnum):
+    """Lifecycle status for a PR head revision tracked inside an aggregate."""
+
+    CURRENT = "current"
+    SUPERSEDED = "superseded"
+
+
+class CheckRunStatus(StrEnum):
+    """Normalized check/workflow execution status for current-head readiness."""
+
+    UNKNOWN = "unknown"
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    PENDING = "pending"
+    COMPLETED = "completed"
+
+
+class ReviewReadinessState(StrEnum):
+    """Whether qaestro can publish a final unified review for the current head."""
+
+    READY = "ready"
+    WAITING_FOR_CHECKS = "waiting_for_checks"
+    CHECKS_FAILED = "checks_failed"
+
+
+class ReviewRunTrigger(StrEnum):
+    """Origin of a review run request tracked in PR aggregate history."""
+
+    MANUAL = "manual"
+    AUTO = "auto"
+    CI_COMPLETED = "ci_completed"
+
+
+@dataclass(frozen=True)
+class CheckRunSnapshot:
+    """Current-head check/workflow snapshot used to gate final review publication."""
+
+    name: str
+    status: CheckRunStatus | str
+    conclusion: str | None
+    head_sha: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", _normalize_check_run_status(self.status))
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status is not CheckRunStatus.COMPLETED
+
+    @property
+    def is_failure(self) -> bool:
+        return self.status is CheckRunStatus.COMPLETED and (self.conclusion or "").lower() in {
+            "action_required",
+            "failure",
+            "startup_failure",
+            "timed_out",
+        }
+
+    @classmethod
+    def from_result(cls, result: CheckRunResult) -> CheckRunSnapshot:
+        return cls(
+            name=result.name,
+            status=result.status,
+            conclusion=result.conclusion or None,
+            head_sha=result.head_sha,
+        )
+
+
+@dataclass(frozen=True)
+class CIWorkflowRunRecord:
+    """CI workflow completion recorded against the commit sha it reported."""
+
+    event_id: str
+    workflow_name: str
+    conclusion: str
+    run_url: str
+    failed_jobs: tuple[str, ...]
+    commit_sha: str
+    is_current_head: bool
+
+    @classmethod
+    def from_event(cls, event: CICompleted, *, current_head_sha: str) -> CIWorkflowRunRecord:
+        return cls(
+            event_id=event.meta.event_id,
+            workflow_name=event.workflow_name,
+            conclusion=event.conclusion,
+            run_url=event.run_url,
+            failed_jobs=event.failed_jobs,
+            commit_sha=event.commit_sha,
+            is_current_head=event.commit_sha == current_head_sha,
+        )
+
+
+@dataclass(frozen=True)
+class PRRevisionState:
+    """State for one PR head commit.
+
+    Analysis and CI data from superseded revisions remains historical evidence.
+    Current verdict/readiness logic must use only the revision whose ``head_sha``
+    matches ``PRAggregateState.current_head_sha``.
+    """
+
+    head_sha: str
+    status: PRRevisionStatus
+    ci_runs: tuple[CIWorkflowRunRecord, ...] = ()
+
+    def record_ci_run(self, record: CIWorkflowRunRecord) -> PRRevisionState:
+        return replace(self, ci_runs=(*self.ci_runs, record))
+
+    def supersede(self) -> PRRevisionState:
+        if self.status is PRRevisionStatus.SUPERSEDED:
+            return self
+        return replace(self, status=PRRevisionStatus.SUPERSEDED)
+
+
+@dataclass(frozen=True)
+class ReviewRun:
+    """One requested/started review run for a PR revision."""
+
+    head_sha: str
+    trigger: ReviewRunTrigger
+    requested_by: str = ""
+
+
+@dataclass(frozen=True)
+class ReviewReadiness:
+    """Readiness verdict for final or interim review output."""
+
+    state: ReviewReadinessState
+    head_sha: str
+    blocking_checks: tuple[str, ...] = ()
+    summary: str = ""
+
+    @property
+    def can_publish_final_review(self) -> bool:
+        return self.state in {ReviewReadinessState.READY, ReviewReadinessState.CHECKS_FAILED}
+
+    @property
+    def can_publish_interim_response(self) -> bool:
+        return self.state is ReviewReadinessState.WAITING_FOR_CHECKS
+
+
+@dataclass(frozen=True)
+class PRAggregateState:
+    """PR-level state shared by PR, CI, and manual review-trigger events."""
+
+    repo_full_name: str
+    pr_number: int
+    title: str
+    current_head_sha: str
+    revisions: dict[str, PRRevisionState] = field(default_factory=dict)
+    event_ids: tuple[str, ...] = ()
+    review_runs: tuple[ReviewRun, ...] = ()
+
+    @classmethod
+    def from_pr_event(cls, event: PREvent) -> PRAggregateState:
+        head_sha = _head_sha_for(event)
+        return cls(
+            repo_full_name=event.repo_full_name,
+            pr_number=event.pr_number,
+            title=event.title,
+            current_head_sha=head_sha,
+            revisions={head_sha: PRRevisionState(head_sha=head_sha, status=PRRevisionStatus.CURRENT)},
+            event_ids=(event.meta.event_id,),
+        )
+
+    @property
+    def current_revision(self) -> PRRevisionState:
+        return self.revisions[self.current_head_sha]
+
+    def apply_pr_event(self, event: PREvent) -> PRAggregateState:
+        head_sha = _head_sha_for(event)
+        revisions = dict(self.revisions)
+        if head_sha != self.current_head_sha:
+            revisions = {
+                sha: revision.supersede() if sha == self.current_head_sha else revision
+                for sha, revision in revisions.items()
+            }
+        revisions[head_sha] = replace(
+            revisions.get(head_sha, PRRevisionState(head_sha=head_sha, status=PRRevisionStatus.CURRENT)),
+            status=PRRevisionStatus.CURRENT,
+        )
+        return replace(
+            self,
+            title=event.title or self.title,
+            current_head_sha=head_sha,
+            revisions=revisions,
+            event_ids=_append_unique(self.event_ids, event.meta.event_id),
+        )
+
+    def record_ci_completed(self, event: CICompleted) -> PRAggregateState:
+        record = CIWorkflowRunRecord.from_event(event, current_head_sha=self.current_head_sha)
+        revisions = dict(self.revisions)
+        if event.commit_sha not in revisions:
+            revisions[event.commit_sha] = PRRevisionState(
+                head_sha=event.commit_sha,
+                status=PRRevisionStatus.SUPERSEDED,
+            )
+        revisions[event.commit_sha] = revisions[event.commit_sha].record_ci_run(record)
+        return replace(self, revisions=revisions, event_ids=_append_unique(self.event_ids, event.meta.event_id))
+
+    def start_review_run(self, *, trigger: ReviewRunTrigger, requested_by: str = "") -> PRAggregateState:
+        run = ReviewRun(head_sha=self.current_head_sha, trigger=trigger, requested_by=requested_by)
+        return replace(self, review_runs=(*self.review_runs, run))
+
+    def evaluate_readiness(self, *, current_check_snapshot: tuple[CheckRunSnapshot, ...]) -> ReviewReadiness:
+        current_checks = tuple(check for check in current_check_snapshot if check.head_sha == self.current_head_sha)
+        blocking = tuple(check.name for check in current_checks if check.is_pending)
+        if blocking:
+            check_list = ", ".join(blocking)
+            return ReviewReadiness(
+                state=ReviewReadinessState.WAITING_FOR_CHECKS,
+                head_sha=self.current_head_sha,
+                blocking_checks=blocking,
+                summary=f"Waiting for current-head checks to finish: {check_list}.",
+            )
+        failed = tuple(check.name for check in current_checks if check.is_failure)
+        if failed:
+            check_list = ", ".join(failed)
+            return ReviewReadiness(
+                state=ReviewReadinessState.CHECKS_FAILED,
+                head_sha=self.current_head_sha,
+                blocking_checks=failed,
+                summary=f"Current-head checks completed with failures: {check_list}.",
+            )
+        return ReviewReadiness(
+            state=ReviewReadinessState.READY,
+            head_sha=self.current_head_sha,
+            summary="Current-head checks are complete; final review can be published.",
+        )
+
+
+class InMemoryPRAggregateStore:
+    """Minimal in-memory store for deterministic tests and future worker wiring."""
+
+    def __init__(self) -> None:
+        self._aggregates: dict[tuple[str, int], PRAggregateState] = {}
+
+    def get(self, repo_full_name: str, pr_number: int) -> PRAggregateState | None:
+        return self._aggregates.get((repo_full_name, pr_number))
+
+    def save(self, aggregate: PRAggregateState) -> PRAggregateState:
+        self._aggregates[(aggregate.repo_full_name, aggregate.pr_number)] = aggregate
+        return aggregate
+
+    def apply_pr_event(self, event: PREvent) -> PRAggregateState:
+        existing = self.get(event.repo_full_name, event.pr_number)
+        aggregate = PRAggregateState.from_pr_event(event) if existing is None else existing.apply_pr_event(event)
+        return self.save(aggregate)
+
+    def record_ci_completed(self, event: CICompleted) -> PRAggregateState | None:
+        if event.pr_number is None:
+            return None
+        existing = self.get(event.repo_full_name, event.pr_number)
+        if existing is None:
+            return None
+        return self.save(existing.record_ci_completed(event))
+
+
+def _head_sha_for(event: PREvent) -> str:
+    head_sha = event.head_sha.strip()
+    if not head_sha:
+        raise ValueError("PR event head_sha is required for aggregate revision state")
+    return head_sha
+
+
+def _normalize_check_run_status(status: CheckRunStatus | str) -> CheckRunStatus:
+    if isinstance(status, CheckRunStatus):
+        return status
+    normalized = status.strip().lower()
+    aliases = {
+        "requested": CheckRunStatus.PENDING,
+        "waiting": CheckRunStatus.PENDING,
+    }
+    if normalized in aliases:
+        return aliases[normalized]
+    try:
+        return CheckRunStatus(normalized)
+    except ValueError:
+        return CheckRunStatus.UNKNOWN
+
+
+def _append_unique(values: tuple[str, ...], value: str) -> tuple[str, ...]:
+    if value in values:
+        return values
+    return (*values, value)

--- a/src/runtime/orchestrator/tool_context.py
+++ b/src/runtime/orchestrator/tool_context.py
@@ -3,13 +3,42 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import overload
+from typing import Protocol, overload
 
-from src.adapters.connectors.github import ActionsJobResult, FileDiff, PRMeta
+from src.adapters.connectors.github import ActionsJobResult, CheckRunResult, FileDiff, PRMeta
 from src.core.analyzer import PRAnalysisContext, PRFileDiff, PRFileStatus
 from src.core.contracts import CICompleted, PREvent
 from src.runtime.stages import WorkflowStage
 from src.runtime.tools import ToolCall, ToolResult, ToolRuntime
+
+from .pr_aggregate import CheckRunSnapshot
+
+
+class PRCheckSnapshotProvider(Protocol):
+    """Loads current-head check snapshots for review readiness decisions."""
+
+    def load(self, *, repo_full_name: str, head_sha: str, correlation_id: str) -> tuple[CheckRunSnapshot, ...]: ...
+
+
+class ToolRuntimePRCheckSnapshotProvider:
+    """Collect current-head check runs through stage-approved GitHub read tools."""
+
+    def __init__(self, runtime: ToolRuntime) -> None:
+        self._runtime = runtime
+
+    def load(self, *, repo_full_name: str, head_sha: str, correlation_id: str) -> tuple[CheckRunSnapshot, ...]:
+        result = self._runtime.execute(
+            ToolCall(
+                stage=WorkflowStage.CONTEXT,
+                name="github.checks.runs_for_ref",
+                input={"repo_full_name": repo_full_name, "ref": head_sha},
+                correlation_id=correlation_id,
+            )
+        )
+        if not result.ok:
+            raise RuntimeError(result.error or "github.checks.runs_for_ref failed")
+        checks = _expect_check_run_tuple(result.output)
+        return tuple(CheckRunSnapshot.from_result(check) for check in checks)
 
 
 class ToolRuntimePRContextProvider:
@@ -121,6 +150,12 @@ def _expect_file_tuple(output: object) -> tuple[FileDiff, ...]:
 def _expect_actions_job_tuple(output: object) -> tuple[ActionsJobResult, ...]:
     if not isinstance(output, tuple) or not all(isinstance(item, ActionsJobResult) for item in output):
         raise TypeError("github.actions.run.jobs returned unexpected output type")
+    return output
+
+
+def _expect_check_run_tuple(output: object) -> tuple[CheckRunResult, ...]:
+    if not isinstance(output, tuple) or not all(isinstance(item, CheckRunResult) for item in output):
+        raise TypeError("github.checks.runs_for_ref returned unexpected output type")
     return output
 
 

--- a/src/runtime/tools/github.py
+++ b/src/runtime/tools/github.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from src.adapters.connectors.github import ActionsJobResult, CommentResult, FileDiff, PRMeta
+from src.adapters.connectors.github import ActionsJobResult, CheckRunResult, CommentResult, FileDiff, PRMeta
 
 from . import ToolCall, ToolCapability, ToolDefinition
 
@@ -19,6 +19,8 @@ class GitHubPRToolClient(Protocol):
     def get_pull_request_diff(self, owner: str, repo: str, number: int) -> str: ...
 
     def list_workflow_run_jobs(self, owner: str, repo: str, run_id: int) -> list[ActionsJobResult]: ...
+
+    def list_check_runs_for_ref(self, owner: str, repo: str, ref: str) -> list[CheckRunResult]: ...
 
     def create_issue_comment(self, owner: str, repo: str, number: int, body: str) -> CommentResult: ...
 
@@ -49,6 +51,11 @@ def build_github_pr_tools(client: GitHubPRToolClient) -> tuple[ToolDefinition, .
             name="github.actions.run.jobs",
             capabilities=(ToolCapability.READ,),
             handler=lambda call: _list_workflow_run_jobs(client, call),
+        ),
+        ToolDefinition(
+            name="github.checks.runs_for_ref",
+            capabilities=(ToolCapability.READ,),
+            handler=lambda call: _list_check_runs_for_ref(client, call),
         ),
         ToolDefinition(
             name="github.pr.comment.create_or_update",
@@ -85,6 +92,14 @@ def _list_workflow_run_jobs(client: GitHubPRToolClient, call: ToolCall) -> tuple
     if run_id <= 0:
         raise ValueError("run_id must be greater than 0")
     return tuple(client.list_workflow_run_jobs(owner, repo, run_id))
+
+
+def _list_check_runs_for_ref(client: GitHubPRToolClient, call: ToolCall) -> tuple[CheckRunResult, ...]:
+    owner, repo = _repo_input(call)
+    ref = str(call.input.get("ref", "")).strip()
+    if not ref:
+        raise ValueError("ref is required")
+    return tuple(client.list_check_runs_for_ref(owner, repo, ref))
 
 
 def _create_or_update_comment(client: GitHubPRToolClient, call: ToolCall) -> CommentResult:

--- a/tests/adapters/connectors/test_github_client.py
+++ b/tests/adapters/connectors/test_github_client.py
@@ -292,6 +292,89 @@ def test_list_workflow_run_jobs_validates_run_id(client):
         client.list_workflow_run_jobs(OWNER, REPO, 0)
 
 
+# ── list_check_runs_for_ref ───────────────────────────────────────────────
+
+
+def test_list_check_runs_for_ref_returns_check_run_results(client, transport):
+    check_payload = {
+        "check_runs": [
+            {
+                "name": "Tests",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "https://github.com/octocat/hello-world/runs/11",
+                "head_sha": "abc123",
+            },
+            {
+                "name": "Lint",
+                "status": "in_progress",
+                "conclusion": None,
+                "html_url": "https://github.com/octocat/hello-world/runs/12",
+                "head_sha": "abc123",
+            },
+        ]
+    }
+    transport.route(
+        "GET",
+        f"https://api.github.com/repos/{OWNER}/{REPO}/commits/abc123/check-runs?per_page=100&page=1",
+        FakeResponse(status=200, body=json.dumps(check_payload).encode()),
+    )
+
+    checks = client.list_check_runs_for_ref(OWNER, REPO, "abc123")
+
+    assert [check.name for check in checks] == ["Tests", "Lint"]
+    assert [check.status for check in checks] == ["completed", "in_progress"]
+    assert [check.conclusion for check in checks] == ["success", ""]
+    assert [check.head_sha for check in checks] == ["abc123", "abc123"]
+
+
+def test_list_check_runs_for_ref_handles_pagination(client, transport):
+    page1 = {
+        "check_runs": [
+            {
+                "name": f"check-{i}",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": f"https://example.com/{i}",
+                "head_sha": "abc123",
+            }
+            for i in range(100)
+        ]
+    }
+    page2 = {
+        "check_runs": [
+            {
+                "name": "last",
+                "status": "queued",
+                "conclusion": None,
+                "html_url": "https://example.com/last",
+                "head_sha": "abc123",
+            }
+        ]
+    }
+    transport.route(
+        "GET",
+        f"https://api.github.com/repos/{OWNER}/{REPO}/commits/abc123/check-runs?per_page=100&page=1",
+        FakeResponse(status=200, body=json.dumps(page1).encode()),
+    )
+    transport.route(
+        "GET",
+        f"https://api.github.com/repos/{OWNER}/{REPO}/commits/abc123/check-runs?per_page=100&page=2",
+        FakeResponse(status=200, body=json.dumps(page2).encode()),
+    )
+
+    checks = client.list_check_runs_for_ref(OWNER, REPO, "abc123")
+
+    assert len(checks) == 101
+    assert checks[-1].name == "last"
+    assert checks[-1].status == "queued"
+
+
+def test_list_check_runs_for_ref_validates_ref(client):
+    with pytest.raises(ValueError, match="ref"):
+        client.list_check_runs_for_ref(OWNER, REPO, "")
+
+
 # ── create_issue_comment ─────────────────────────────────────────────────
 
 

--- a/tests/app/worker/test_redis_queue.py
+++ b/tests/app/worker/test_redis_queue.py
@@ -103,6 +103,7 @@ def _pr_opened() -> PROpened:
         head_branch="feat/redis-queue",
         diff_url="https://github.com/Kimcheolhui/qaestro/pull/34.diff",
         files_changed=(FileChange(path="src/app/jobs.py", status="modified", additions=20, deletions=2),),
+        head_sha="abc123",
     )
 
 
@@ -121,6 +122,7 @@ def _events() -> list[Event]:
             head_branch=opened.head_branch,
             diff_url=opened.diff_url,
             files_changed=opened.files_changed,
+            head_sha="def456",
         ),
         PRCommented(
             meta=_meta(EventType.PR_COMMENTED),

--- a/tests/replay/test_replay_github.py
+++ b/tests/replay/test_replay_github.py
@@ -44,6 +44,7 @@ class TestGitHubPRReplay:
         assert event.author == "jane-dev"
         assert event.base_branch == "main"
         assert event.head_branch == "feat/auth-middleware"
+        assert event.head_sha == "def789abc123456"
         assert len(event.files_changed) == 3
         assert event.files_changed[0].path == "src/middleware/auth_middleware.py"
         assert event.files_changed[0].status == "added"

--- a/tests/runtime/test_github_tools.py
+++ b/tests/runtime/test_github_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.adapters.connectors.github import ActionsJobResult, CommentResult, FileDiff, PRMeta
+from src.adapters.connectors.github import ActionsJobResult, CheckRunResult, CommentResult, FileDiff, PRMeta
 from src.adapters.renderers import PRCommentPayload
 from src.runtime.orchestrator import ToolRuntimePRCommentPoster
 from src.runtime.stages import WorkflowStage
@@ -62,6 +62,25 @@ class RecordingGitHubClient:
             ),
         ]
 
+    def list_check_runs_for_ref(self, owner: str, repo: str, ref: str) -> list[CheckRunResult]:
+        self.calls.append(("check_runs", owner, repo, ref))
+        return [
+            CheckRunResult(
+                name="Tests",
+                status="completed",
+                conclusion="success",
+                html_url="https://github.com/octocat/hello-world/runs/11",
+                head_sha=ref,
+            ),
+            CheckRunResult(
+                name="Lint",
+                status="in_progress",
+                conclusion="",
+                html_url="https://github.com/octocat/hello-world/runs/12",
+                head_sha=ref,
+            ),
+        ]
+
     def create_issue_comment(self, owner: str, repo: str, number: int, body: str) -> CommentResult:
         self.calls.append(("comment", owner, repo, number, body))
         return CommentResult(
@@ -84,7 +103,12 @@ def _runtime(client: RecordingGitHubClient) -> RegisteredToolRuntime:
         tools=build_github_pr_tools(client),
         policy=StageToolPolicy(
             {
-                WorkflowStage.CONTEXT: ("github.pr.view", "github.pr.files", "github.pr.diff"),
+                WorkflowStage.CONTEXT: (
+                    "github.pr.view",
+                    "github.pr.files",
+                    "github.pr.diff",
+                    "github.checks.runs_for_ref",
+                ),
                 WorkflowStage.OUTPUT: ("github.pr.comment.create_or_update",),
             }
         ),
@@ -177,6 +201,62 @@ def test_github_actions_jobs_tool_returns_failed_job_names_through_context_stage
         ),
     )
     assert client.calls == [("actions_jobs", "octocat", "hello-world", 99)]
+
+
+def test_github_check_runs_tool_returns_current_ref_snapshot_through_context_stage() -> None:
+    client = RecordingGitHubClient()
+    runtime = RegisteredToolRuntime(
+        tools=build_github_pr_tools(client),
+        policy=StageToolPolicy({WorkflowStage.CONTEXT: ("github.checks.runs_for_ref",)}),
+    )
+
+    result = runtime.execute(
+        ToolCall(
+            stage=WorkflowStage.CONTEXT,
+            name="github.checks.runs_for_ref",
+            input={"repo_full_name": "octocat/hello-world", "ref": "abc123"},
+            correlation_id="corr-checks",
+        )
+    )
+
+    assert result.ok is True
+    assert result.output == (
+        CheckRunResult(
+            name="Tests",
+            status="completed",
+            conclusion="success",
+            html_url="https://github.com/octocat/hello-world/runs/11",
+            head_sha="abc123",
+        ),
+        CheckRunResult(
+            name="Lint",
+            status="in_progress",
+            conclusion="",
+            html_url="https://github.com/octocat/hello-world/runs/12",
+            head_sha="abc123",
+        ),
+    )
+    assert client.calls == [("check_runs", "octocat", "hello-world", "abc123")]
+
+
+def test_github_check_runs_tool_requires_ref() -> None:
+    client = RecordingGitHubClient()
+    runtime = RegisteredToolRuntime(
+        tools=build_github_pr_tools(client),
+        policy=StageToolPolicy({WorkflowStage.CONTEXT: ("github.checks.runs_for_ref",)}),
+    )
+
+    result = runtime.execute(
+        ToolCall(
+            stage=WorkflowStage.CONTEXT,
+            name="github.checks.runs_for_ref",
+            input={"repo_full_name": "octocat/hello-world", "ref": ""},
+            correlation_id="corr-checks",
+        )
+    )
+
+    assert result.ok is False
+    assert "ref is required" in result.error
 
 
 def test_github_actions_jobs_tool_requires_run_id() -> None:

--- a/tests/runtime/test_pr_aggregate.py
+++ b/tests/runtime/test_pr_aggregate.py
@@ -1,0 +1,170 @@
+"""Tests for PR aggregate state and current-head review readiness."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from src.core.contracts import CICompleted, EventMeta, EventSource, EventType, FileChange, PROpened, PRUpdated
+from src.runtime.orchestrator import (
+    CheckRunSnapshot,
+    CheckRunStatus,
+    PRAggregateState,
+    PRRevisionStatus,
+    ReviewReadinessState,
+    ReviewRunTrigger,
+)
+
+
+def _meta(event_id: str, event_type: EventType) -> EventMeta:
+    return EventMeta(
+        event_id=event_id,
+        event_type=event_type,
+        correlation_id=f"corr-{event_id}",
+        timestamp=datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
+        source=EventSource.GITHUB,
+    )
+
+
+def _pr_event(*, event_id: str = "pr-open", head_sha: str = "sha-1") -> PROpened:
+    return PROpened(
+        meta=_meta(event_id, EventType.PR_OPENED),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=54,
+        title="feat: aggregate readiness",
+        body="Wire PR aggregate state.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/pr-aggregate",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/54.diff",
+        head_sha=head_sha,
+        files_changed=(FileChange(path="src/runtime/orchestrator/pr_aggregate.py", status="added", additions=80),),
+    )
+
+
+def _pr_update(*, event_id: str = "pr-update", head_sha: str = "sha-2") -> PRUpdated:
+    return PRUpdated(
+        meta=_meta(event_id, EventType.PR_UPDATED),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=54,
+        title="feat: aggregate readiness",
+        body="Wire PR aggregate state.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/pr-aggregate",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/54.diff",
+        head_sha=head_sha,
+        files_changed=(FileChange(path="src/runtime/orchestrator/pr_aggregate.py", status="modified", additions=20),),
+    )
+
+
+def _ci_event(*, event_id: str, commit_sha: str, conclusion: str, workflow_name: str = "Tests") -> CICompleted:
+    return CICompleted(
+        meta=_meta(event_id, EventType.CI_COMPLETED),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=54,
+        commit_sha=commit_sha,
+        workflow_name=workflow_name,
+        conclusion=conclusion,
+        run_url=f"https://github.com/Kimcheolhui/qaestro/actions/runs/{event_id}",
+        failed_jobs=("pytest",) if conclusion == "failure" else (),
+        run_id=123,
+    )
+
+
+def test_pr_event_starts_aggregate_with_current_revision() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-1"))
+
+    assert aggregate.repo_full_name == "Kimcheolhui/qaestro"
+    assert aggregate.pr_number == 54
+    assert aggregate.current_head_sha == "sha-1"
+    assert aggregate.current_revision.head_sha == "sha-1"
+    assert aggregate.current_revision.status is PRRevisionStatus.CURRENT
+    assert aggregate.event_ids == ("pr-open",)
+
+
+def test_new_pr_head_supersedes_previous_revision_but_keeps_historical_evidence() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-1"))
+    aggregate = aggregate.record_ci_completed(_ci_event(event_id="ci-old", commit_sha="sha-1", conclusion="failure"))
+
+    aggregate = aggregate.apply_pr_event(_pr_update(head_sha="sha-2"))
+
+    assert aggregate.current_head_sha == "sha-2"
+    assert aggregate.revisions["sha-1"].status is PRRevisionStatus.SUPERSEDED
+    assert aggregate.revisions["sha-1"].ci_runs[0].conclusion == "failure"
+    assert aggregate.current_revision.head_sha == "sha-2"
+    assert aggregate.current_revision.ci_runs == ()
+    assert aggregate.current_revision.status is PRRevisionStatus.CURRENT
+
+
+def test_stale_ci_result_is_recorded_without_affecting_current_readiness() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-1"))
+    aggregate = aggregate.apply_pr_event(_pr_update(head_sha="sha-2"))
+
+    aggregate = aggregate.record_ci_completed(_ci_event(event_id="ci-stale", commit_sha="sha-1", conclusion="failure"))
+    readiness = aggregate.evaluate_readiness(
+        current_check_snapshot=(
+            CheckRunSnapshot(name="Tests", status=CheckRunStatus.COMPLETED, conclusion="success", head_sha="sha-2"),
+        )
+    )
+
+    assert aggregate.revisions["sha-1"].ci_runs[0].is_current_head is False
+    assert readiness.state is ReviewReadinessState.READY
+    assert readiness.head_sha == "sha-2"
+    assert readiness.blocking_checks == ()
+
+
+def test_failed_current_head_check_is_ready_for_final_review_with_failure_state() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-2"))
+
+    readiness = aggregate.evaluate_readiness(
+        current_check_snapshot=(
+            CheckRunSnapshot(name="Tests", status=CheckRunStatus.COMPLETED, conclusion="failure", head_sha="sha-2"),
+        )
+    )
+
+    assert readiness.state is ReviewReadinessState.CHECKS_FAILED
+    assert readiness.can_publish_final_review is True
+    assert readiness.blocking_checks == ("Tests",)
+
+
+def test_requested_or_unknown_check_status_is_treated_as_pending_not_crashing() -> None:
+    requested = CheckRunSnapshot(name="Security", status="requested", conclusion=None, head_sha="sha-2")
+    unknown = CheckRunSnapshot(name="External", status="custom_pending", conclusion=None, head_sha="sha-2")
+
+    assert requested.status is CheckRunStatus.PENDING
+    assert requested.is_pending is True
+    assert unknown.status is CheckRunStatus.UNKNOWN
+    assert unknown.is_pending is True
+
+
+def test_pending_current_head_check_blocks_final_review_readiness() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-2"))
+
+    readiness = aggregate.evaluate_readiness(
+        current_check_snapshot=(
+            CheckRunSnapshot(name="Lint", status=CheckRunStatus.COMPLETED, conclusion="success", head_sha="sha-2"),
+            CheckRunSnapshot(name="Tests", status=CheckRunStatus.IN_PROGRESS, conclusion=None, head_sha="sha-2"),
+        )
+    )
+
+    assert readiness.state is ReviewReadinessState.WAITING_FOR_CHECKS
+    assert readiness.can_publish_final_review is False
+    assert readiness.blocking_checks == ("Tests",)
+    assert "Tests" in readiness.summary
+
+
+def test_manual_trigger_records_review_run_and_allows_interim_response() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-2"))
+    aggregate = aggregate.start_review_run(trigger=ReviewRunTrigger.MANUAL, requested_by="Kimcheolhui")
+
+    readiness = aggregate.evaluate_readiness(
+        current_check_snapshot=(
+            CheckRunSnapshot(name="Tests", status=CheckRunStatus.QUEUED, conclusion=None, head_sha="sha-2"),
+        )
+    )
+
+    assert aggregate.review_runs[-1].trigger is ReviewRunTrigger.MANUAL
+    assert aggregate.review_runs[-1].head_sha == "sha-2"
+    assert readiness.state is ReviewReadinessState.WAITING_FOR_CHECKS
+    assert readiness.can_publish_interim_response is True
+    assert readiness.can_publish_final_review is False

--- a/tests/runtime/test_tool_pr_adapters.py
+++ b/tests/runtime/test_tool_pr_adapters.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from src.adapters.connectors.github import CommentResult, FileDiff, PRMeta
+from src.adapters.connectors.github import CheckRunResult, CommentResult, FileDiff, PRMeta
 from src.adapters.renderers import PRCommentPayload
 from src.core.contracts import EventMeta, EventSource, EventType, PROpened
-from src.runtime.orchestrator import ToolRuntimePRCommentPoster, ToolRuntimePRContextProvider
+from src.runtime.orchestrator import (
+    CheckRunStatus,
+    ToolRuntimePRCheckSnapshotProvider,
+    ToolRuntimePRCommentPoster,
+    ToolRuntimePRContextProvider,
+)
 from src.runtime.stages import WorkflowStage
 from src.runtime.tools import ToolAuditEntry, ToolCall, ToolResult
 
@@ -38,6 +43,22 @@ class RecordingRuntime:
                 ),
             ),
             "github.pr.diff": "diff --git a/src/runtime/tools/__init__.py b/src/runtime/tools/__init__.py",
+            "github.checks.runs_for_ref": (
+                CheckRunResult(
+                    name="Tests",
+                    status="completed",
+                    conclusion="success",
+                    html_url="https://github.com/octocat/hello-world/runs/1",
+                    head_sha="abc123",
+                ),
+                CheckRunResult(
+                    name="Lint",
+                    status="in_progress",
+                    conclusion="",
+                    html_url="https://github.com/octocat/hello-world/runs/2",
+                    head_sha="abc123",
+                ),
+            ),
             "github.pr.comment.create_or_update": CommentResult(
                 id=9876,
                 html_url="https://github.com/octocat/hello-world/pull/77#issuecomment-9876",
@@ -86,6 +107,29 @@ def test_tool_runtime_pr_context_provider_collects_context_via_context_stage_too
         (WorkflowStage.CONTEXT, "github.pr.view", "corr-tools"),
         (WorkflowStage.CONTEXT, "github.pr.files", "corr-tools"),
         (WorkflowStage.CONTEXT, "github.pr.diff", "corr-tools"),
+    ]
+
+
+def test_tool_runtime_check_snapshot_provider_collects_current_head_checks() -> None:
+    runtime = RecordingRuntime()
+
+    checks = ToolRuntimePRCheckSnapshotProvider(runtime).load(
+        repo_full_name="octocat/hello-world",
+        head_sha="abc123",
+        correlation_id="corr-checks",
+    )
+
+    assert [(check.name, check.status, check.conclusion, check.head_sha) for check in checks] == [
+        ("Tests", CheckRunStatus.COMPLETED, "success", "abc123"),
+        ("Lint", CheckRunStatus.IN_PROGRESS, None, "abc123"),
+    ]
+    assert [(call.stage, call.name, call.input, call.correlation_id) for call in runtime.calls] == [
+        (
+            WorkflowStage.CONTEXT,
+            "github.checks.runs_for_ref",
+            {"repo_full_name": "octocat/hello-world", "ref": "abc123"},
+            "corr-checks",
+        )
     ]
 
 


### PR DESCRIPTION
## Summary

Step 4 needs PR events, CI events, and manual `@qaestro review` triggers to converge on one PR-level state instead of being judged as isolated webhook events. This PR introduces that current-head lifecycle contract: PR aggregate state owns the PR-level timeline, revision state is keyed by `head_sha`, and review readiness is decided from the current head's check snapshot.

The important boundary is that stale evidence is preserved but not promoted into the current verdict. CI from an older head remains available as historical evidence on a superseded revision; final readiness only considers the current `head_sha`.

## Review focus

- Check whether `head_sha` is preserved across every PR event boundary that matters for durable workers: GitHub parser → normalized event → Redis/job serialization → aggregate state.
- Check whether check-run reads stay behind the stage-approved `ToolRuntime` boundary via `github.checks.runs_for_ref` rather than leaking raw GitHub client calls into orchestration logic.
- Check the readiness semantics: pending/queued/in-progress/requested/waiting/unknown statuses should block final review, while completed failures should allow a final review with a failed-check state.
- Check whether the aggregate contracts are sufficient inputs for #49~#51 without prematurely implementing renderer/inline review output in this PR.

## Design notes

`PRAggregateState` is intentionally PR-scoped, while `PRRevisionState` is head-scoped. That shape keeps long-lived PR context and review history in one place, but prevents analysis/CI results from a superseded commit from becoming the source of truth for the current verdict.

The check snapshot provider is ToolRuntime-backed even though this PR only introduces the contract-level readiness path. That keeps the same stage policy boundary as the previous CI job enrichment work: orchestration asks for approved context, and adapter-specific GitHub reads remain behind narrow tools.

Unknown check statuses are treated as pending rather than fatal. This is defensive against real GitHub or third-party check states that are not in qaestro's current enum but should not cause readiness evaluation to crash.

## Scope / follow-up

This PR does not publish final unified reviews, update managed PR comments, or create inline review comments. It establishes the aggregate/readiness state that #49, #50, and #51 can consume for strategy feedback, renderer output, and replay coverage.

Closes #54

## Verification

Local verification completed before opening the PR:

- Targeted affected pytest set passed.
- Full `uv run pytest -q` passed.
- `uv run mypy src tests` passed.
- `uv run ruff check src/ tests/` passed.
- `uv run ruff format --check src/ tests/` passed.
- `uv lock --check` passed.
- Independent second-pass review found no remaining blockers.

---
🤖 *Created by Hermes Agent*
