### PR TITLE
feat: add agent framework tool adapter seam

### DIFF
--- a/docs/MODULE_REQUIREMENTS.md
+++ b/docs/MODULE_REQUIREMENTS.md
@@ -201,12 +201,14 @@ qaestro를 구현할 때 참고할 수 있는 모듈 단위 요구사항 문서.
 - GitHub backend는 기존 GitHub Client API adapter를 유지할 수 있어야 함
 - raw shell/CLI를 노출하지 않고, destructive action은 기본 금지해야 함
 - agent runner 도입 전에는 deterministic tool sequence로 실행 가능해야 함
+- Microsoft Agent Framework runner에는 모든 registered tool을 직접 넘기지 않고, 현재 `WorkflowStage`의 allowlist를 통과한 tool spec과 단일 invocation adapter만 제공해야 함
 
 **제외 범위**
 
 - 외부 webhook event ingestion 대체
 - GitHub backend를 CLI로 전환
 - LLM/Agent Framework 기반 tool selection 구현
+- Microsoft Agent Framework SDK 객체와 core/runtime contract의 직접 결합
 - runtime validation probe 전체 구현
 
 **선행 조건**
@@ -219,6 +221,7 @@ qaestro를 구현할 때 참고할 수 있는 모듈 단위 요구사항 문서.
 
 - PR context acquisition과 PR comment write가 ToolRuntime을 통해 실행 가능
 - workflow stage별 allowed tools가 코드에서 강제됨
+- Agent Framework-facing adapter seam이 stage-approved tool spec만 노출하고, 실제 호출은 `ToolRuntime.execute()`를 통과함
 - 기존 PR analysis vertical slice의 observable behavior가 유지됨
 
 ### 6. `app/worker`

--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -51,6 +51,8 @@ qaestro의 autonomy model은 완전 자율 agent가 아니라, **bounded tool au
 
 Step 3.5의 ToolRuntime 전환은 이 방향을 코드 경계로 고정하기 위한 중간 단계다. 외부 webhook input event는 계속 gateway가 normalized event로 변환하며, tool call로 대체하지 않는다. GitHub backend도 당분간 기존 GitHub Client API adapter를 유지한다. 이번 결정의 핵심은 API transport를 CLI로 바꾸는 것이 아니라, `Worker`/workflow가 `GitHubClient`, PR context provider, comment poster 같은 concrete read/write dependency를 직접 들고 있지 않도록 narrow tool capability 뒤로 이동시키는 것이다. Agent Framework runner가 들어오기 전까지 tool 선택은 deterministic sequence로 구현해도 되지만, 모든 read/write는 같은 `ToolRuntime` contract와 stage allowlist를 통과해야 한다.
 
+#46의 Agent Framework 정렬은 SDK full integration이 아니라 adapter seam으로 제한한다. `src.runtime.tools.agent_framework`는 Microsoft Agent Framework의 function/tool calling model에 넘길 수 있는 framework-neutral tool spec을 만들되, stage policy가 허용한 tool만 노출한다. 실제 호출도 runner가 raw handler를 직접 실행하지 않고 `ToolRuntime.execute()`를 통과해야 하므로 qaestro의 stage policy, audit, correlation/idempotency 경계가 유지된다. 구체 SDK 객체 import, LLM 기반 tool selection, validation probe 실행은 후속 Step 5 범위에서 다룬다.
+
 ### 5. PR review lifecycle: deferred unified review + manual trigger first
 
 qaestro는 PR opened, PR synchronize, workflow_run completed, GitHub comment/review, ChatOps mention을 별도 이벤트로 수신하되, 판단과 출력은 PR 단위 aggregate state에서 종합한다. 권장 MVP는 manual-trigger first다. 사용자가 PR 또는 channel에서 `@qaestro review`처럼 명시적으로 요청하면 current PR aggregate를 만들고, current `head_sha` 기준 CI/check snapshot을 확인한 뒤 가능한 경우 unified review를 수행한다. 자동 리뷰는 이후 repo 설정으로 opt-in/optional하게 확장한다.

