### PR TITLE
feat(agent): add runtime foundation contracts

### DIFF
--- a/src/runtime/agent/__init__.py
+++ b/src/runtime/agent/__init__.py
@@ -1,0 +1,29 @@
+"""Provider-neutral Agent Runtime public API."""
+
+from __future__ import annotations
+
+from .fake import FakeAgentRunner
+from .manager import WorkflowAgentSessionManager
+from .types import (
+    AgentRunInput,
+    AgentRunResult,
+    AgentRunStatus,
+    AgentSessionHandle,
+    AgentSessionRecord,
+    AgentSessionScope,
+    AgentSessionStatus,
+    AgentSessionTurn,
+)
+
+__all__ = [
+    "AgentRunInput",
+    "AgentRunResult",
+    "AgentRunStatus",
+    "AgentSessionHandle",
+    "AgentSessionRecord",
+    "AgentSessionScope",
+    "AgentSessionStatus",
+    "AgentSessionTurn",
+    "FakeAgentRunner",
+    "WorkflowAgentSessionManager",
+]

--- a/src/runtime/agent/fake.py
+++ b/src/runtime/agent/fake.py
@@ -1,0 +1,37 @@
+"""Deterministic fake Agent Runtime runner for tests and local wiring."""
+
+from __future__ import annotations
+
+from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunResult, AgentRunStatus, AgentSessionHandle
+
+
+class FakeAgentRunner(AgentRunner):
+    """Small fake runner that exercises the provider-neutral contract.
+
+    The fake deliberately performs no LLM call. It lets config, session lifecycle,
+    stage tool exposure, and worker/orchestrator wiring tests run without real
+    provider credentials.
+    """
+
+    def __init__(self, *, response: str = "") -> None:
+        self._response = response
+        self.started_sessions: list[AgentSessionHandle] = []
+        self.closed_sessions: list[tuple[str, str]] = []
+        self.run_inputs: list[AgentRunInput] = []
+
+    def start_session(self, handle: AgentSessionHandle) -> AgentSessionHandle:
+        self.started_sessions.append(handle)
+        return handle
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        self.run_inputs.append(run_input)
+        return AgentRunResult(
+            session=session,
+            stage=run_input.stage,
+            status=AgentRunStatus.SUCCEEDED,
+            output_text=self._response,
+            allowed_tool_names=run_input.allowed_tool_names,
+        )
+
+    def close_session(self, handle: AgentSessionHandle, *, reason: str) -> None:
+        self.closed_sessions.append((handle.session_id, reason))

