### PR TITLE
feat(agent): add runtime capability health checks

### DIFF
--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -69,9 +69,11 @@ PR aggregate는 PR 전체 수명과 대화 history를 유지하고, 그 안에 `
 
 - `BYOK`를 전제로 설계
 - Agent Runtime 설정은 provider, model/deployment id, endpoint/base URL, credential reference, timeout, max turns/tool calls, temperature 같은 실행 예산을 명시적으로 표현해야 한다.
+- 최소 capability policy는 tool/function calling, structured output 또는 schema-constrained response, context window를 별도 설정으로 선언하게 한다. provider가 capability metadata를 안정적으로 주지 않는 경우에도 bootstrap에서 unsupported/degraded/supported 상태를 구분할 수 있어야 한다.
 - Azure OpenAI와 OpenAI-compatible provider는 설정 shape를 분리하되, core 계층은 특정 provider SDK type에 직접 종속되지 않도록 유지한다.
-- credential 값은 config object의 repr, log, report, issue output에 노출하지 않는다.
+- credential 값은 config object의 repr, log, report, issue output에 노출하지 않는다. health check error도 credential 값 대신 env var 이름과 조치 가능한 누락 항목만 보여준다.
 - provider 선택과 session 생성은 `app/worker` 또는 `runtime/agent` adapter/factory 경계에 두고, 테스트에서는 fake provider로 같은 contract를 검증한다.
+- worker bootstrap health check는 offline config/capability validation을 기본으로 하며, 비용이 발생할 수 있는 live provider smoke call은 명시 opt-in 경로로만 수행한다.
 
 ### 7. Queue backend: Redis Streams for process separation
 

--- a/src/app/worker/__init__.py
+++ b/src/app/worker/__init__.py
@@ -16,11 +16,12 @@ from ..jobs import (
     RedisStreamsJobQueue,
 )
 from .entrypoint import main
-from .factory import build_worker
+from .factory import AgentRuntimeUnavailableError, build_worker, check_worker_agent_runtime_health
 from .runner import NoopOutputPoster, Orchestrator, OutputPoster, Worker
 from .types import WorkerExecution, WorkerExecutionContext, WorkerStatus
 
 __all__ = [
+    "AgentRuntimeUnavailableError",
     "EnqueueQueue",
     "EventJob",
     "InMemoryJobQueue",
@@ -36,5 +37,6 @@ __all__ = [
     "WorkerExecutionContext",
     "WorkerStatus",
     "build_worker",
+    "check_worker_agent_runtime_health",
     "main",
 ]

--- a/src/app/worker/entrypoint.py
+++ b/src/app/worker/entrypoint.py
@@ -9,7 +9,7 @@ import sys
 from src.shared import get_logger, load_config, setup_logging
 
 from ..queue_factory import build_job_queue
-from .factory import build_worker
+from .factory import build_worker, check_worker_agent_runtime_health
 
 logger = get_logger(__name__)
 
@@ -24,6 +24,15 @@ def main() -> None:
     cfg = load_config()
     setup_logging(level=cfg.log_level, fmt=cfg.log_format)
     logger.info("qaestro-worker starting")
+    agent_runtime_health = check_worker_agent_runtime_health(cfg)
+    logger.info(
+        "agent runtime health checked",
+        extra={
+            "agent_runtime_provider": agent_runtime_health.provider.value,
+            "agent_runtime_status": agent_runtime_health.status.value,
+            "agent_runtime_warnings": agent_runtime_health.warnings,
+        },
+    )
     queue = build_job_queue(cfg, consumer=cfg.redis_consumer or default_redis_consumer_name())
     worker = build_worker(cfg)
     if cfg.queue_backend == "memory":

--- a/src/app/worker/factory.py
+++ b/src/app/worker/factory.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 from src.adapters.connectors.github import GitHubAppAuth, GitHubClient
 from src.core.contracts import CIFeedbackContext, PREvent
+from src.runtime.agent import AgentRuntimeHealthResult, AgentRuntimeHealthStatus, check_agent_runtime_health
 from src.runtime.orchestrator import (
     CIWorkflowOrchestrator,
     EventOrchestrator,
@@ -23,6 +25,29 @@ from src.runtime.tools.github import build_github_pr_tools
 from src.shared.config import AppConfig
 
 from .runner import Worker
+
+
+class AgentRuntimeUnavailableError(RuntimeError):
+    """Raised when worker bootstrap rejects Agent Runtime configuration."""
+
+
+def check_worker_agent_runtime_health(
+    cfg: AppConfig,
+    *,
+    environ: Mapping[str, str] | None = None,
+    opt_in_live_smoke: bool = False,
+) -> AgentRuntimeHealthResult:
+    """Validate worker Agent Runtime readiness before validation stages use it."""
+
+    health = check_agent_runtime_health(
+        cfg.agent_runtime,
+        environ=environ,
+        opt_in_live_smoke=opt_in_live_smoke,
+    )
+    if health.status is AgentRuntimeHealthStatus.UNSUPPORTED:
+        detail = "; ".join(health.actionable_errors)
+        raise AgentRuntimeUnavailableError(f"Agent Runtime configuration is unsupported: {detail}")
+    return health
 
 
 def build_worker(cfg: AppConfig) -> Worker:

--- a/src/runtime/agent/__init__.py
+++ b/src/runtime/agent/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .fake import FakeAgentRunner
+from .health import AgentRuntimeHealthResult, AgentRuntimeHealthStatus, check_agent_runtime_health
 from .manager import WorkflowAgentSessionManager
 from .types import (
     AgentRunInput,
@@ -19,6 +20,8 @@ __all__ = [
     "AgentRunInput",
     "AgentRunResult",
     "AgentRunStatus",
+    "AgentRuntimeHealthResult",
+    "AgentRuntimeHealthStatus",
     "AgentSessionHandle",
     "AgentSessionRecord",
     "AgentSessionScope",
@@ -26,4 +29,5 @@ __all__ = [
     "AgentSessionTurn",
     "FakeAgentRunner",
     "WorkflowAgentSessionManager",
+    "check_agent_runtime_health",
 ]

--- a/src/runtime/agent/health.py
+++ b/src/runtime/agent/health.py
@@ -1,0 +1,140 @@
+"""Agent Runtime capability policy and offline health checks."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
+
+RECOMMENDED_CONTEXT_WINDOW_TOKENS = 32_000
+
+
+class AgentRuntimeHealthStatus(StrEnum):
+    """Offline health state for an Agent Runtime configuration."""
+
+    DISABLED = "disabled"
+    SUPPORTED = "supported"
+    DEGRADED = "degraded"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class AgentRuntimeHealthResult:
+    """Secret-safe result of checking Agent Runtime readiness.
+
+    This check is intentionally offline by default. Live provider calls can cost
+    money and require network credentials, so provider smoke probes must be
+    explicitly opted in by a future adapter-specific path.
+    """
+
+    provider: AgentRuntimeProvider
+    status: AgentRuntimeHealthStatus
+    actionable_errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {AgentRuntimeHealthStatus.SUPPORTED, AgentRuntimeHealthStatus.DEGRADED}
+
+
+def check_agent_runtime_health(
+    config: AgentRuntimeConfig,
+    *,
+    environ: Mapping[str, str] | None = None,
+    opt_in_live_smoke: bool = False,
+) -> AgentRuntimeHealthResult:
+    """Validate whether ``config`` can support qaestro Agent Runtime execution.
+
+    The policy verifies only configuration and declared capabilities. It does
+    not perform a live LLM call unless a provider adapter later implements the
+    explicit ``opt_in_live_smoke`` path.
+    """
+
+    env = os.environ if environ is None else environ
+    if config.provider is AgentRuntimeProvider.DISABLED:
+        return AgentRuntimeHealthResult(
+            provider=config.provider,
+            status=AgentRuntimeHealthStatus.DISABLED,
+            warnings=("Agent Runtime is disabled; runtime validation will not call an LLM provider.",),
+        )
+
+    provider_errors = _provider_config_errors(config, env)
+    warnings = list(_capability_warnings(config))
+    if provider_errors:
+        return AgentRuntimeHealthResult(
+            provider=config.provider,
+            status=AgentRuntimeHealthStatus.UNSUPPORTED,
+            actionable_errors=provider_errors,
+            warnings=tuple(warnings),
+        )
+
+    capability_errors = _capability_errors(config)
+    if capability_errors:
+        return AgentRuntimeHealthResult(
+            provider=config.provider,
+            status=AgentRuntimeHealthStatus.UNSUPPORTED,
+            actionable_errors=capability_errors,
+            warnings=tuple(warnings),
+        )
+
+    if not opt_in_live_smoke:
+        warnings.append(
+            "Live provider smoke check not executed; set opt_in_live_smoke=True to probe provider connectivity."
+        )
+
+    return AgentRuntimeHealthResult(
+        provider=config.provider,
+        status=AgentRuntimeHealthStatus.DEGRADED if warnings and _has_degradation_warning(warnings) else AgentRuntimeHealthStatus.SUPPORTED,
+        warnings=tuple(warnings),
+    )
+
+
+def _provider_config_errors(config: AgentRuntimeConfig, env: Mapping[str, str]) -> tuple[str, ...]:
+    errors: list[str] = []
+    if config.provider is AgentRuntimeProvider.AZURE_OPENAI:
+        if not config.endpoint:
+            errors.append("Azure OpenAI endpoint is required for QAESTRO_AGENT_ENDPOINT.")
+        if not config.deployment:
+            errors.append("Azure OpenAI deployment is required for QAESTRO_AGENT_DEPLOYMENT.")
+        if not config.api_version:
+            errors.append("Azure OpenAI API version is required for QAESTRO_AGENT_API_VERSION.")
+    elif config.provider is AgentRuntimeProvider.OPENAI_COMPATIBLE:
+        if not config.base_url:
+            errors.append("OpenAI-compatible base URL is required for QAESTRO_AGENT_BASE_URL.")
+        if not config.model:
+            errors.append("OpenAI-compatible model is required for QAESTRO_AGENT_MODEL.")
+    elif config.provider is AgentRuntimeProvider.GITHUB_COPILOT:
+        errors.append("GitHub Copilot is not supported as a non-interactive Agent Runtime provider yet.")
+
+    if not config.credential_env_var:
+        errors.append("Credential environment variable name is required for QAESTRO_AGENT_CREDENTIAL_ENV_VAR.")
+    elif not env.get(config.credential_env_var):
+        errors.append(f"Credential environment variable {config.credential_env_var} is not set.")
+    return tuple(errors)
+
+
+def _capability_errors(config: AgentRuntimeConfig) -> tuple[str, ...]:
+    errors: list[str] = []
+    if not config.supports_tool_calling:
+        errors.append("tool calling is required")
+    if not config.supports_structured_output:
+        errors.append("structured output or schema-constrained responses are required")
+    if config.context_window_tokens <= 0:
+        errors.append("context window token capacity is required for QAESTRO_AGENT_CONTEXT_WINDOW_TOKENS.")
+    return tuple(errors)
+
+
+def _capability_warnings(config: AgentRuntimeConfig) -> tuple[str, ...]:
+    if 0 < config.context_window_tokens < RECOMMENDED_CONTEXT_WINDOW_TOKENS:
+        return (
+            f"Configured context window {config.context_window_tokens} tokens is below the recommended "
+            f"{RECOMMENDED_CONTEXT_WINDOW_TOKENS} tokens.",
+        )
+    return ()
+
+
+def _has_degradation_warning(warnings: list[str]) -> bool:
+    return any("context window" in warning for warning in warnings)

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -41,6 +41,9 @@ class AgentRuntimeConfig:
     max_turns: int = 8
     max_tool_calls: int = 16
     temperature: float = 0.0
+    supports_tool_calling: bool = False
+    supports_structured_output: bool = False
+    context_window_tokens: int = 0
 
     def __repr__(self) -> str:
         credential = "<redacted>" if self.credential_env_var else ""
@@ -56,7 +59,10 @@ class AgentRuntimeConfig:
             f"timeout_seconds={self.timeout_seconds!r}, "
             f"max_turns={self.max_turns!r}, "
             f"max_tool_calls={self.max_tool_calls!r}, "
-            f"temperature={self.temperature!r}"
+            f"temperature={self.temperature!r}, "
+            f"supports_tool_calling={self.supports_tool_calling!r}, "
+            f"supports_structured_output={self.supports_structured_output!r}, "
+            f"context_window_tokens={self.context_window_tokens!r}"
             ")"
         )
 
@@ -167,6 +173,9 @@ _AGENT_ENV_MAP: dict[str, tuple[str, type[Any]]] = {
     "max_turns": ("AGENT_MAX_TURNS", int),
     "max_tool_calls": ("AGENT_MAX_TOOL_CALLS", int),
     "temperature": ("AGENT_TEMPERATURE", float),
+    "supports_tool_calling": ("AGENT_SUPPORTS_TOOL_CALLING", bool),
+    "supports_structured_output": ("AGENT_SUPPORTS_STRUCTURED_OUTPUT", bool),
+    "context_window_tokens": ("AGENT_CONTEXT_WINDOW_TOKENS", int),
 }
 
 

--- a/src/shared/logging.py
+++ b/src/shared/logging.py
@@ -30,6 +30,9 @@ class _JsonFormatter(logging.Formatter):
         # Keep the whitelist explicit so logs stay predictable and don't leak
         # arbitrary objects.
         for key in (
+            "agent_runtime_provider",
+            "agent_runtime_status",
+            "agent_runtime_warnings",
             "attempts",
             "correlation_id",
             "delivery_id",

--- a/tests/app/test_worker_agent_runtime_health.py
+++ b/tests/app/test_worker_agent_runtime_health.py
@@ -1,0 +1,37 @@
+"""Tests for Agent Runtime health check wiring at worker bootstrap."""
+
+from __future__ import annotations
+
+from src.app.worker import AgentRuntimeUnavailableError, check_worker_agent_runtime_health
+from src.runtime.agent import AgentRuntimeHealthStatus
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider, AppConfig
+
+
+def test_worker_agent_runtime_health_allows_disabled_runtime_for_local_development() -> None:
+    result = check_worker_agent_runtime_health(AppConfig())
+
+    assert result.status is AgentRuntimeHealthStatus.DISABLED
+
+
+def test_worker_agent_runtime_health_fails_closed_for_unsupported_config() -> None:
+    cfg = AppConfig(
+        agent_runtime=AgentRuntimeConfig(
+            provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+            model="review-model",
+            base_url="https://llm.example.test/v1",
+            credential_env_var="QAESTRO_AGENT_API_KEY",
+            supports_tool_calling=False,
+            supports_structured_output=True,
+            context_window_tokens=64_000,
+        )
+    )
+
+    try:
+        check_worker_agent_runtime_health(cfg, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+    except AgentRuntimeUnavailableError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("unsupported Agent Runtime config should fail closed")
+
+    assert "tool calling is required" in message
+    assert "super-secret-token" not in message

--- a/tests/runtime/test_agent_runtime_config.py
+++ b/tests/runtime/test_agent_runtime_config.py
@@ -37,6 +37,9 @@ class TestAgentRuntimeConfig:
             "QAESTRO_AGENT_MAX_TURNS": "12",
             "QAESTRO_AGENT_MAX_TOOL_CALLS": "24",
             "QAESTRO_AGENT_TEMPERATURE": "0.2",
+            "QAESTRO_AGENT_SUPPORTS_TOOL_CALLING": "true",
+            "QAESTRO_AGENT_SUPPORTS_STRUCTURED_OUTPUT": "yes",
+            "QAESTRO_AGENT_CONTEXT_WINDOW_TOKENS": "64000",
         }
 
         with patch.dict(os.environ, env, clear=True):
@@ -54,6 +57,9 @@ class TestAgentRuntimeConfig:
             max_turns=12,
             max_tool_calls=24,
             temperature=0.2,
+            supports_tool_calling=True,
+            supports_structured_output=True,
+            context_window_tokens=64_000,
         )
 
     def test_agent_runtime_config_repr_redacts_credential_reference(self) -> None:

--- a/tests/runtime/test_agent_runtime_health.py
+++ b/tests/runtime/test_agent_runtime_health.py
@@ -1,0 +1,110 @@
+"""Tests for Agent Runtime capability policy and health checks."""
+
+from __future__ import annotations
+
+from src.runtime.agent import AgentRuntimeHealthStatus, check_agent_runtime_health
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
+
+
+def test_disabled_agent_runtime_health_is_disabled_without_credentials() -> None:
+    result = check_agent_runtime_health(AgentRuntimeConfig())
+
+    assert result.status is AgentRuntimeHealthStatus.DISABLED
+    assert result.provider is AgentRuntimeProvider.DISABLED
+    assert result.actionable_errors == ()
+    assert result.warnings == ("Agent Runtime is disabled; runtime validation will not call an LLM provider.",)
+
+
+def test_openai_compatible_runtime_requires_tool_calling_and_structured_output() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+        model="small-chat-model",
+        base_url="https://llm.example.test/v1",
+        credential_env_var="QAESTRO_AGENT_API_KEY",
+        supports_tool_calling=False,
+        supports_structured_output=False,
+        context_window_tokens=16_000,
+    )
+
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+
+    assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
+    assert result.ok is False
+    assert "tool calling is required" in result.actionable_errors
+    assert "structured output or schema-constrained responses are required" in result.actionable_errors
+    assert "super-secret-token" not in repr(result)
+    assert "super-secret-token" not in str(result.actionable_errors)
+
+
+def test_azure_openai_runtime_reports_missing_endpoint_deployment_api_version_and_credential() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.AZURE_OPENAI,
+        credential_env_var="QAESTRO_AZURE_OPENAI_KEY",
+    )
+
+    result = check_agent_runtime_health(config, environ={})
+
+    assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
+    assert result.actionable_errors == (
+        "Azure OpenAI endpoint is required for QAESTRO_AGENT_ENDPOINT.",
+        "Azure OpenAI deployment is required for QAESTRO_AGENT_DEPLOYMENT.",
+        "Azure OpenAI API version is required for QAESTRO_AGENT_API_VERSION.",
+        "Credential environment variable QAESTRO_AZURE_OPENAI_KEY is not set.",
+    )
+
+
+def test_enabled_runtime_requires_declared_context_window() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+        model="review-model",
+        base_url="https://llm.example.test/v1",
+        credential_env_var="QAESTRO_AGENT_API_KEY",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=0,
+    )
+
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+
+    assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
+    assert result.ok is False
+    assert result.actionable_errors == ("context window token capacity is required for QAESTRO_AGENT_CONTEXT_WINDOW_TOKENS.",)
+
+
+def test_supported_runtime_can_warn_when_live_smoke_is_not_enabled() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+        model="review-model",
+        base_url="https://llm.example.test/v1",
+        credential_env_var="QAESTRO_AGENT_API_KEY",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=64_000,
+    )
+
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+
+    assert result.status is AgentRuntimeHealthStatus.SUPPORTED
+    assert result.ok is True
+    assert result.actionable_errors == ()
+    assert result.warnings == ("Live provider smoke check not executed; set opt_in_live_smoke=True to probe provider connectivity.",)
+    assert "super-secret-token" not in repr(result)
+
+
+def test_capability_policy_marks_small_context_window_as_degraded() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+        model="review-model",
+        base_url="https://llm.example.test/v1",
+        credential_env_var="QAESTRO_AGENT_API_KEY",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=8_000,
+    )
+
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+
+    assert result.status is AgentRuntimeHealthStatus.DEGRADED
+    assert result.ok is True
+    assert result.actionable_errors == ()
+    assert result.warnings[0] == "Configured context window 8000 tokens is below the recommended 32000 tokens."

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,28 @@
+"""Tests for structured logging field allowlist."""
+
+from __future__ import annotations
+
+import io
+import json
+
+from src.shared import get_logger, setup_logging
+
+
+def test_json_formatter_includes_agent_runtime_health_fields_without_credentials() -> None:
+    stream = io.StringIO()
+    setup_logging(fmt="json", stream=stream)
+
+    get_logger("tests.logging").info(
+        "agent runtime health checked",
+        extra={
+            "agent_runtime_provider": "openai-compatible",
+            "agent_runtime_status": "supported",
+            "agent_runtime_warnings": ("Live provider smoke check not executed",),
+        },
+    )
+
+    payload = json.loads(stream.getvalue())
+
+    assert payload["agent_runtime_provider"] == "openai-compatible"
+    assert payload["agent_runtime_status"] == "supported"
+    assert payload["agent_runtime_warnings"] == ["Live provider smoke check not executed"]


### PR DESCRIPTION
## Summary

This PR completes the Step 5 slice for Agent Runtime capability policy and bootstrap health checks. The previous PR established the provider-neutral session/runner contract, but an enabled provider could still be configured without proving that the selected model supports qaestro's minimum runtime needs. This change makes that preflight explicit before Step 6 starts depending on real validation execution.

The new health check classifies Agent Runtime configuration as `disabled`, `supported`, `degraded`, or `unsupported`. Disabled remains valid for local development. Enabled providers now fail closed when required provider settings, credentials, tool calling, structured output, or context window declaration are missing. Small-but-declared context windows are treated as degraded rather than silently accepted as ideal.

## What changed

- Adds declared model capability fields to `AgentRuntimeConfig`: tool calling, structured/schema output, and context window tokens.
- Adds `runtime/agent` health checking with actionable, secret-safe errors for unsupported configuration.
- Wires worker startup through `check_worker_agent_runtime_health()` so unsupported Agent Runtime settings fail before validation stages attempt to run.
- Keeps live provider smoke checks opt-in only; the default path is offline config/capability validation to avoid unexpected cost or network dependency.
- Adds structured logging fields for agent runtime health status without logging credential values.
- Records the capability/health-check policy in `docs/TECH_DECISIONS.md`.

## Review focus

- Check whether `unsupported` vs `degraded` is the right boundary: missing/unknown required capability fails closed, while a declared but smaller context window warns.
- Check that health-check output remains actionable without leaking credential values.
- Check whether the worker startup placement is the right bootstrap boundary before real provider adapters are added.

## Scope / follow-up

This does not implement a real Azure OpenAI/OpenAI-compatible adapter and does not perform live LLM connectivity checks. The live smoke path is intentionally only represented as an opt-in seam for the provider-adapter PRs.

## Verification

- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest` — 248 passed
- Static security scan over staged diff — no findings
- Independent pre-commit review passed after fixing the context-window fail-closed edge case

Closes #69

---
🤖 *Created by Hermes Agent*