--- a/src/runtime/tools/__init__.py
+++ b/src/runtime/tools/__init__.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from .agent_framework import AgentFrameworkToolAdapter, AgentFrameworkToolSpec
 from .policy import StageToolPolicy, ToolPolicyError
 from .runtime import RegisteredToolRuntime, ToolNotFoundError, ToolRuntime
 from .types import ToolAuditEntry, ToolCall, ToolCapability, ToolDefinition, ToolHandler, ToolResult
 
 __all__ = [
+    "AgentFrameworkToolAdapter",
+    "AgentFrameworkToolSpec",
     "RegisteredToolRuntime",
     "StageToolPolicy",
     "ToolAuditEntry",

--- a/src/runtime/tools/agent_framework.py
+++ b/src/runtime/tools/agent_framework.py
@@ -1,0 +1,90 @@
+"""Microsoft Agent Framework-facing adapters for qaestro tools.
+
+This module intentionally keeps Agent Framework integration at the seam level.
+qaestro owns workflow stage policy, audit, and correlation; an Agent Framework
+runner can use these specs/callables as its function-tool bridge without getting
+raw access to every registered capability.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from src.runtime.stages import WorkflowStage
+
+from .policy import StageToolPolicy
+from .runtime import ToolRuntime
+from .types import ToolCapability, ToolDefinition, ToolResult
+
+
+@dataclass(frozen=True)
+class AgentFrameworkToolSpec:
+    """Framework-neutral function-tool metadata for a stage-approved qaestro tool."""
+
+    name: str
+    description: str
+    parameters_schema: Mapping[str, Any]
+    stage: WorkflowStage
+    capabilities: tuple[ToolCapability, ...]
+
+
+class AgentFrameworkToolAdapter:
+    """Expose qaestro ToolRuntime capabilities through an Agent Framework seam.
+
+    Microsoft Agent Framework provides function/tool calling primitives such as
+    Python functions wrapped as model-callable tools. This adapter deliberately
+    does not import the preview SDK or let the runner bypass qaestro policy. It
+    supplies stable tool specs and a single invocation path that still executes
+    ``ToolRuntime.execute()`` with the workflow stage and correlation id.
+    """
+
+    def __init__(
+        self,
+        *,
+        runtime: ToolRuntime,
+        tools: tuple[ToolDefinition, ...],
+        policy: StageToolPolicy,
+    ) -> None:
+        self._runtime = runtime
+        self._tools = {tool.name: tool for tool in tools}
+        self._policy = policy
+
+    def tool_specs_for_stage(self, stage: WorkflowStage) -> tuple[AgentFrameworkToolSpec, ...]:
+        """Return only tool specs that qaestro policy allows for ``stage``."""
+        specs: list[AgentFrameworkToolSpec] = []
+        for name in self._policy.allowed_tool_names(stage):
+            definition = self._tools.get(name)
+            if definition is None:
+                continue
+            specs.append(
+                AgentFrameworkToolSpec(
+                    name=definition.name,
+                    description=definition.description,
+                    parameters_schema=definition.input_schema or {"type": "object", "properties": {}},
+                    stage=stage,
+                    capabilities=definition.capabilities,
+                )
+            )
+        return tuple(specs)
+
+    def invoke(
+        self,
+        *,
+        stage: WorkflowStage,
+        name: str,
+        arguments: Mapping[str, Any],
+        correlation_id: str,
+    ) -> ToolResult:
+        """Invoke a framework-requested function call through ToolRuntime."""
+        from .types import ToolCall
+
+        return self._runtime.execute(
+            ToolCall(
+                stage=stage,
+                name=name,
+                input=dict(arguments),
+                correlation_id=correlation_id,
+            )
+        )

--- a/src/runtime/tools/policy.py
+++ b/src/runtime/tools/policy.py
@@ -25,6 +25,10 @@ class StageToolPolicy:
         self._allowed_tools_by_stage = {stage: frozenset(tools) for stage, tools in allowed_tools_by_stage.items()}
         self._allow_destructive = allow_destructive
 
+    def allowed_tool_names(self, stage: WorkflowStage) -> tuple[str, ...]:
+        """Return tool names explicitly exposed to an agent runner for a stage."""
+        return tuple(sorted(self._allowed_tools_by_stage.get(stage, frozenset())))
+
     def check(self, call: ToolCall, definition: ToolDefinition) -> None:
         allowed_tools = self._allowed_tools_by_stage.get(call.stage, frozenset())
         if call.name not in allowed_tools:

--- a/src/runtime/tools/types.py
+++ b/src/runtime/tools/types.py
@@ -60,3 +60,5 @@ class ToolDefinition:
     name: str
     capabilities: tuple[ToolCapability, ...]
     handler: ToolHandler
+    description: str = ""
+    input_schema: Mapping[str, Any] | None = None

--- a/tests/runtime/test_agent_framework_tools.py
+++ b/tests/runtime/test_agent_framework_tools.py
@@ -1,0 +1,104 @@
+"""Tests for Microsoft Agent Framework-facing ToolRuntime adapters."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.runtime.stages import WorkflowStage
+from src.runtime.tools import (
+    AgentFrameworkToolAdapter,
+    AgentFrameworkToolSpec,
+    RegisteredToolRuntime,
+    StageToolPolicy,
+    ToolCall,
+    ToolCapability,
+    ToolDefinition,
+    ToolPolicyError,
+)
+
+
+def _tool_definitions() -> tuple[ToolDefinition, ...]:
+    return (
+        ToolDefinition(
+            name="demo.read",
+            description="Read demo data through a stage-approved qaestro tool.",
+            input_schema={
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            },
+            capabilities=(ToolCapability.READ,),
+            handler=lambda call: {"stage": call.stage.value, "value": call.input["value"]},
+        ),
+        ToolDefinition(
+            name="demo.write",
+            description="Write demo data through the output stage.",
+            input_schema={"type": "object", "properties": {}},
+            capabilities=(ToolCapability.WRITE,),
+            handler=lambda call: {"wrote": True},
+        ),
+    )
+
+
+def _adapter() -> AgentFrameworkToolAdapter:
+    tools = _tool_definitions()
+    policy = StageToolPolicy(
+        {
+            WorkflowStage.CONTEXT: ("demo.read",),
+            WorkflowStage.OUTPUT: ("demo.write",),
+        }
+    )
+    runtime = RegisteredToolRuntime(tools=tools, policy=policy)
+    return AgentFrameworkToolAdapter(runtime=runtime, tools=tools, policy=policy)
+
+
+def test_agent_framework_adapter_exposes_only_stage_approved_tool_specs() -> None:
+    adapter = _adapter()
+
+    specs = adapter.tool_specs_for_stage(WorkflowStage.CONTEXT)
+
+    assert specs == (
+        AgentFrameworkToolSpec(
+            name="demo.read",
+            description="Read demo data through a stage-approved qaestro tool.",
+            parameters_schema={
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            },
+            stage=WorkflowStage.CONTEXT,
+            capabilities=(ToolCapability.READ,),
+        ),
+    )
+
+
+def test_agent_framework_adapter_invokes_tool_runtime_with_stage_and_correlation() -> None:
+    adapter = _adapter()
+
+    result = adapter.invoke(
+        stage=WorkflowStage.CONTEXT,
+        name="demo.read",
+        arguments={"value": "ok"},
+        correlation_id="corr-agent-framework",
+    )
+
+    assert result.ok is True
+    assert result.output == {"stage": "context", "value": "ok"}
+    assert result.call == ToolCall(
+        stage=WorkflowStage.CONTEXT,
+        name="demo.read",
+        input={"value": "ok"},
+        correlation_id="corr-agent-framework",
+    )
+
+
+def test_agent_framework_adapter_keeps_stage_policy_as_guardrail() -> None:
+    adapter = _adapter()
+
+    with pytest.raises(ToolPolicyError, match="not allowed"):
+        adapter.invoke(
+            stage=WorkflowStage.CONTEXT,
+            name="demo.write",
+            arguments={},
+            correlation_id="corr-agent-framework-denied",
+        )

--- a/tests/runtime/test_tool_package_structure.py
+++ b/tests/runtime/test_tool_package_structure.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import src.runtime.tools as tools
+from src.runtime.tools.agent_framework import AgentFrameworkToolAdapter, AgentFrameworkToolSpec
 from src.runtime.tools.policy import StageToolPolicy, ToolPolicyError
 from src.runtime.tools.runtime import RegisteredToolRuntime, ToolNotFoundError, ToolRuntime
 from src.runtime.tools.types import ToolAuditEntry, ToolCall, ToolCapability, ToolDefinition, ToolResult
@@ -20,9 +21,12 @@ def test_runtime_tools_init_only_reexports_public_api() -> None:
     assert "from .types import" in source
     assert "from .policy import" in source
     assert "from .runtime import" in source
+    assert "from .agent_framework import" in source
 
 
 def test_runtime_tools_public_api_is_reexported_from_focused_modules() -> None:
+    assert tools.AgentFrameworkToolAdapter is AgentFrameworkToolAdapter
+    assert tools.AgentFrameworkToolSpec is AgentFrameworkToolSpec
     assert tools.ToolAuditEntry is ToolAuditEntry
     assert tools.ToolCall is ToolCall
     assert tools.ToolCapability is ToolCapability

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -82,3 +82,16 @@ def test_registered_tool_runtime_denies_destructive_tools_by_default() -> None:
         )
 
     assert runtime.audit_log == ()