--- a/src/runtime/agent/manager.py
+++ b/src/runtime/agent/manager.py
@@ -1,0 +1,141 @@
+"""Workflow-scoped Agent Runtime session manager."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+
+from src.runtime.agent.types import (
+    AgentRunInput,
+    AgentRunner,
+    AgentRunResult,
+    AgentSessionHandle,
+    AgentSessionRecord,
+    AgentSessionScope,
+    AgentSessionStatus,
+    AgentSessionTurn,
+)
+
+
+class AgentSessionNotFoundError(RuntimeError):
+    """Raised when a session handle does not match a known live/retained record."""
+
+
+class WorkflowAgentSessionManager:
+    """Manage workflow-scoped Agent Runtime sessions.
+
+    The manager treats provider sessions as live execution handles, not as durable
+    source-of-truth state. It retains only normalized turn metadata in memory for
+    tests and future audit stores. Stage turns always provide their own allowed
+    tools so a reused workflow session cannot silently inherit broader access.
+    """
+
+    def __init__(self, *, runner: AgentRunner) -> None:
+        self._runner = runner
+        self._records: dict[str, AgentSessionRecord] = {}
+        self._next_id = 1
+
+    def start_workflow_session(
+        self,
+        *,
+        repo_full_name: str,
+        pr_number: int,
+        head_sha: str,
+        trigger: str,
+        correlation_id: str,
+    ) -> AgentSessionRecord:
+        session_id = self._new_session_id(repo_full_name=repo_full_name, pr_number=pr_number, head_sha=head_sha)
+        handle = AgentSessionHandle(
+            session_id=session_id,
+            scope=AgentSessionScope.WORKFLOW,
+            repo_full_name=repo_full_name,
+            pr_number=pr_number,
+            head_sha=head_sha,
+            trigger=trigger,
+            correlation_id=correlation_id,
+        )
+        handle = self._runner.start_session(handle)
+        record = AgentSessionRecord(handle=handle, status=AgentSessionStatus.ACTIVE)
+        self._records[handle.session_id] = record
+        return record
+
+    def run_stage(self, handle: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        record = self.get_session(handle.session_id)
+        if not record.is_active:
+            msg = f"agent session {handle.session_id!r} is not active"
+            raise AgentSessionNotFoundError(msg)
+        result = self._runner.run(session=record.handle, run_input=run_input)
+        turn = AgentSessionTurn(
+            stage=run_input.stage,
+            correlation_id=run_input.correlation_id,
+            status=result.status,
+            allowed_tool_names=run_input.allowed_tool_names,
+            error=result.error,
+        )
+        self._records[handle.session_id] = replace(record, turns=(*record.turns, turn))
+        return result
+
+    def get_session(self, session_id: str) -> AgentSessionRecord:
+        record = self._records.get(session_id)
+        if record is None:
+            msg = f"agent session {session_id!r} was not found"
+            raise AgentSessionNotFoundError(msg)
+        return record
+
+    def turns_for_session(self, session_id: str) -> tuple[AgentSessionTurn, ...]:
+        return self.get_session(session_id).turns
+
+    def cancel_superseded_sessions(
+        self,
+        *,
+        repo_full_name: str,
+        pr_number: int,
+        current_head_sha: str,
+        reason: str,
+    ) -> tuple[AgentSessionRecord, ...]:
+        return self._close_matching(
+            repo_full_name=repo_full_name,
+            pr_number=pr_number,
+            reason=reason,
+            predicate=lambda record: record.handle.head_sha != current_head_sha,
+            terminal_status=AgentSessionStatus.CANCELLED,
+        )
+
+    def close_pr_sessions(self, *, repo_full_name: str, pr_number: int, reason: str) -> tuple[AgentSessionRecord, ...]:
+        return self._close_matching(
+            repo_full_name=repo_full_name,
+            pr_number=pr_number,
+            reason=reason,
+            predicate=lambda record: True,
+            terminal_status=AgentSessionStatus.COMPLETED,
+        )
+
+    def _close_matching(
+        self,
+        *,
+        repo_full_name: str,
+        pr_number: int,
+        reason: str,
+        predicate: Callable[[AgentSessionRecord], bool],
+        terminal_status: AgentSessionStatus,
+    ) -> tuple[AgentSessionRecord, ...]:
+        closed: list[AgentSessionRecord] = []
+        for record in tuple(self._records.values()):
+            if not record.is_active:
+                continue
+            if record.handle.repo_full_name != repo_full_name or record.handle.pr_number != pr_number:
+                continue
+            if not predicate(record):
+                continue
+            self._runner.close_session(record.handle, reason=reason)
+            updated = replace(record, status=terminal_status, termination_reason=reason)
+            self._records[record.handle.session_id] = updated
+            closed.append(updated)
+        return tuple(closed)
+
+    def _new_session_id(self, *, repo_full_name: str, pr_number: int, head_sha: str) -> str:
+        safe_repo = repo_full_name.replace("/", "-")
+        short_sha = head_sha[:12] if head_sha else "unknown"
+        session_id = f"review-{safe_repo}-{pr_number}-{short_sha}-{self._next_id}"
+        self._next_id += 1
+        return session_id

--- a/src/runtime/agent/types.py
+++ b/src/runtime/agent/types.py
@@ -1,0 +1,130 @@
+"""Provider-neutral Agent Runtime value contracts.
+
+This module intentionally contains no Microsoft Agent Framework or provider SDK
+objects. It models qaestro's own execution contract so workflow/orchestrator code
+can reason about session scope, stage boundaries, and cleanup without depending
+on a concrete LLM backend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+from src.runtime.stages import WorkflowStage
+from src.runtime.tools import AgentFrameworkToolSpec
+
+
+class AgentSessionScope(StrEnum):
+    """Supported live session scopes for Agent Runtime execution."""
+
+    WORKFLOW = "workflow"
+    STAGE = "stage"
+
+
+class AgentSessionStatus(StrEnum):
+    """Lifecycle state of a live provider-neutral agent session."""
+
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+
+class AgentRunStatus(StrEnum):
+    """Normalized status for one stage turn executed through an agent runner."""
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class AgentSessionHandle:
+    """Opaque provider-neutral reference to a live workflow/stage session."""
+
+    session_id: str
+    scope: AgentSessionScope
+    repo_full_name: str
+    pr_number: int
+    head_sha: str
+    trigger: str
+    correlation_id: str
+    provider_session_id: str = ""
+
+
+@dataclass(frozen=True)
+class AgentRunInput:
+    """One stage turn request sent to an Agent Runtime runner.
+
+    ``allowed_tools`` must be supplied per turn so reusing a workflow-scoped
+    session never widens a later stage's tool access implicitly.
+    """
+
+    stage: WorkflowStage
+    prompt: str
+    correlation_id: str
+    allowed_tools: tuple[AgentFrameworkToolSpec, ...] = ()
+    context: Mapping[str, object] | None = None
+    max_turns: int | None = None
+    max_tool_calls: int | None = None
+    timeout_seconds: float | None = None
+
+    @property
+    def allowed_tool_names(self) -> tuple[str, ...]:
+        return tuple(tool.name for tool in self.allowed_tools)
+
+
+@dataclass(frozen=True)
+class AgentRunResult:
+    """Provider-neutral result returned by an Agent Runtime runner."""
+
+    session: AgentSessionHandle
+    stage: WorkflowStage
+    status: AgentRunStatus
+    output_text: str = ""
+    error: str = ""
+    allowed_tool_names: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return self.status is AgentRunStatus.SUCCEEDED
+
+
+@dataclass(frozen=True)
+class AgentSessionTurn:
+    """Redacted audit metadata for one stage turn inside a session."""
+
+    stage: WorkflowStage
+    correlation_id: str
+    status: AgentRunStatus
+    allowed_tool_names: tuple[str, ...]
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class AgentSessionRecord:
+    """In-memory lifecycle record for one provider-neutral agent session."""
+
+    handle: AgentSessionHandle
+    status: AgentSessionStatus
+    turns: tuple[AgentSessionTurn, ...] = ()
+    termination_reason: str = ""
+
+    @property
+    def is_active(self) -> bool:
+        return self.status is AgentSessionStatus.ACTIVE
+
+
+class AgentRunner(Protocol):
+    """Provider-neutral runner implemented by fake and real provider adapters."""
+
+    def start_session(self, handle: AgentSessionHandle) -> AgentSessionHandle: ...
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult: ...
+
+    def close_session(self, handle: AgentSessionHandle, *, reason: str) -> None: ...

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -5,11 +5,13 @@ Re-exports the public API so consumers can do::
     from src.shared import load_config, get_logger, new_correlation_id
 """
 
-from .config import AppConfig, load_config
+from .config import AgentRuntimeConfig, AgentRuntimeProvider, AppConfig, load_config
 from .logging import get_logger, setup_logging
 from .tracing import get_correlation_id, new_correlation_id, set_correlation_id
 
 __all__ = [
+    "AgentRuntimeConfig",
+    "AgentRuntimeProvider",
     "AppConfig",
     "get_correlation_id",
     "get_logger",

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -8,10 +8,60 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
 
 
-@dataclass(frozen=True)
+class AgentRuntimeProvider(StrEnum):
+    """Supported Agent Runtime provider families.
+
+    ``DISABLED`` keeps local development and tests credential-free. Real
+    providers are added behind ``runtime/agent`` adapters so core logic remains
+    provider-neutral.
+    """
+
+    DISABLED = "disabled"
+    AZURE_OPENAI = "azure-openai"
+    GITHUB_COPILOT = "github-copilot"
+    OPENAI_COMPATIBLE = "openai-compatible"
+
+
+@dataclass(frozen=True, repr=False)
+class AgentRuntimeConfig:
+    """Agent Runtime settings loaded from ``QAESTRO_AGENT_*`` variables."""
+
+    provider: AgentRuntimeProvider = AgentRuntimeProvider.DISABLED
+    model: str = ""
+    deployment: str = ""
+    endpoint: str = ""
+    base_url: str = ""
+    api_version: str = ""
+    credential_env_var: str = ""
+    timeout_seconds: float = 60.0
+    max_turns: int = 8
+    max_tool_calls: int = 16
+    temperature: float = 0.0
+
+    def __repr__(self) -> str:
+        credential = "<redacted>" if self.credential_env_var else ""
+        return (
+            "AgentRuntimeConfig("
+            f"provider={self.provider!r}, "
+            f"model={self.model!r}, "
+            f"deployment={self.deployment!r}, "
+            f"endpoint={self.endpoint!r}, "
+            f"base_url={self.base_url!r}, "
+            f"api_version={self.api_version!r}, "
+            f"credential_env_var={credential}, "
+            f"timeout_seconds={self.timeout_seconds!r}, "
+            f"max_turns={self.max_turns!r}, "
+            f"max_tool_calls={self.max_tool_calls!r}, "
+            f"temperature={self.temperature!r}"
+            ")"
+        )
+
+
+@dataclass(frozen=True, repr=False)
 class AppConfig:
     """Top-level application configuration.
 
