### PR TITLE
feat(renderers): surface CI feedback in PR report

### DIFF
--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from src.core.contracts import QAReport
+from src.core.contracts import CIFeedbackContext, CIHistoricalEvidence, CIObservation, QAReport
 
 if TYPE_CHECKING:
     from src.runtime.orchestrator.pr_triage import PRWorkflowTriage
@@ -33,9 +33,11 @@ class GitHubPRCommentRenderer:
         *,
         correlation_id: str,
         triage: PRWorkflowTriage | None = None,
+        ci_feedback: CIFeedbackContext | None = None,
     ) -> PRCommentPayload:
         if report.pr_number is None:
             raise ValueError("PR comment renderer requires report.pr_number")
+        ci_feedback = ci_feedback if ci_feedback is not None else report.ci_feedback
 
         body = "\n".join(
             [
@@ -52,6 +54,7 @@ class GitHubPRCommentRenderer:
                 "",
                 "### Diff Stats",
                 *_diff_stat_lines(report),
+                *_ci_feedback_section(ci_feedback),
                 "",
                 "### Impact Areas",
                 *_impact_lines(report),
@@ -129,6 +132,84 @@ def _status_counts(stats: dict[str, int]) -> list[tuple[str, int]]:
 
 def _status_label(key: str) -> str:
     return key.removeprefix("files_").replace("_", " ")
+
+
+def _ci_feedback_section(ci_feedback: CIFeedbackContext | None) -> list[str]:
+    """Render already-produced CI/check facts without making strategy decisions."""
+    if ci_feedback is None:
+        return []
+    lines = [
+        "",
+        "### CI / Check Feedback",
+        f"- Current head: {_inline_code_span(ci_feedback.current_head_sha)}",
+        f"- Readiness: **{_markdown_text(ci_feedback.readiness.value.replace('_', ' ').upper())}**",
+    ]
+    if ci_feedback.pending_checks:
+        lines.append("- Pending checks: " + ", ".join(_inline_code_span(check) for check in ci_feedback.pending_checks))
+    if ci_feedback.current_observations:
+        lines.append("- Current-head observations:")
+        lines.extend(f"  - {_ci_observation_line(observation)}" for observation in ci_feedback.current_observations)
+    else:
+        lines.append("- Current-head observations: none recorded.")
+    historical_lines = _historical_ci_lines(ci_feedback.historical_evidence)
+    if historical_lines:
+        lines.append("- Historical CI evidence from superseded heads:")
+        lines.extend(historical_lines)
+    return lines
+
+
+def _ci_observation_line(observation: CIObservation) -> str:
+    conclusion = _inline_code_span(observation.conclusion.strip().lower() or "unknown")
+    line = f"**{_markdown_text(observation.workflow_name)}** — {conclusion}"
+    if observation.failed_jobs:
+        line += "; failed jobs: " + ", ".join(_inline_code_span(job) for job in observation.failed_jobs)
+    links = _ci_observation_links(observation)
+    if links:
+        line += f" ({'; '.join(links)})"
+    return line
+
+
+def _ci_observation_links(observation: CIObservation) -> list[str]:
+    links: list[str] = []
+    if observation.run_url:
+        links.append(f"[run]({observation.run_url})")
+    if observation.logs_url:
+        links.append(f"[logs]({observation.logs_url})")
+    return links
+
+
+def _historical_ci_lines(evidence: tuple[CIHistoricalEvidence, ...]) -> list[str]:
+    lines: list[str] = []
+    for item in evidence:
+        if not item.observations:
+            continue
+        summary = "; ".join(_ci_observation_line(observation) for observation in item.observations)
+        lines.append(f"  - {_inline_code_span(item.head_sha)}: {summary}")
+    return lines
+
+
+def _inline_code_span(text: str) -> str:
+    """Return a Markdown inline-code span that can contain backticks safely."""
+    longest_run = _longest_backtick_run(text)
+    delimiter = "`" * (longest_run + 1)
+    if text.startswith("`") or text.endswith("`"):
+        return f"{delimiter} {text} {delimiter}"
+    return f"{delimiter}{text}{delimiter}"
+
+
+def _longest_backtick_run(text: str) -> int:
+    longest = current = 0
+    for char in text:
+        if char == "`":
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _markdown_text(text: str) -> str:
+    return text.replace("[", "\\[").replace("*", "\\*").replace("_", "\\_")
 
 
 def _impact_lines(report: QAReport) -> list[str]:

--- a/src/core/contracts/domain.py
+++ b/src/core/contracts/domain.py
@@ -211,3 +211,4 @@ class QAReport:
     strategy: StrategyResult
     validations: tuple[ValidationResult, ...]
     summary_markdown: str
+    ci_feedback: CIFeedbackContext | None = None

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -95,6 +95,7 @@ class PRWorkflowOrchestrator:
         impact = self._analyzer.analyze(context)
 
         strategy: StrategyResult
+        ci_feedback: CIFeedbackContext | None = None
         if triage.runs_strategy:
             stages.append(WorkflowStage.STRATEGY)
             ci_feedback = self._ci_feedback_provider(event) if self._ci_feedback_provider is not None else None
@@ -125,6 +126,7 @@ class PRWorkflowOrchestrator:
             strategy=strategy,
             validations=validations,
             summary_markdown=impact.summary,
+            ci_feedback=ci_feedback,
         )
         stage_order = (*stages, WorkflowStage.RENDERER)
         draft = PRWorkflowDraft(event=event, report=report, triage=triage, stage_order=stage_order)
@@ -145,7 +147,12 @@ class _DefaultDraftRenderer:
         self._renderer = GitHubPRCommentRenderer()
 
     def render(self, draft: PRWorkflowDraft) -> PRCommentPayload:
-        return self._renderer.render(draft.report, correlation_id=draft.correlation_id, triage=draft.triage)
+        return self._renderer.render(
+            draft.report,
+            correlation_id=draft.correlation_id,
+            triage=draft.triage,
+            ci_feedback=draft.report.ci_feedback,
+        )
 
 
 class StubPRRuntimeValidator:

--- a/tests/adapters/renderers/test_pr_comment.py
+++ b/tests/adapters/renderers/test_pr_comment.py
@@ -6,6 +6,10 @@ from src.adapters.renderers import GitHubPRCommentRenderer, PRCommentPayload
 from src.core.contracts import (
     ActionType,
     BehaviourImpact,
+    CIFeedbackContext,
+    CIHistoricalEvidence,
+    CIObservation,
+    CIReadinessState,
     ImpactArea,
     QAReport,
     RiskLevel,
@@ -151,3 +155,97 @@ def test_github_pr_comment_renderer_lists_triaged_execution_stages_precisely() -
     assert "Overall risk: **MEDIUM**" in payload.body
     assert "Triaged analysis/validation stages: `analyzer, strategy, validator`" in payload.body
     assert "Allowed stages after triage" not in payload.body
+
+
+def test_github_pr_comment_renderer_surfaces_ci_feedback_as_distinct_section() -> None:
+    report = _qa_report()
+    ci_feedback = CIFeedbackContext(
+        current_head_sha="abc123",
+        readiness=CIReadinessState.CHECKS_FAILED,
+        current_observations=(
+            CIObservation(
+                workflow_name="Qaestro Smoke CI",
+                conclusion="failure",
+                run_url="https://github.com/Kimcheolhui/qaestro/actions/runs/100",
+                logs_url="https://github.com/Kimcheolhui/qaestro/actions/runs/100/job/200",
+                failed_jobs=("qaestro-smoke",),
+                commit_sha="abc123",
+            ),
+            CIObservation(
+                workflow_name="GitGuardian Security Checks",
+                conclusion="success",
+                run_url="https://dashboard.gitguardian.com/checks/1",
+                commit_sha="abc123",
+            ),
+        ),
+        historical_evidence=(
+            CIHistoricalEvidence(
+                head_sha="old123",
+                observations=(
+                    CIObservation(
+                        workflow_name="Tests",
+                        conclusion="failure",
+                        run_url="https://github.com/Kimcheolhui/qaestro/actions/runs/99",
+                        failed_jobs=("pytest",),
+                        commit_sha="old123",
+                    ),
+                ),
+            ),
+        ),
+        pending_checks=("Type Check (Mypy)",),
+    )
+
+    payload = GitHubPRCommentRenderer().render(
+        report,
+        correlation_id="corr-ci-feedback",
+        ci_feedback=ci_feedback,
+    )
+
+    assert "### CI / Check Feedback" in payload.body
+    assert "Current head: `abc123`" in payload.body
+    assert "Readiness: **CHECKS FAILED**" in payload.body
+    assert "Qaestro Smoke CI" in payload.body
+    assert "failure" in payload.body
+    assert "failed jobs: `qaestro-smoke`" in payload.body
+    assert "[run](https://github.com/Kimcheolhui/qaestro/actions/runs/100)" in payload.body
+    assert "[logs](https://github.com/Kimcheolhui/qaestro/actions/runs/100/job/200)" in payload.body
+    assert "GitGuardian Security Checks" in payload.body
+    assert "Pending checks: `Type Check (Mypy)`" in payload.body
+    assert "Historical CI evidence from superseded heads" in payload.body
+    assert "old123" in payload.body
+
+
+def test_github_pr_comment_renderer_omits_ci_feedback_section_when_absent() -> None:
+    payload = GitHubPRCommentRenderer().render(_qa_report(), correlation_id="corr-no-ci")
+
+    assert "### CI / Check Feedback" not in payload.body
+
+
+def test_github_pr_comment_renderer_escapes_ci_feedback_markdown_text() -> None:
+    ci_feedback = CIFeedbackContext(
+        current_head_sha="sha`with`tick",
+        readiness=CIReadinessState.CHECKS_FAILED,
+        current_observations=(
+            CIObservation(
+                workflow_name="CI [spoof](https://example.invalid)",
+                conclusion="failure",
+                run_url="https://github.com/Kimcheolhui/qaestro/actions/runs/100",
+                failed_jobs=("job `with` tick", "job [spoof](https://example.invalid)"),
+                commit_sha="sha`with`tick",
+            ),
+        ),
+        pending_checks=("pending `quoted`", "multi `` ticks", "`edge`"),
+    )
+
+    payload = GitHubPRCommentRenderer().render(
+        _qa_report(),
+        correlation_id="corr-ci-escaping",
+        ci_feedback=ci_feedback,
+    )
+
+    assert "Current head: ``sha`with`tick``" in payload.body
+    assert "**CI \\[spoof](https://example.invalid)**" in payload.body
+    assert "``job `with` tick``" in payload.body
+    assert "`job [spoof](https://example.invalid)`" in payload.body
+    assert "Pending checks: `` pending `quoted` ``, ```multi `` ticks```" in payload.body
+    assert "`` `edge` ``" in payload.body

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -378,6 +378,11 @@ def test_pr_workflow_orchestrator_passes_ci_feedback_to_strategy_engine() -> Non
 
     assert strategy_engine.ci_feedback == [ci_feedback]
     assert result.strategy.reasoning == "strategy saw ci feedback"
+    assert result.report.ci_feedback == ci_feedback
+    assert result.comment_payload is not None
+    assert "### CI / Check Feedback" in result.comment_payload.body
+    assert "Tests" in result.comment_payload.body
+    assert "failed jobs: `pytest`" in result.comment_payload.body
 
 
 def test_pr_workflow_orchestrator_can_skip_validation_via_policy_hook():

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -559,3 +559,16 @@ class TestQAReport:
         assert report.pr_number == 123
         assert len(report.validations) == 1
         assert report.validations[0].outcome == ValidationOutcome.PASS
+
+    def test_ci_feedback_defaults_to_none(self):
+        report = QAReport(
+            event_id="evt-001",
+            repo_full_name="acme-corp/web-api",
+            pr_number=123,
+            impact=BehaviourImpact(summary="Docs", areas=(), overall_risk=RiskLevel.LOW),
+            strategy=StrategyResult(actions=(), reasoning="No runtime action needed", confidence=0.8),
+            validations=(),
+            summary_markdown="Docs changed.",
+        )
+
+        assert report.ci_feedback is None


### PR DESCRIPTION
## Summary

This PR makes CI/check feedback a first-class part of the GitHub-facing Behaviour Impact Report. PR #57 already fed current-head CI state into strategy planning; this slice preserves that `CIFeedbackContext` on `QAReport` and renders it as a distinct report section instead of leaving it buried inside strategy reasoning or recommended actions.

The renderer remains formatting-only: it does not infer CI root cause or change validation strategy. It only displays the already-produced current-head observations, pending checks, run/log links, and historical evidence from superseded heads.

## Review focus

- Check that `PRWorkflowOrchestrator` carries the same CI feedback into `StrategyEngine` and `QAReport` without changing triage/no-output behavior.
- Check that `GitHubPRCommentRenderer` keeps PR summary comments separate from future inline review output surfaces.
- Check the Markdown hardening around external CI/check strings: workflow names, job names, pending check names, and SHAs are rendered safely even when they contain backticks or Markdown-looking text.

## Design notes

`QAReport.ci_feedback` is optional and defaults to `None`, so existing tests and call sites that construct reports without CI state stay compatible. The PR comment renderer can also accept an explicit `ci_feedback` argument for direct tests or future renderer call sites, but the default workflow path reads it from the report.

For inline-code values, the renderer does not try to backslash-escape backticks inside code spans. It chooses a delimiter run longer than the longest backtick run in the content, matching CommonMark/GitHub Markdown behavior.

## Verification

Local verification before opening this PR:

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run pytest tests/ -q`
- diff security-pattern scan
- independent pre-commit review

Live smoke verification with the qaestro GitHub App / `Kimcheolhui/qaestro-test` will be added as a PR comment after this PR is opened and deployed to the test VM.

Closes #50

---
🤖 *Created by Hermes Agent*