+
+
+def test_stage_tool_policy_exposes_allowed_tool_names_without_mutation() -> None:
+    policy = StageToolPolicy(
+        {
+            WorkflowStage.CONTEXT: ("demo.z", "demo.a"),
+            WorkflowStage.OUTPUT: ("demo.write",),
+        }
+    )
+
+    assert policy.allowed_tool_names(WorkflowStage.CONTEXT) == ("demo.a", "demo.z")
+    assert policy.allowed_tool_names(WorkflowStage.OUTPUT) == ("demo.write",)
+    assert policy.allowed_tool_names(WorkflowStage.VALIDATOR) == ()


### PR DESCRIPTION
## Summary

This PR closes the remaining Step 4 issue for aligning qaestro tool execution with Microsoft Agent Framework without pulling the preview SDK into core/runtime contracts yet.

The key boundary is: Agent Framework may receive function-tool metadata for the current workflow stage, but qaestro still owns stage policy, audit, correlation, and the actual invocation path through `ToolRuntime.execute()`.

## What changed

- Adds a framework-neutral Agent Framework adapter seam for `runtime/tools`:
  - `AgentFrameworkToolSpec` describes model-callable tool metadata.
  - `AgentFrameworkToolAdapter.tool_specs_for_stage()` exposes only `WorkflowStage`-approved tools.
  - `AgentFrameworkToolAdapter.invoke()` routes calls back through `ToolRuntime.execute()` instead of exposing raw handlers.
