### PR TITLE
docs: replan Step 5 around Agent Runtime Foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,12 +113,15 @@ normalized event
 | Context acquisition | PR metadata/diff/files, PR comments/reviews, CI workflow/run jobs, 관련 chat thread, knowledge read | `github.pr.view`, `github.pr.files`, `github.pr.diff`, `github.actions.run.jobs` |
 | Triage / readiness | 수집된 PR·CI·check context를 바탕으로 workflow depth와 final review 가능 여부 결정 | `PRWorkflowTriage`, current head check snapshot |
 | Analysis / strategy | 수집된 context, knowledge read, 제한된 추가 조회 | `knowledge.search` |
-| Validation | strategy가 선택한 runtime probe/test execution | 이후 Step 5에서 runtime probe tool 추가 |
+| Agent runtime | provider/session/runner 생성, LLM-backed tool selection 준비 | Step 5에서 BYOK provider 설정과 runner factory 추가 |
+| Validation | strategy가 선택한 runtime probe/test execution | 이후 Step 6에서 runtime probe tool 추가 |
 | Output | PR managed comment, PR review/inline comment, chat response 같은 write action | `github.pr.comment.create_or_update`, 이후 `github.pr.review.create` |
 
 Read tool은 맥락 수집과 판단을 돕기 위해 비교적 넓게 허용할 수 있지만, write tool은 output policy를 거쳐야 한다. destructive action은 기본 금지이며, comment 작성·knowledge write 같은 side effect는 correlation id와 중복 방지 정책을 함께 고려한다.
 
 Step 3.5에서는 GitHub backend를 기존 GitHub Client API adapter로 유지하고, raw shell/CLI를 열지 않는다. 목표는 transport 교체가 아니라 `Worker`/workflow가 GitHub-specific provider나 poster를 직접 잡지 않도록 read/write 실행 경계를 `ToolRuntime` 뒤로 옮기는 것이다. Agent Framework runner가 들어오기 전까지 tool 선택은 deterministic sequence로 시작하되, 같은 tool contract와 stage policy 위에서 나중에 agent 선택으로 교체할 수 있어야 한다.
+
+Step 5는 그 교체 가능성을 실제 실행 준비 상태로 만드는 단계다. `app/worker`는 Agent Runtime host가 되지만, Microsoft Agent Framework SDK 객체와 provider SDK 객체는 adapter/factory 밖으로 새지 않아야 한다. `shared/config`는 BYOK 기반 provider/session 설정을 typed config로 읽고, `runtime/agent`는 fake provider와 real provider를 같은 runner contract 뒤에 둔다. Step 6의 runtime validation은 이 foundation 위에서 validation stage에 허용된 tool과 probe만 노출한다.
 
 ### PR aggregate lifecycle
 

--- a/docs/MODULE_REQUIREMENTS.md
+++ b/docs/MODULE_REQUIREMENTS.md
@@ -605,19 +605,21 @@ qaestro를 구현할 때 참고할 수 있는 모듈 단위 요구사항 문서.
 | 3    | GitHub PR 분석 vertical slice     | `core/analyzer`, `core/strategy`, `core/knowledge`(interface+mock), `adapters/renderers`                 | PR 오픈 시 Behaviour Impact Report 자동 생성                    |
 | 3.5  | Tool Runtime 경계 정리            | `runtime/tools`, `runtime/orchestrator`, `adapters/connectors`(GitHub), `app/worker`                     | PR read/write가 stage policy를 거친 ToolRuntime으로 실행        |
 | 4    | CI 결과 피드백 루프               | `runtime/orchestrator`, `runtime/tools`, `core/strategy`, `adapters/renderers`                           | PR/CI/check를 PR aggregate로 묶고, current head 기준 unified review 가능 |