@@ -49,8 +99,36 @@ class AppConfig:
     redis_read_block_ms: int = 5000
     redis_claim_idle_ms: int = 300000
 
+    # ── Agent Runtime ──────────────────────────────────────────────
+    agent_runtime: AgentRuntimeConfig = field(default_factory=AgentRuntimeConfig)
+
     # ── Feature flags (for future use) ─────────────────────────────
     features: dict[str, bool] = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        fields = (
+            f"env={self.env!r}",
+            f"debug={self.debug!r}",
+            f"log_level={self.log_level!r}",
+            f"log_format={self.log_format!r}",
+            f"gateway_host={self.gateway_host!r}",
+            f"gateway_port={self.gateway_port!r}",
+            f"github_webhook_secret={'<redacted>' if self.github_webhook_secret else ''}",
+            f"github_app_id={self.github_app_id!r}",
+            f"github_app_installation_id={self.github_app_installation_id!r}",
+            f"github_app_private_key_path={self.github_app_private_key_path!r}",
+            f"worker_concurrency={self.worker_concurrency!r}",
+            f"queue_backend={self.queue_backend!r}",
+            f"redis_url={self.redis_url!r}",
+            f"redis_stream={self.redis_stream!r}",
+            f"redis_consumer_group={self.redis_consumer_group!r}",
+            f"redis_consumer={self.redis_consumer!r}",
+            f"redis_read_block_ms={self.redis_read_block_ms!r}",
+            f"redis_claim_idle_ms={self.redis_claim_idle_ms!r}",
+            f"agent_runtime={self.agent_runtime!r}",
+            f"features={self.features!r}",
+        )
+        return f"AppConfig({', '.join(fields)})"
 
 
 _ENV_PREFIX = "QAESTRO_"
