### PR TITLE
fix(agent): clarify live smoke health status

### DIFF
--- a/src/runtime/agent/__init__.py
+++ b/src/runtime/agent/__init__.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from .fake import FakeAgentRunner
-from .health import AgentRuntimeHealthResult, AgentRuntimeHealthStatus, check_agent_runtime_health
+from .health import (
+    AgentRuntimeHealthResult,
+    AgentRuntimeHealthStatus,
+    LiveSmokeProbeStatus,
+    check_agent_runtime_health,
+)
 from .manager import WorkflowAgentSessionManager
 from .types import (
     AgentRunInput,
@@ -28,6 +33,7 @@ __all__ = [
     "AgentSessionStatus",
     "AgentSessionTurn",
     "FakeAgentRunner",
+    "LiveSmokeProbeStatus",
     "WorkflowAgentSessionManager",
     "check_agent_runtime_health",
 ]

--- a/src/runtime/agent/health.py
+++ b/src/runtime/agent/health.py
@@ -21,6 +21,13 @@ class AgentRuntimeHealthStatus(StrEnum):
     UNSUPPORTED = "unsupported"
 
 
+class LiveSmokeProbeStatus(StrEnum):
+    """Whether an opt-in live provider smoke probe actually ran."""
+
+    NOT_REQUESTED = "not_requested"
+    NOT_IMPLEMENTED = "not_implemented"
+
+
 @dataclass(frozen=True)
 class AgentRuntimeHealthResult:
     """Secret-safe result of checking Agent Runtime readiness.
@@ -34,6 +41,7 @@ class AgentRuntimeHealthResult:
     status: AgentRuntimeHealthStatus
     actionable_errors: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
+    live_smoke_probe_status: LiveSmokeProbeStatus = LiveSmokeProbeStatus.NOT_REQUESTED
 
     @property
     def ok(self) -> bool:
@@ -80,15 +88,22 @@ def check_agent_runtime_health(
             warnings=tuple(warnings),
         )
 
-    if not opt_in_live_smoke:
+    if opt_in_live_smoke:
+        warnings.append("Live provider smoke check was requested but no provider adapter implements it yet.")
+        live_smoke_probe_status = LiveSmokeProbeStatus.NOT_IMPLEMENTED
+    else:
         warnings.append(
             "Live provider smoke check not executed; set opt_in_live_smoke=True to probe provider connectivity."
         )
+        live_smoke_probe_status = LiveSmokeProbeStatus.NOT_REQUESTED
 
     return AgentRuntimeHealthResult(
         provider=config.provider,
-        status=AgentRuntimeHealthStatus.DEGRADED if warnings and _has_degradation_warning(warnings) else AgentRuntimeHealthStatus.SUPPORTED,
+        status=AgentRuntimeHealthStatus.DEGRADED
+        if warnings and _has_degradation_warning(warnings)
+        else AgentRuntimeHealthStatus.SUPPORTED,
         warnings=tuple(warnings),
+        live_smoke_probe_status=live_smoke_probe_status,
     )
 
 

--- a/tests/runtime/test_agent_runtime_health.py
+++ b/tests/runtime/test_agent_runtime_health.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from src.runtime.agent import AgentRuntimeHealthStatus, check_agent_runtime_health
+from src.runtime.agent import AgentRuntimeHealthStatus, LiveSmokeProbeStatus, check_agent_runtime_health
 from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
 
 
@@ -68,7 +68,9 @@ def test_enabled_runtime_requires_declared_context_window() -> None:
 
     assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
     assert result.ok is False
-    assert result.actionable_errors == ("context window token capacity is required for QAESTRO_AGENT_CONTEXT_WINDOW_TOKENS.",)
+    assert result.actionable_errors == (
+        "context window token capacity is required for QAESTRO_AGENT_CONTEXT_WINDOW_TOKENS.",
+    )
 
 
 def test_supported_runtime_can_warn_when_live_smoke_is_not_enabled() -> None:
@@ -87,7 +89,33 @@ def test_supported_runtime_can_warn_when_live_smoke_is_not_enabled() -> None:
     assert result.status is AgentRuntimeHealthStatus.SUPPORTED
     assert result.ok is True
     assert result.actionable_errors == ()
-    assert result.warnings == ("Live provider smoke check not executed; set opt_in_live_smoke=True to probe provider connectivity.",)
+    assert result.warnings == (
+        "Live provider smoke check not executed; set opt_in_live_smoke=True to probe provider connectivity.",
+    )
+    assert result.live_smoke_probe_status is LiveSmokeProbeStatus.NOT_REQUESTED
+    assert "super-secret-token" not in repr(result)
+
+
+def test_opt_in_live_smoke_is_explicitly_not_implemented_until_provider_adapter_exists() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+        model="review-model",
+        base_url="https://llm.example.test/v1",
+        credential_env_var="QAESTRO_AGENT_API_KEY",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=64_000,
+    )
+
+    result = check_agent_runtime_health(
+        config,
+        environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"},
+        opt_in_live_smoke=True,
+    )
+
+    assert result.status is AgentRuntimeHealthStatus.SUPPORTED
+    assert result.live_smoke_probe_status is LiveSmokeProbeStatus.NOT_IMPLEMENTED
+    assert result.warnings == ("Live provider smoke check was requested but no provider adapter implements it yet.",)
     assert "super-secret-token" not in repr(result)
 
 


### PR DESCRIPTION
## Summary

This is a small follow-up after #74. The merged PR had already passed local checks, but CI showed that `ruff format --check` would reformat two files. This PR applies the formatting and also makes the `opt_in_live_smoke=True` seam explicit so callers cannot mistake the current health check for an actual live provider connectivity probe.

## What changed

- Applies Ruff formatting to the Agent Runtime health-check files that failed CI format check.
- Adds `LiveSmokeProbeStatus` to the public Agent Runtime API.
- Records `NOT_REQUESTED` when the default offline health check runs.
- Records `NOT_IMPLEMENTED` with an explicit warning when `opt_in_live_smoke=True` is requested before a real provider adapter implements live probing.

## Review focus

Check whether `NOT_IMPLEMENTED` is the right interim status for the opt-in seam. The important boundary is that `opt_in_live_smoke=True` must not imply that network/provider connectivity was actually verified until provider adapters add that behavior.

## Verification

- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest` — 249 passed
- Static security scan over staged diff — no findings
- Independent pre-commit review passed

Refs #69

---
🤖 *Created by Hermes Agent*