-| 5    | Runtime Validation MVP            | `runtime/validator`, `runtime/tools`, Microsoft Agent Framework 연결                                     | 선택된 PR에 대해 runtime validation 실행 및 결과 반영           |
-| 6    | ChatOps 흐름 연결                 | `app/gateway`(chat), `runtime/tools`, `adapters/connectors`(ChatOps), `adapters/renderers`               | `@qaestro` 호출 시 전략 제안, PR 맥락과 연결                    |
-| 7    | Knowledge Store 실 adapter 적용   | `adapters/knowledge`, `core/strategy`                                                                    | 실제 backing store 연결, 과거 패턴 조회 가능, adapter 교체 가능 |
-| 8    | CLI와 self-hosted 설치 흐름       | `app/cli`                                                                                                | repo 소스 이해 없이 CLI로 설치/실행 가능                        |
-| 9    | 운영 안정화 및 베타 준비          | telemetry, permission, 문서                                                                              | 내부 dogfooding 또는 design partner 테스트 가능                 |
+| 5    | Agent Runtime Foundation          | `shared/config`, `runtime/agent`, `app/worker`, `runtime/tools`, Microsoft Agent Framework 연결          | provider/session/runner 설정이 가능하고 fake/real provider 경계가 테스트 가능 |
+| 6    | Runtime Validation MVP            | `runtime/validator`, `runtime/tools`, Agent Runtime runner 연결                                          | 선택된 PR에 대해 runtime validation 실행 및 결과 반영           |
+| 7    | ChatOps 흐름 연결                 | `app/gateway`(chat), `runtime/tools`, `adapters/connectors`(ChatOps), `adapters/renderers`               | `@qaestro` 호출 시 전략 제안, PR 맥락과 연결                    |
+| 8    | Knowledge Store 실 adapter 적용   | `adapters/knowledge`, `core/strategy`                                                                    | 실제 backing store 연결, 과거 패턴 조회 가능, adapter 교체 가능 |
+| 9    | CLI와 self-hosted 설치 흐름       | `app/cli`                                                                                                | repo 소스 이해 없이 CLI로 설치/실행 가능                        |
+| 10   | 운영 안정화 및 베타 준비          | telemetry, permission, 문서                                                                              | 내부 dogfooding 또는 design partner 테스트 가능                 |
 
 ### 병렬 개발 권장 구간
 
 - Step 0 ~ 2는 가급적 순차 진행
 - Step 3부터는 `core/analyzer`, `core/strategy`, `adapters/renderers`를 병렬 진행 가능
-- Step 5와 Step 6은 공통 orchestration이 잡힌 뒤 병렬 진행 가능
-- Step 7(`adapters/knowledge`)은 Step 5 ~ 6과 병렬 진행 가능 (`core/knowledge` interface는 Step 3에서 확보됨)
-- Step 8 ~ 9는 제품 기능이 일정 수준 붙은 뒤 진행
+- Step 5는 Step 6 Runtime Validation보다 먼저 진행한다. Agent session/provider/runner 준비 없이 validation workflow만 쌓으면 실제 실행 경로가 늦게 흔들린다.
+- Step 6과 Step 7은 Agent Runtime Foundation과 공통 orchestration이 잡힌 뒤 병렬 진행 가능
+- Step 8(`adapters/knowledge`)은 Step 6 ~ 7과 병렬 진행 가능 (`core/knowledge` interface는 Step 3에서 확보됨)
+- Step 9 ~ 10은 제품 기능이 일정 수준 붙은 뒤 진행
 
 ### 권장 마일스톤
 
@@ -625,9 +627,10 @@ qaestro를 구현할 때 참고할 수 있는 모듈 단위 요구사항 문서.
 | -------------------------- | ------------- | ----------------------------------------- |
 | A. GitHub-only 분석 MVP    | Step 0 ~ 4    | PR과 CI 결과에 대해 구조화된 QA 코멘트    |
 | A-1. Tool Runtime 경계     | Step 3.5      | read/write/validation tool boundary 정리  |
-| B. Runtime Validation MVP  | Step 5        | 전략 판단을 실제 runtime 검증까지 연결    |
-| C. ChatOps + Knowledge MVP | Step 6 ~ 7    | 채널 호출과 지식 조회를 포함한 협업 흐름  |
-| D. Self-hosted 베타        | Step 8 ~ 9    | CLI 기반 설치와 내부 운영 가능            |
+| B. Agent Runtime Foundation | Step 5       | provider/session/runner 기반 실행 준비    |
+| C. Runtime Validation MVP  | Step 6        | 전략 판단을 실제 runtime 검증까지 연결    |
+| D. ChatOps + Knowledge MVP | Step 7 ~ 8    | 채널 호출과 지식 조회를 포함한 협업 흐름  |
+| E. Self-hosted 베타        | Step 9 ~ 10   | CLI 기반 설치와 내부 운영 가능            |
 
 ### 각 단계의 Definition of Done
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -117,7 +117,7 @@ adapters.knowledge  → core.knowledge, shared
 ### `app/`
 
 - `app/gateway`: GitHub, Slack/Teams에서 들어오는 payload를 받아 공통 이벤트로 normalize