@@ -77,10 +155,60 @@ _ENV_MAP: dict[str, tuple[str, type[Any]]] = {
     "redis_claim_idle_ms": ("REDIS_CLAIM_IDLE_MS", int),
 }
 
+_AGENT_ENV_MAP: dict[str, tuple[str, type[Any]]] = {
+    "provider": ("AGENT_PROVIDER", AgentRuntimeProvider),
+    "model": ("AGENT_MODEL", str),
+    "deployment": ("AGENT_DEPLOYMENT", str),
+    "endpoint": ("AGENT_ENDPOINT", str),
+    "base_url": ("AGENT_BASE_URL", str),
+    "api_version": ("AGENT_API_VERSION", str),
+    "credential_env_var": ("AGENT_CREDENTIAL_ENV_VAR", str),
+    "timeout_seconds": ("AGENT_TIMEOUT_SECONDS", float),
+    "max_turns": ("AGENT_MAX_TURNS", int),
+    "max_tool_calls": ("AGENT_MAX_TOOL_CALLS", int),
+    "temperature": ("AGENT_TEMPERATURE", float),
+}
+
 
 def _parse_bool(value: str) -> bool:
     """Parse a boolean from an environment variable string."""
     return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _convert_env_value(env_key: str, raw: str, converter: type[Any]) -> Any:
+    if converter is bool:
+        return _parse_bool(raw)
+    if converter is int:
+        try:
+            return int(raw)
+        except ValueError:
+            msg = f"Invalid integer value for {env_key}: {raw!r}"
+            raise ValueError(msg) from None
+    if converter is float:
+        try:
+            return float(raw)
+        except ValueError:
+            msg = f"Invalid float value for {env_key}: {raw!r}"
+            raise ValueError(msg) from None
+    if converter is AgentRuntimeProvider:
+        try:
+            return AgentRuntimeProvider(raw)
+        except ValueError:
+            allowed = ", ".join(provider.value for provider in AgentRuntimeProvider)
+            msg = f"Invalid Agent Runtime provider for {env_key}: {raw!r}. Expected one of: {allowed}"
+            raise ValueError(msg) from None
+    return raw
+
+
+def _load_agent_runtime_config() -> AgentRuntimeConfig:
+    overrides: dict[str, Any] = {}
+    for field_name, (suffix, converter) in _AGENT_ENV_MAP.items():
+        env_key = f"{_ENV_PREFIX}{suffix}"
+        raw = os.environ.get(env_key)
+        if raw is None:
+            continue
+        overrides[field_name] = _convert_env_value(env_key, raw, converter)
+    return AgentRuntimeConfig(**overrides)
 
 
 def load_config() -> AppConfig:
@@ -99,15 +227,7 @@ def load_config() -> AppConfig:
         if raw is None:
             continue
 
-        if converter is bool:
-            overrides[field_name] = _parse_bool(raw)
-        elif converter is int:
-            try:
-                overrides[field_name] = int(raw)
-            except ValueError:
-                msg = f"Invalid integer value for {env_key}: {raw!r}"
-                raise ValueError(msg) from None
-        else:
-            overrides[field_name] = raw
+        overrides[field_name] = _convert_env_value(env_key, raw, converter)
 
+    overrides["agent_runtime"] = _load_agent_runtime_config()
     return AppConfig(**overrides)

--- a/tests/replay/test_ci_feedback_loop_replay.py
+++ b/tests/replay/test_ci_feedback_loop_replay.py
@@ -11,7 +11,7 @@ from src.adapters.renderers import PRCommentPayload
 from src.app.gateway import GitHubWebhookGateway, WebhookRequest
 from src.app.jobs import InMemoryJobQueue
 from src.app.worker import Worker, WorkerStatus
