### PR TITLE
feat(agent): add openai-compatible provider boundary

### DIFF
--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -71,7 +71,7 @@ PR aggregate는 PR 전체 수명과 대화 history를 유지하고, 그 안에 `
 - Agent Runtime 설정은 provider, model/deployment id, endpoint/base URL, credential reference, timeout, max turns/tool calls, temperature 같은 실행 예산을 명시적으로 표현해야 한다.
 - 최소 capability policy는 tool/function calling, structured output 또는 schema-constrained response, context window를 별도 설정으로 선언하게 한다. provider가 capability metadata를 안정적으로 주지 않는 경우에도 bootstrap에서 unsupported/degraded/supported 상태를 구분할 수 있어야 한다.
 - Azure OpenAI와 OpenAI-compatible provider는 설정 shape를 분리하되, core 계층은 특정 provider SDK type에 직접 종속되지 않도록 유지한다.
-- OpenAI-compatible 계열은 `base_url` + `model` + API key env var를 기본 shape로 두고, runner factory는 provider-neutral `AgentRunner` 뒤에 좁은 client protocol을 주입받는다. Step 5에서는 실제 HTTP/SDK live client를 만들지 않고 mocked client로 contract를 검증한다.
+- OpenAI-compatible 계열은 `base_url` + `model` + API key env var를 기본 shape로 두고, runner factory는 provider-neutral `AgentRunner` 뒤에 좁은 client protocol을 주입받는다. Step 5에서는 실제 HTTP/SDK live client를 만들지 않고 mocked client로 contract를 검증한다. organization/project headers처럼 HTTP 요청 표면에 직접 묶이는 옵션은 live adapter 구현 시점으로 defer하여, 아직 확정되지 않은 header shape가 runtime contract를 불필요하게 키우지 않도록 한다.
 - GitHub Copilot은 self-hosted 비대화형 runtime provider로 직접 지원하지 않는다. 인증/정책/ToS와 비대화형 사용 경계가 명확해지기 전까지는 explicit unsupported provider로 남기고, OpenAI-compatible endpoint 또는 Azure OpenAI를 지원 경로로 둔다.
 - credential 값은 config object의 repr, log, report, issue output에 노출하지 않는다. health check error도 credential 값 대신 env var 이름과 조치 가능한 누락 항목만 보여준다.
 - provider 선택과 session 생성은 `app/worker` 또는 `runtime/agent` adapter/factory 경계에 두고, 테스트에서는 fake provider로 같은 contract를 검증한다.

--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -71,6 +71,8 @@ PR aggregate는 PR 전체 수명과 대화 history를 유지하고, 그 안에 `
 - Agent Runtime 설정은 provider, model/deployment id, endpoint/base URL, credential reference, timeout, max turns/tool calls, temperature 같은 실행 예산을 명시적으로 표현해야 한다.
 - 최소 capability policy는 tool/function calling, structured output 또는 schema-constrained response, context window를 별도 설정으로 선언하게 한다. provider가 capability metadata를 안정적으로 주지 않는 경우에도 bootstrap에서 unsupported/degraded/supported 상태를 구분할 수 있어야 한다.
 - Azure OpenAI와 OpenAI-compatible provider는 설정 shape를 분리하되, core 계층은 특정 provider SDK type에 직접 종속되지 않도록 유지한다.
+- OpenAI-compatible 계열은 `base_url` + `model` + API key env var를 기본 shape로 두고, runner factory는 provider-neutral `AgentRunner` 뒤에 좁은 client protocol을 주입받는다. Step 5에서는 실제 HTTP/SDK live client를 만들지 않고 mocked client로 contract를 검증한다.
+- GitHub Copilot은 self-hosted 비대화형 runtime provider로 직접 지원하지 않는다. 인증/정책/ToS와 비대화형 사용 경계가 명확해지기 전까지는 explicit unsupported provider로 남기고, OpenAI-compatible endpoint 또는 Azure OpenAI를 지원 경로로 둔다.
 - credential 값은 config object의 repr, log, report, issue output에 노출하지 않는다. health check error도 credential 값 대신 env var 이름과 조치 가능한 누락 항목만 보여준다.
 - provider 선택과 session 생성은 `app/worker` 또는 `runtime/agent` adapter/factory 경계에 두고, 테스트에서는 fake provider로 같은 contract를 검증한다.
 - worker bootstrap health check는 offline config/capability validation을 기본으로 하며, 비용이 발생할 수 있는 live provider smoke call은 명시 opt-in 경로로만 수행한다.