- Extends `ToolDefinition` with optional `description` and JSON-style `input_schema` fields so runner-facing function specs can be built from existing tool registrations.
- Adds `StageToolPolicy.allowed_tool_names()` as the explicit read-side surface for runner exposure, separate from enforcement in `check()`.
- Documents the intended scope: this is an adapter seam, not full SDK integration, LLM tool selection, or Step 5 runtime validation execution.

## Review focus

Please check the architectural guardrail rather than just the new class shape:

- Does the adapter avoid exposing all registered tools globally?
- Is stage policy still the source of truth for both exposure and execution?
- Is it clear enough that Microsoft Agent Framework SDK objects are intentionally not imported into qaestro core/runtime contracts in this slice?
- Are `description` and `input_schema` on `ToolDefinition` sufficiently minimal for future function-tool wrapping without overfitting to one SDK version?

## Scope / follow-up

Intentionally out of scope:

- direct Microsoft Agent Framework SDK integration,
- LLM-driven tool selection,
- runtime validation probe execution,
- GitHub review/inline comment write tools.

Those remain follow-up work for the Step 5 validation path and later output surfaces. This PR only fixes the seam so future runners cannot bypass qaestro-owned workflow policy.

## Verification

Local verification already completed:

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`
- `uv run pytest tests/ -q`
- independent reviewer subagent found no blocking security or logic issues

Closes #46

---
🤖 *Created by Hermes Agent*