-from src.core.contracts import CICompleted, CIReadinessState, PREvent
+from src.core.contracts import CICompleted, CIFeedbackContext, CIReadinessState, PREvent
 from src.core.contracts.parsers import parse_github_ci_event
 from src.runtime.orchestrator import (
     CheckRunSnapshot,
@@ -93,7 +93,7 @@ def _enqueue_with_payload(
 def _build_worker(
     *, aggregate_store: InMemoryPRAggregateStore, check_provider: MutableCheckSnapshotProvider
 ) -> tuple[Worker, RecordingOutputPoster]:
-    def ci_feedback_for(event: PREvent):
+    def ci_feedback_for(event: PREvent) -> CIFeedbackContext:
         aggregate = aggregate_store.apply_pr_event(event)
         checks = check_provider.load(
             repo_full_name=event.repo_full_name,
@@ -293,4 +293,5 @@ def test_ci_feedback_loop_replay_separates_pending_current_head_and_stale_histor
 def _fixture_json(name: str) -> dict[str, object]:
     import json
 
-    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+    payload: dict[str, object] = json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+    return payload

--- a/tests/runtime/test_agent_runtime.py
+++ b/tests/runtime/test_agent_runtime.py
@@ -1,0 +1,134 @@
+"""Tests for provider-neutral Agent Runtime runner contracts."""
+
+from __future__ import annotations
+
+from src.runtime.agent import (
+    AgentRunInput,
+    AgentRunStatus,
+    AgentSessionScope,
+    FakeAgentRunner,
+    WorkflowAgentSessionManager,
+)
+from src.runtime.stages import WorkflowStage
+from src.runtime.tools import AgentFrameworkToolSpec, ToolCapability
+
+
+def test_fake_runner_creates_workflow_scoped_session_and_records_stage_turns() -> None:
+    manager = WorkflowAgentSessionManager(runner=FakeAgentRunner(response="analysis ok"))
+    session = manager.start_workflow_session(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        head_sha="abc123",
+        trigger="manual",
+        correlation_id="corr-session",
+    )
+
+    result = manager.run_stage(
+        session.handle,
+        AgentRunInput(
+            stage=WorkflowStage.ANALYZER,
+            prompt="Analyze this PR",
+            correlation_id="corr-session",
+            allowed_tools=(
+                AgentFrameworkToolSpec(
+                    name="github.pr.diff",
+                    description="Read PR diff",
+                    parameters_schema={"type": "object", "properties": {}},
+                    stage=WorkflowStage.ANALYZER,
+                    capabilities=(ToolCapability.READ,),
+                ),
+            ),
+            max_turns=2,
+            max_tool_calls=3,
+            timeout_seconds=30.0,
+        ),
+    )
+
+    assert session.handle.scope is AgentSessionScope.WORKFLOW
+    assert session.handle.repo_full_name == "Kimcheolhui/qaestro"
+    assert session.handle.pr_number == 42
+    assert session.handle.head_sha == "abc123"
+    assert result.status is AgentRunStatus.SUCCEEDED
+    assert result.output_text == "analysis ok"
+    assert result.stage is WorkflowStage.ANALYZER
+    assert result.allowed_tool_names == ("github.pr.diff",)
+    assert manager.turns_for_session(session.handle.session_id)[0].stage is WorkflowStage.ANALYZER
+
+
+def test_session_manager_reuses_workflow_session_without_widening_stage_tools() -> None:
+    manager = WorkflowAgentSessionManager(runner=FakeAgentRunner(response="ok"))
+    session = manager.start_workflow_session(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        head_sha="abc123",
+        trigger="manual",
+        correlation_id="corr-session",
+    )
+
+    manager.run_stage(
+        session.handle,
+        AgentRunInput(
+            stage=WorkflowStage.ANALYZER,
+            prompt="Analyze",
+            correlation_id="corr-session",
+            allowed_tools=(
+                AgentFrameworkToolSpec(
+                    name="github.pr.diff",
+                    description="Read PR diff",
+                    parameters_schema={"type": "object", "properties": {}},
+                    stage=WorkflowStage.ANALYZER,
+                    capabilities=(ToolCapability.READ,),
+                ),
+            ),
+        ),
+    )
+    manager.run_stage(
+        session.handle,
+        AgentRunInput(
+            stage=WorkflowStage.VALIDATOR,
+            prompt="Validate",
+            correlation_id="corr-session",
+            allowed_tools=(),
+        ),
+    )
+
+    turns = manager.turns_for_session(session.handle.session_id)
+    assert [turn.stage for turn in turns] == [WorkflowStage.ANALYZER, WorkflowStage.VALIDATOR]
+    assert turns[0].allowed_tool_names == ("github.pr.diff",)
+    assert turns[1].allowed_tool_names == ()
+
+
+def test_session_manager_cancels_superseded_head_and_closes_pr_sessions() -> None:
+    manager = WorkflowAgentSessionManager(runner=FakeAgentRunner(response="ok"))
+    old = manager.start_workflow_session(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        head_sha="old-sha",
+        trigger="manual",
+        correlation_id="corr-old",
+    )
+    current = manager.start_workflow_session(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        head_sha="new-sha",
+        trigger="manual",
+        correlation_id="corr-new",
+    )
+
+    cancelled = manager.cancel_superseded_sessions(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        current_head_sha="new-sha",
+        reason="new commit pushed",
+    )
+
+    assert [session.handle.session_id for session in cancelled] == [old.handle.session_id]
+    assert manager.get_session(old.handle.session_id).is_active is False
+    assert manager.get_session(old.handle.session_id).termination_reason == "new commit pushed"
+    assert manager.get_session(current.handle.session_id).is_active is True
+
+    closed = manager.close_pr_sessions(repo_full_name="Kimcheolhui/qaestro", pr_number=42, reason="PR merged")
+
+    assert {session.handle.session_id for session in closed} == {current.handle.session_id}
+    assert manager.get_session(current.handle.session_id).is_active is False
+    assert manager.get_session(current.handle.session_id).termination_reason == "PR merged"

--- a/tests/runtime/test_agent_runtime_config.py
+++ b/tests/runtime/test_agent_runtime_config.py
@@ -1,0 +1,80 @@
+"""Tests for Agent Runtime configuration loading."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider, AppConfig, load_config
+
+
+class TestAgentRuntimeConfig:
+    """Agent Runtime settings are explicit and secret-safe."""
+
+    def test_defaults_keep_agent_runtime_disabled_for_local_development(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = load_config()
+
+        assert isinstance(cfg.agent_runtime, AgentRuntimeConfig)
+        assert cfg.agent_runtime.provider is AgentRuntimeProvider.DISABLED
+        assert cfg.agent_runtime.model == ""
+        assert cfg.agent_runtime.credential_env_var == ""
+        assert cfg.agent_runtime.timeout_seconds == 60.0
+        assert cfg.agent_runtime.max_turns == 8
+        assert cfg.agent_runtime.max_tool_calls == 16
+        assert cfg.agent_runtime.temperature == 0.0
+
+    def test_load_config_reads_qaestro_agent_environment_variables(self) -> None:
+        env = {
+            "QAESTRO_AGENT_PROVIDER": "azure-openai",
+            "QAESTRO_AGENT_MODEL": "gpt-4.1",
+            "QAESTRO_AGENT_DEPLOYMENT": "qaestro-reviewer",
+            "QAESTRO_AGENT_ENDPOINT": "https://example.openai.azure.com/",
+            "QAESTRO_AGENT_BASE_URL": "https://api.example.com/v1",
+            "QAESTRO_AGENT_API_VERSION": "2025-01-01-preview",
+            "QAESTRO_AGENT_CREDENTIAL_ENV_VAR": "QAESTRO_AGENT_API_KEY",
+            "QAESTRO_AGENT_TIMEOUT_SECONDS": "90.5",
+            "QAESTRO_AGENT_MAX_TURNS": "12",
+            "QAESTRO_AGENT_MAX_TOOL_CALLS": "24",
+            "QAESTRO_AGENT_TEMPERATURE": "0.2",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            cfg = load_config()
+
+        assert cfg.agent_runtime == AgentRuntimeConfig(
+            provider=AgentRuntimeProvider.AZURE_OPENAI,
+            model="gpt-4.1",
+            deployment="qaestro-reviewer",
+            endpoint="https://example.openai.azure.com/",
+            base_url="https://api.example.com/v1",
+            api_version="2025-01-01-preview",
+            credential_env_var="QAESTRO_AGENT_API_KEY",
+            timeout_seconds=90.5,
+            max_turns=12,
+            max_tool_calls=24,
+            temperature=0.2,
+        )
+
+    def test_agent_runtime_config_repr_redacts_credential_reference(self) -> None:
+        config = AgentRuntimeConfig(
+            provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+            model="review-model",
+            credential_env_var="SECRET_ENV_NAME",
+        )
+
+        rendered = repr(config)
+
+        assert "SECRET_ENV_NAME" not in rendered
+        assert "credential_env_var=<redacted>" in rendered
+
+    def test_app_config_repr_does_not_leak_agent_credential_reference(self) -> None:
+        cfg = AppConfig(
+            agent_runtime=AgentRuntimeConfig(
+                provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+                model="review-model",
+                credential_env_var="SECRET_ENV_NAME",
+            )
+        )
+
+        assert "SECRET_ENV_NAME" not in repr(cfg)


### PR DESCRIPTION
## Summary
- Adds the provider-neutral `runtime/agent` foundation for Agent Runtime execution.
- Adds explicit `QAESTRO_AGENT_*` typed configuration under `AppConfig.agent_runtime` with secret-safe repr output.
- Defines workflow-scoped agent session handles, stage turn input/result contracts, fake runner support, and lifecycle cleanup for superseded heads / closed PRs.
- Keeps real provider SDK objects out of core/orchestrator contracts; this PR only introduces the fake/provider-neutral foundation.
- Fixes existing replay test type annotations surfaced by strict mypy while running the full suite.

## Design notes
- Default Agent Runtime provider is `disabled`, so local development and CI remain credential-free.
- The session model is ReviewRun/workflow-scoped with stage-scoped execution context: each stage turn must pass its own `WorkflowStage`, allowed tool specs, budget, and sanitized prompt/context.
- Live provider sessions are not durable source-of-truth state. The manager retains only normalized/redacted turn metadata and explicit termination reason.

## Verification
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest`

Closes #65
Closes #66
Closes #72

Generated by Hermes Agent.