--- a/src/runtime/agent/__init__.py
+++ b/src/runtime/agent/__init__.py
@@ -10,6 +10,13 @@ from .health import (
     check_agent_runtime_health,
 )
 from .manager import WorkflowAgentSessionManager
+from .openai_compatible import (
+    OpenAICompatibleAgentRunner,
+    OpenAICompatibleChatClient,
+    OpenAICompatibleClientResponse,
+    UnsupportedAgentRuntimeProviderError,
+    build_agent_runner,
+)
 from .types import (
     AgentRunInput,
     AgentRunResult,
@@ -34,6 +41,11 @@ __all__ = [
     "AgentSessionTurn",
     "FakeAgentRunner",
     "LiveSmokeProbeStatus",
+    "OpenAICompatibleAgentRunner",
+    "OpenAICompatibleChatClient",
+    "OpenAICompatibleClientResponse",
+    "UnsupportedAgentRuntimeProviderError",
     "WorkflowAgentSessionManager",
+    "build_agent_runner",
     "check_agent_runtime_health",
 ]

--- a/src/runtime/agent/health.py
+++ b/src/runtime/agent/health.py
@@ -122,7 +122,7 @@ def _provider_config_errors(config: AgentRuntimeConfig, env: Mapping[str, str]) 
         if not config.model:
             errors.append("OpenAI-compatible model is required for QAESTRO_AGENT_MODEL.")
     elif config.provider is AgentRuntimeProvider.GITHUB_COPILOT:
-        errors.append("GitHub Copilot is not supported as a non-interactive Agent Runtime provider yet.")
+        return ("GitHub Copilot is not supported as a non-interactive Agent Runtime provider yet.",)
 
     if not config.credential_env_var:
         errors.append("Credential environment variable name is required for QAESTRO_AGENT_CREDENTIAL_ENV_VAR.")

--- a/src/runtime/agent/openai_compatible.py
+++ b/src/runtime/agent/openai_compatible.py
@@ -43,7 +43,16 @@ class OpenAICompatibleAgentRunner(AgentRunner):
         return handle
 
     def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
-        response = self._client.complete(self._request_for(session=session, run_input=run_input))
+        try:
+            response = self._client.complete(self._request_for(session=session, run_input=run_input))
+        except Exception as exc:
+            return AgentRunResult(
+                session=session,
+                stage=run_input.stage,
+                status=AgentRunStatus.FAILED,
+                error=_redact_secret(str(exc), self._credential),
+                allowed_tool_names=run_input.allowed_tool_names,
+            )
         if response.error:
             return AgentRunResult(
                 session=session,
@@ -71,9 +80,13 @@ class OpenAICompatibleAgentRunner(AgentRunner):
             "prompt": run_input.prompt,
             "stage": run_input.stage.value,
             "correlation_id": run_input.correlation_id,
-            "timeout_seconds": run_input.timeout_seconds or self._config.timeout_seconds,
-            "max_turns": run_input.max_turns or self._config.max_turns,
-            "max_tool_calls": run_input.max_tool_calls or self._config.max_tool_calls,
+            "timeout_seconds": self._config.timeout_seconds
+            if run_input.timeout_seconds is None
+            else run_input.timeout_seconds,
+            "max_turns": self._config.max_turns if run_input.max_turns is None else run_input.max_turns,
+            "max_tool_calls": self._config.max_tool_calls
+            if run_input.max_tool_calls is None
+            else run_input.max_tool_calls,
             "temperature": self._config.temperature,
             "tool_names": run_input.allowed_tool_names,
             "credential_present": bool(self._credential),

--- a/src/runtime/agent/openai_compatible.py
+++ b/src/runtime/agent/openai_compatible.py
@@ -1,0 +1,119 @@
+"""OpenAI-compatible Agent Runtime provider boundary."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.runtime.agent.health import AgentRuntimeHealthStatus, check_agent_runtime_health
+from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunResult, AgentRunStatus, AgentSessionHandle
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
+
+
+@dataclass(frozen=True)
+class OpenAICompatibleClientResponse:
+    """Provider-adapter response normalized before entering qaestro contracts."""
+
+    output_text: str
+    error: str = ""
+
+
+class OpenAICompatibleChatClient(Protocol):
+    """Minimal mocked/live client seam for OpenAI-compatible chat completion."""
+
+    def complete(self, request: dict[str, object]) -> OpenAICompatibleClientResponse: ...
+
+
+class OpenAICompatibleAgentRunner(AgentRunner):
+    """Provider-neutral runner backed by an OpenAI-compatible client seam.
+
+    This adapter intentionally accepts a narrow client protocol instead of a
+    concrete SDK object. Tests can inject a fake client without credentials, and
+    future live clients can translate this request shape to a specific SDK/API.
+    """
+
+    def __init__(self, *, config: AgentRuntimeConfig, client: OpenAICompatibleChatClient, credential: str) -> None:
+        self._config = config
+        self._client = client
+        self._credential = credential
+
+    def start_session(self, handle: AgentSessionHandle) -> AgentSessionHandle:
+        return handle
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        response = self._client.complete(self._request_for(session=session, run_input=run_input))
+        if response.error:
+            return AgentRunResult(
+                session=session,
+                stage=run_input.stage,
+                status=AgentRunStatus.FAILED,
+                error=_redact_secret(response.error, self._credential),
+                allowed_tool_names=run_input.allowed_tool_names,
+            )
+        return AgentRunResult(
+            session=session,
+            stage=run_input.stage,
+            status=AgentRunStatus.SUCCEEDED,
+            output_text=response.output_text,
+            allowed_tool_names=run_input.allowed_tool_names,
+        )
+
+    def close_session(self, handle: AgentSessionHandle, *, reason: str) -> None:
+        _ = (handle, reason)
+
+    def _request_for(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> dict[str, object]:
+        _ = session
+        return {
+            "base_url": self._config.base_url,
+            "model": self._config.model,
+            "prompt": run_input.prompt,
+            "stage": run_input.stage.value,
+            "correlation_id": run_input.correlation_id,
+            "timeout_seconds": run_input.timeout_seconds or self._config.timeout_seconds,
+            "max_turns": run_input.max_turns or self._config.max_turns,
+            "max_tool_calls": run_input.max_tool_calls or self._config.max_tool_calls,
+            "temperature": self._config.temperature,
+            "tool_names": run_input.allowed_tool_names,
+            "credential_present": bool(self._credential),
+        }
+
+
+class UnsupportedAgentRuntimeProviderError(ValueError):
+    """Raised when runner construction rejects provider config."""
+
+
+def build_agent_runner(
+    config: AgentRuntimeConfig,
+    *,
+    environ: Mapping[str, str] | None = None,
+    openai_compatible_client: OpenAICompatibleChatClient | None = None,
+) -> AgentRunner:
+    """Build a provider-neutral runner from Agent Runtime configuration."""
+
+    env = os.environ if environ is None else environ
+    health = check_agent_runtime_health(config, environ=env)
+    if health.status is AgentRuntimeHealthStatus.UNSUPPORTED:
+        raise UnsupportedAgentRuntimeProviderError("; ".join(health.actionable_errors))
+
+    if config.provider is AgentRuntimeProvider.OPENAI_COMPATIBLE:
+        if openai_compatible_client is None:
+            raise UnsupportedAgentRuntimeProviderError(
+                "OpenAI-compatible runner requires an injected client until a live adapter is configured."
+            )
+        return OpenAICompatibleAgentRunner(
+            config=config,
+            client=openai_compatible_client,
+            credential=env.get(config.credential_env_var, ""),
+        )
+
+    raise UnsupportedAgentRuntimeProviderError(
+        f"Agent Runtime provider {config.provider.value!r} is not implemented yet."
+    )
+
+
+def _redact_secret(value: str, secret: str) -> str:
+    if not secret:
+        return value
+    return value.replace(secret, "<redacted>")

--- a/tests/runtime/test_agent_runtime_health.py
+++ b/tests/runtime/test_agent_runtime_health.py
@@ -53,6 +53,17 @@ def test_azure_openai_runtime_reports_missing_endpoint_deployment_api_version_an
     )
 
 
+def test_github_copilot_runtime_reports_unsupported_without_credential_requirement() -> None:
+    config = AgentRuntimeConfig(provider=AgentRuntimeProvider.GITHUB_COPILOT)
+
+    result = check_agent_runtime_health(config, environ={})
+
+    assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
+    assert result.actionable_errors == (
+        "GitHub Copilot is not supported as a non-interactive Agent Runtime provider yet.",
+    )
+
+
 def test_enabled_runtime_requires_declared_context_window() -> None:
     config = AgentRuntimeConfig(
         provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,

--- a/tests/runtime/test_openai_compatible_provider.py
+++ b/tests/runtime/test_openai_compatible_provider.py
@@ -26,6 +26,12 @@ class RecordingOpenAICompatibleClient(OpenAICompatibleChatClient):
         return self.response
 
 
+class FailingOpenAICompatibleClient(OpenAICompatibleChatClient):
+    def complete(self, request: dict[str, object]) -> OpenAICompatibleClientResponse:
+        _ = request
+        raise TimeoutError("provider timed out with credential super-secret-token")
+
+
 def _supported_config() -> AgentRuntimeConfig:
     return AgentRuntimeConfig(
         provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
@@ -113,6 +119,48 @@ def test_openai_compatible_runner_normalizes_client_errors_without_secret_value(
 
     assert result.status is AgentRunStatus.FAILED
     assert result.error == "provider unavailable: <redacted>"
+
+
+def test_openai_compatible_runner_preserves_explicit_zero_budgets() -> None:
+    client = RecordingOpenAICompatibleClient(OpenAICompatibleClientResponse(output_text="analysis ok"))
+    runner = OpenAICompatibleAgentRunner(
+        config=_supported_config(),
+        client=client,
+        credential="super-secret-token",
+    )
+
+    result = runner.run(
+        session=_session(),
+        run_input=AgentRunInput(
+            stage=WorkflowStage.VALIDATOR,
+            prompt="Validate without tools",
+            correlation_id="corr-1",
+            timeout_seconds=0.0,
+            max_turns=0,
+            max_tool_calls=0,
+        ),
+    )
+
+    assert result.status is AgentRunStatus.SUCCEEDED
+    assert client.calls[0]["timeout_seconds"] == 0.0
+    assert client.calls[0]["max_turns"] == 0
+    assert client.calls[0]["max_tool_calls"] == 0
+
+
+def test_openai_compatible_runner_normalizes_client_exceptions_without_secret_value() -> None:
+    runner = OpenAICompatibleAgentRunner(
+        config=_supported_config(),
+        client=FailingOpenAICompatibleClient(),
+        credential="super-secret-token",
+    )
+
+    result = runner.run(
+        session=_session(),
+        run_input=AgentRunInput(stage=WorkflowStage.VALIDATOR, prompt="Validate", correlation_id="corr-1"),
+    )
+
+    assert result.status is AgentRunStatus.FAILED
+    assert result.error == "provider timed out with credential <redacted>"
 
 
 def test_agent_runner_factory_builds_openai_compatible_runner_from_env() -> None:

--- a/tests/runtime/test_openai_compatible_provider.py
+++ b/tests/runtime/test_openai_compatible_provider.py
@@ -1,0 +1,146 @@
+"""Tests for OpenAI-compatible Agent Runtime provider boundary."""
+
+from __future__ import annotations
+
+from src.runtime.agent import (
+    AgentRunInput,
+    AgentRunStatus,
+    AgentSessionHandle,
+    AgentSessionScope,
+    OpenAICompatibleAgentRunner,
+    OpenAICompatibleChatClient,
+    OpenAICompatibleClientResponse,
+    build_agent_runner,
+)
+from src.runtime.stages import WorkflowStage
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
+
+
+class RecordingOpenAICompatibleClient(OpenAICompatibleChatClient):
+    def __init__(self, response: OpenAICompatibleClientResponse) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+
+    def complete(self, request: dict[str, object]) -> OpenAICompatibleClientResponse:
+        self.calls.append(request)
+        return self.response
+
+
+def _supported_config() -> AgentRuntimeConfig:
+    return AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.OPENAI_COMPATIBLE,
+        model="review-model",
+        base_url="https://llm.example.test/v1",
+        credential_env_var="QAESTRO_AGENT_API_KEY",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=64_000,
+        timeout_seconds=45.0,
+        max_turns=4,
+        max_tool_calls=6,
+        temperature=0.1,
+    )
+
+
+def _session() -> AgentSessionHandle:
+    return AgentSessionHandle(
+        session_id="session-1",
+        scope=AgentSessionScope.WORKFLOW,
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=76,
+        head_sha="abc123",
+        trigger="manual",
+        correlation_id="corr-1",
+    )
+
+
+def test_openai_compatible_runner_builds_provider_neutral_request_without_secret_value() -> None:
+    client = RecordingOpenAICompatibleClient(OpenAICompatibleClientResponse(output_text="analysis ok"))
+    runner = OpenAICompatibleAgentRunner(
+        config=_supported_config(),
+        client=client,
+        credential="super-secret-token",
+    )
+    session = runner.start_session(_session())
+
+    result = runner.run(
+        session=session,
+        run_input=AgentRunInput(
+            stage=WorkflowStage.VALIDATOR,
+            prompt="Validate the PR",
+            correlation_id="corr-1",
+            max_turns=2,
+            max_tool_calls=3,
+            timeout_seconds=30.0,
+        ),
+    )
+
+    assert result.status is AgentRunStatus.SUCCEEDED
+    assert result.output_text == "analysis ok"
+    assert result.stage is WorkflowStage.VALIDATOR
+    assert client.calls == [
+        {
+            "base_url": "https://llm.example.test/v1",
+            "model": "review-model",
+            "prompt": "Validate the PR",
+            "stage": "validator",
+            "correlation_id": "corr-1",
+            "timeout_seconds": 30.0,
+            "max_turns": 2,
+            "max_tool_calls": 3,
+            "temperature": 0.1,
+            "tool_names": (),
+            "credential_present": True,
+        }
+    ]
+    assert "super-secret-token" not in repr(client.calls[0])
+
+
+def test_openai_compatible_runner_normalizes_client_errors_without_secret_value() -> None:
+    client = RecordingOpenAICompatibleClient(
+        OpenAICompatibleClientResponse(output_text="", error="provider unavailable: super-secret-token")
+    )
+    runner = OpenAICompatibleAgentRunner(
+        config=_supported_config(),
+        client=client,
+        credential="super-secret-token",
+    )
+
+    result = runner.run(
+        session=_session(),
+        run_input=AgentRunInput(stage=WorkflowStage.VALIDATOR, prompt="Validate", correlation_id="corr-1"),
+    )
+
+    assert result.status is AgentRunStatus.FAILED
+    assert result.error == "provider unavailable: <redacted>"
+
+
+def test_agent_runner_factory_builds_openai_compatible_runner_from_env() -> None:
+    runner = build_agent_runner(
+        _supported_config(),
+        environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"},
+        openai_compatible_client=RecordingOpenAICompatibleClient(OpenAICompatibleClientResponse(output_text="ok")),
+    )
+
+    assert isinstance(runner, OpenAICompatibleAgentRunner)
+
+
+def test_agent_runner_factory_rejects_github_copilot_as_unsupported_provider() -> None:
+    config = AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.GITHUB_COPILOT,
+        model="copilot",
+        credential_env_var="QAESTRO_COPILOT_TOKEN",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=64_000,
+    )
+
+    try:
+        build_agent_runner(config, environ={"QAESTRO_COPILOT_TOKEN": "super-secret-token"})
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("GitHub Copilot provider should be unsupported for non-interactive runtime")
+
+    assert "GitHub Copilot is not supported as a non-interactive Agent Runtime provider yet." in message
+    assert "super-secret-token" not in message


### PR DESCRIPTION
## Summary

This PR completes the Step 5 provider-boundary slice for #68. After the Agent Runtime health policy and live-smoke seam were merged, the remaining question was how qaestro should treat OpenAI-compatible endpoints and GitHub Copilot before real provider SDKs are introduced.

The chosen shape is intentionally narrow: OpenAI-compatible support is represented as a provider-neutral `AgentRunner` backed by an injected client protocol. Tests use a mocked client, so the contract can be verified without credentials or live network calls. GitHub Copilot is kept as an explicit unsupported provider for non-interactive self-hosted runtime use until its auth/policy/ToS boundary is clear.

## What changed

- Adds `OpenAICompatibleAgentRunner` behind the existing provider-neutral Agent Runtime contract.
- Adds a narrow `OpenAICompatibleChatClient` protocol and normalized client response type so tests/future live clients do not leak SDK objects into core runtime contracts.
- Adds `build_agent_runner()` factory behavior for OpenAI-compatible configuration and explicit unsupported-provider errors.
- Keeps credential values out of provider request shape; the request only records `credential_present`.
- Redacts credential values from provider/client error strings before returning `AgentRunResult`.
- Documents the OpenAI-compatible config shape and GitHub Copilot non-goal in `docs/TECH_DECISIONS.md`.

## Review focus

- Check whether the OpenAI-compatible request boundary is narrow enough for Step 5 without prematurely designing a full HTTP/SDK client.
- Check whether keeping GitHub Copilot unsupported is the right product boundary for self-hosted non-interactive runtime execution.
- Check that provider-specific details remain behind `runtime/agent` and do not leak into core/orchestrator contracts.

## Scope / follow-up

This PR does not implement live HTTP calls to OpenAI-compatible endpoints. A future adapter can translate the injected client protocol to an actual SDK/API call, including full tool/function metadata. Azure OpenAI remains separate in #67.

## Verification

- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest` — 253 passed
- Static security scan over staged diff — no findings
- Independent pre-commit review passed

Closes #68

---
🤖 *Created by Hermes Agent*