-- `app/worker`: `runtime/orchestrator`를 실행하는 background processing entrypoint이자 Microsoft Agent Framework runner host
+- `app/worker`: `runtime/orchestrator`를 실행하는 background processing entrypoint이자 Agent Runtime/Microsoft Agent Framework runner host
 - `app/cli`: 로컬 replay, fixture 실행, 수동 검증용 엔트리포인트. GitHub App manifest, ChatOps app 설정 등 설치 매니페스트도 CLI 리소스로 관리
 
 ### `core/`
@@ -130,6 +130,7 @@ adapters.knowledge  → core.knowledge, shared
 ### `runtime/`
 
 - `runtime/orchestrator`: Event Router, correlation id, PR/채널/CI 맥락 묶기, workflow state 관리
+- `runtime/agent`: BYOK provider/session 설정, runner factory, fake/real provider 경계를 관리하는 Agent Runtime foundation
 - `runtime/validator`: 실제 런타임 검증 실행. MVP는 `api_contract`, `ui_flow` probe부터 시작
 
 ### `adapters/`
@@ -191,6 +192,7 @@ tests/replay/
 아래는 MVP 이후 시점에 확장한다.
 
 ```text
+src/runtime/agent/          # P1
 src/runtime/validator/      # P1
 src/adapters/connectors/    # ChatOps, LLM connector (P1)
 src/adapters/knowledge/     # concrete backing store adapter (P1)
@@ -202,7 +204,8 @@ tests/e2e/
 
 - 채널/provider별 코드는 `app/gateway`에 박아 넣기보다 `adapters/connectors/`로 분리하는 편이 확장에 유리하다.
 - 고객별 QA knowledge는 `core/knowledge` port 뒤로 숨기고, 실제 저장소 구현은 `adapters/knowledge`로 미루는 편이 현재 배포 모델과 맞다.
+- Agent Runtime은 `runtime/agent`로 분리해 provider/session/runner 준비를 먼저 다룬다. validation workflow는 이 foundation 없이 먼저 확장하지 않는다.
 - Runtime Validation은 `runtime/validator`로 분리해야 이후 DB 정합성, 성능, multi-step behaviour probe를 붙이기 쉽다.
-- Agent Framework 전용 객체 타입과 설정은 `app/worker`와 `runtime/*` 근처에 두고, `core/*`에는 직접 퍼뜨리지 않는다.
+- Agent Framework 전용 객체 타입과 설정은 `app/worker`와 `runtime/agent` 근처에 두고, `core/*`에는 직접 퍼뜨리지 않는다.
 - `tests/replay/`는 이 프로젝트의 성격상 중요하다. 단순 unit test보다 실제 event bundle replay가 더 많은 가치를 준다.
 - GitHub App manifest, ChatOps app 설정 등 설치 매니페스트는 `app/cli`가 참조하는 리소스로 관리한다. 설치 = CLI가 전부 책임지는 구조.

--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -51,7 +51,9 @@ qaestro의 autonomy model은 완전 자율 agent가 아니라, **bounded tool au
 
 Step 3.5의 ToolRuntime 전환은 이 방향을 코드 경계로 고정하기 위한 중간 단계다. 외부 webhook input event는 계속 gateway가 normalized event로 변환하며, tool call로 대체하지 않는다. GitHub backend도 당분간 기존 GitHub Client API adapter를 유지한다. 이번 결정의 핵심은 API transport를 CLI로 바꾸는 것이 아니라, `Worker`/workflow가 `GitHubClient`, PR context provider, comment poster 같은 concrete read/write dependency를 직접 들고 있지 않도록 narrow tool capability 뒤로 이동시키는 것이다. Agent Framework runner가 들어오기 전까지 tool 선택은 deterministic sequence로 구현해도 되지만, 모든 read/write는 같은 `ToolRuntime` contract와 stage allowlist를 통과해야 한다.
 
-#46의 Agent Framework 정렬은 SDK full integration이 아니라 adapter seam으로 제한한다. `src.runtime.tools.agent_framework`는 Microsoft Agent Framework의 function/tool calling model에 넘길 수 있는 framework-neutral tool spec을 만들되, stage policy가 허용한 tool만 노출한다. 실제 호출도 runner가 raw handler를 직접 실행하지 않고 `ToolRuntime.execute()`를 통과해야 하므로 qaestro의 stage policy, audit, correlation/idempotency 경계가 유지된다. 구체 SDK 객체 import, LLM 기반 tool selection, validation probe 실행은 후속 Step 5 범위에서 다룬다.
+#46의 Agent Framework 정렬은 SDK full integration이 아니라 adapter seam으로 제한한다. `src.runtime.tools.agent_framework`는 Microsoft Agent Framework의 function/tool calling model에 넘길 수 있는 framework-neutral tool spec을 만들되, stage policy가 허용한 tool만 노출한다. 실제 호출도 runner가 raw handler를 직접 실행하지 않고 `ToolRuntime.execute()`를 통과해야 하므로 qaestro의 stage policy, audit, correlation/idempotency 경계가 유지된다.
+
+Step 5는 Runtime Validation 자체가 아니라 **Agent Runtime Foundation**으로 둔다. 현재 구현은 `WorkerExecutionContext.agent_runner` 같은 opaque slot과 tool adapter seam만 있고, 실제 agent session 생성, LLM provider 설정, model/deployment 선택, credential loading, execution budget, fake/real provider 분리, 최소 capability 판단이 없다. 이 상태에서 validation probe workflow를 먼저 구현하면 실행 주체가 없는 interface만 늘거나, Azure OpenAI/GitHub Models/OpenAI-compatible provider 중 하나에 우발적으로 결합될 가능성이 높다. 따라서 구체 validation probe와 report 반영은 Step 6으로 미루고, Step 5에서는 BYOK 기반 provider/session/runner contract와 Microsoft Agent Framework SDK 격리 경계를 먼저 구현한다.
 
 ### 5. PR review lifecycle: deferred unified review + manual trigger first
 
@@ -66,8 +68,10 @@ PR aggregate는 PR 전체 수명과 대화 history를 유지하고, 그 안에 `
 ### 6. 모델 제공 방식: BYOK
 
 - `BYOK`를 전제로 설계
-- provider 선택은 추후 결정
-- core 계층은 특정 provider에 직접 종속되지 않도록 유지
+- Agent Runtime 설정은 provider, model/deployment id, endpoint/base URL, credential reference, timeout, max turns/tool calls, temperature 같은 실행 예산을 명시적으로 표현해야 한다.
+- Azure OpenAI와 GitHub Models/OpenAI-compatible provider는 설정 shape를 분리하되, core 계층은 특정 provider SDK type에 직접 종속되지 않도록 유지한다.
+- credential 값은 config object의 repr, log, report, issue output에 노출하지 않는다.
+- provider 선택과 session 생성은 `app/worker` 또는 `runtime/agent` adapter/factory 경계에 두고, 테스트에서는 fake provider로 같은 contract를 검증한다.
 
 ### 7. Queue backend: Redis Streams for process separation
 


### PR DESCRIPTION
## Summary
- Replans Step 5 as **Agent Runtime Foundation** instead of jumping directly into Runtime Validation.
- Moves Runtime Validation to Step 6 in docs, with ChatOps/Knowledge/CLI/Ops shifted to Steps 7–10.
- Documents the reasoning: qaestro currently has ToolRuntime/Agent Framework seams, but not provider/session/runner setup, so validation should depend on a real Agent Runtime foundation first.
- Adds `runtime/agent` as the intended home for BYOK provider/session config, runner factories, and fake/real provider boundaries.

## GitHub planning updates already applied
- Milestone #9 is now `Step 5 — Agent Runtime Foundation`.
- New milestone #15 is `Step 6 — Runtime Validation MVP`.
- Issues #61–#64 moved to Step 6.
- Issues #65–#69 now define Step 5 Agent Runtime work.

## Verification
- Confirmed this PR changes docs only:
  - `docs/ARCHITECTURE.md`
  - `docs/MODULE_REQUIREMENTS.md`
  - `docs/PROJECT_STRUCTURE.md`
  - `docs/TECH_DECISIONS.md`
- Ran `git diff --check origin/main...HEAD`.
- Verified milestone/issue bodies do not include Hermes attribution.

Generated by Hermes Agent.