### PR TITLE
feat(agent): add azure openai provider adapter

### DIFF
--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -71,8 +71,9 @@ PR aggregate는 PR 전체 수명과 대화 history를 유지하고, 그 안에 `
 - Agent Runtime 설정은 provider, model/deployment id, endpoint/base URL, credential reference, timeout, max turns/tool calls, temperature 같은 실행 예산을 명시적으로 표현해야 한다.
 - 최소 capability policy는 tool/function calling, structured output 또는 schema-constrained response, context window를 별도 설정으로 선언하게 한다. provider가 capability metadata를 안정적으로 주지 않는 경우에도 bootstrap에서 unsupported/degraded/supported 상태를 구분할 수 있어야 한다.
 - Azure OpenAI와 OpenAI-compatible provider는 설정 shape를 분리하되, core 계층은 특정 provider SDK type에 직접 종속되지 않도록 유지한다.
+- Azure OpenAI는 `endpoint` + `deployment` + `api_version` + credential env var를 기본 shape로 둔다. `endpoint`는 Azure OpenAI v1 base URL(`.../openai/v1`)이며 live smoke는 명시 opt-in일 때만 `/responses`에 1회 호출한다.
 - OpenAI-compatible 계열은 `base_url` + `model` + API key env var를 기본 shape로 두고, runner factory는 provider-neutral `AgentRunner` 뒤에 좁은 client protocol을 주입받는다. Step 5에서는 실제 HTTP/SDK live client를 만들지 않고 mocked client로 contract를 검증한다. organization/project headers처럼 HTTP 요청 표면에 직접 묶이는 옵션은 live adapter 구현 시점으로 defer하여, 아직 확정되지 않은 header shape가 runtime contract를 불필요하게 키우지 않도록 한다.
-- GitHub Copilot은 self-hosted 비대화형 runtime provider로 직접 지원하지 않는다. 인증/정책/ToS와 비대화형 사용 경계가 명확해지기 전까지는 explicit unsupported provider로 남기고, OpenAI-compatible endpoint 또는 Azure OpenAI를 지원 경로로 둔다.
+- GitHub Copilot은 직접 runtime provider로 지원할 예정이지만, Azure OpenAI와 인증·모델 카탈로그·entitlement·request path가 다르므로 별도 issue/PR로 분리한다. GitHub Models는 qaestro provider roadmap에서 제외한다.
 - credential 값은 config object의 repr, log, report, issue output에 노출하지 않는다. health check error도 credential 값 대신 env var 이름과 조치 가능한 누락 항목만 보여준다.
 - provider 선택과 session 생성은 `app/worker` 또는 `runtime/agent` adapter/factory 경계에 두고, 테스트에서는 fake provider로 같은 contract를 검증한다.
 - worker bootstrap health check는 offline config/capability validation을 기본으로 하며, 비용이 발생할 수 있는 live provider smoke call은 명시 opt-in 경로로만 수행한다.

--- a/src/runtime/agent/__init__.py
+++ b/src/runtime/agent/__init__.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+from .azure_openai import (
+    AzureOpenAIAgentRunner,
+    AzureOpenAIChatClient,
+    AzureOpenAIClientResponse,
+    AzureOpenAIHTTPClient,
+    AzureOpenAILiveSmokeResult,
+    run_azure_openai_live_smoke,
+)
 from .fake import FakeAgentRunner
 from .health import (
     AgentRuntimeHealthResult,
@@ -39,6 +47,11 @@ __all__ = [
     "AgentSessionScope",
     "AgentSessionStatus",
     "AgentSessionTurn",
+    "AzureOpenAIAgentRunner",
+    "AzureOpenAIChatClient",
+    "AzureOpenAIClientResponse",
+    "AzureOpenAIHTTPClient",
+    "AzureOpenAILiveSmokeResult",
     "FakeAgentRunner",
     "LiveSmokeProbeStatus",
     "OpenAICompatibleAgentRunner",
@@ -48,4 +61,5 @@ __all__ = [
     "WorkflowAgentSessionManager",
     "build_agent_runner",
     "check_agent_runtime_health",
+    "run_azure_openai_live_smoke",
 ]

--- a/src/runtime/agent/azure_openai.py
+++ b/src/runtime/agent/azure_openai.py
@@ -1,0 +1,233 @@
+"""Azure OpenAI Agent Runtime provider adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.runtime.agent.health import LiveSmokeProbeStatus
+from src.runtime.agent.types import AgentRunInput, AgentRunResult, AgentRunStatus, AgentSessionHandle, AgentSessionScope
+from src.runtime.stages import WorkflowStage
+from src.shared.config import AgentRuntimeConfig
+
+
+@dataclass(frozen=True)
+class AzureOpenAIClientResponse:
+    """Azure provider-adapter response normalized before entering qaestro contracts."""
+
+    output_text: str
+    error: str = ""
+
+
+class AzureOpenAIChatClient(Protocol):
+    """Minimal mocked/live client seam for Azure OpenAI responses."""
+
+    def complete(self, request: dict[str, object]) -> AzureOpenAIClientResponse: ...
+
+
+@dataclass(frozen=True)
+class AzureOpenAILiveSmokeResult:
+    """Result of an explicit Azure OpenAI live smoke probe."""
+
+    status: LiveSmokeProbeStatus
+    output_text: str = ""
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status is LiveSmokeProbeStatus.SUCCEEDED
+
+
+class AzureOpenAIAgentRunner:
+    """Provider-neutral runner backed by an Azure OpenAI client seam."""
+
+    def __init__(self, *, config: AgentRuntimeConfig, client: AzureOpenAIChatClient, credential: str) -> None:
+        self._config = config
+        self._client = client
+        self._credential = credential
+
+    def start_session(self, handle: AgentSessionHandle) -> AgentSessionHandle:
+        return handle
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        try:
+            response = self._client.complete(
+                _request_for(self._config, session=session, run_input=run_input, self_credential=self._credential)
+            )
+        except Exception as exc:
+            return AgentRunResult(
+                session=session,
+                stage=run_input.stage,
+                status=AgentRunStatus.FAILED,
+                error=_redact_secret(str(exc), self._credential),
+                allowed_tool_names=run_input.allowed_tool_names,
+            )
+        if response.error:
+            return AgentRunResult(
+                session=session,
+                stage=run_input.stage,
+                status=AgentRunStatus.FAILED,
+                error=_redact_secret(response.error, self._credential),
+                allowed_tool_names=run_input.allowed_tool_names,
+            )
+        return AgentRunResult(
+            session=session,
+            stage=run_input.stage,
+            status=AgentRunStatus.SUCCEEDED,
+            output_text=response.output_text,
+            allowed_tool_names=run_input.allowed_tool_names,
+        )
+
+    def close_session(self, handle: AgentSessionHandle, *, reason: str) -> None:
+        _ = (handle, reason)
+
+
+class AzureOpenAIHTTPClient:
+    """Small stdlib live client for opt-in Azure OpenAI smoke probes.
+
+    The configured endpoint is expected to be the Azure OpenAI v1 base URL
+    (for example ``https://resource.openai.azure.com/openai/v1``), and this
+    client calls its ``/responses`` endpoint with the configured deployment as
+    the model. This is intentionally isolated behind ``AzureOpenAIChatClient``
+    so provider SDK or HTTP details do not leak into qaestro's provider-neutral
+    contracts.
+    """
+
+    def __init__(self, *, credential: str) -> None:
+        self._credential = credential
+
+    def complete(self, request: dict[str, object]) -> AzureOpenAIClientResponse:
+        endpoint = str(request["endpoint"]).rstrip("/")
+        url = f"{endpoint}/responses"
+        body = {
+            "model": str(request["deployment"]),
+            "input": str(request["prompt"]),
+            "temperature": request["temperature"],
+        }
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "api-key": self._credential,
+            },
+            method="POST",
+        )
+        timeout_value = request["timeout_seconds"]
+        timeout = float(timeout_value) if isinstance(timeout_value, int | float | str) else 60.0
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            return AzureOpenAIClientResponse(output_text="", error=f"Azure OpenAI HTTP {exc.code}: {detail}")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            return AzureOpenAIClientResponse(output_text="", error=str(exc))
+        return AzureOpenAIClientResponse(output_text=_extract_output_text(payload))
+
+
+def run_azure_openai_live_smoke(
+    config: AgentRuntimeConfig,
+    *,
+    environ: Mapping[str, str] | None = None,
+    client: AzureOpenAIChatClient | None = None,
+    opt_in_live_smoke: bool = False,
+) -> AzureOpenAILiveSmokeResult:
+    """Run one explicit Azure OpenAI smoke completion when opted in."""
+
+    if not opt_in_live_smoke:
+        return AzureOpenAILiveSmokeResult(status=LiveSmokeProbeStatus.NOT_REQUESTED)
+
+    env = os.environ if environ is None else environ
+    credential = env.get(config.credential_env_var, "")
+    smoke_client = client or AzureOpenAIHTTPClient(credential=credential)
+    session = AgentSessionHandle(
+        session_id="azure-openai-live-smoke",
+        scope=AgentSessionScope.STAGE,
+        repo_full_name="",
+        pr_number=0,
+        head_sha="",
+        trigger="live-smoke",
+        correlation_id="azure-openai-live-smoke",
+    )
+    run_input = AgentRunInput(
+        stage=WorkflowStage.VALIDATOR,
+        prompt="Respond with exactly: qaestro-live-smoke-ok",
+        correlation_id="azure-openai-live-smoke",
+        max_turns=1,
+        max_tool_calls=0,
+        timeout_seconds=config.timeout_seconds,
+    )
+    try:
+        response = smoke_client.complete(
+            _request_for(config, session=session, run_input=run_input, self_credential=credential)
+        )
+    except Exception as exc:
+        return AzureOpenAILiveSmokeResult(
+            status=LiveSmokeProbeStatus.FAILED,
+            error=_redact_secret(str(exc), credential),
+        )
+    if response.error:
+        return AzureOpenAILiveSmokeResult(
+            status=LiveSmokeProbeStatus.FAILED,
+            error=_redact_secret(response.error, credential),
+        )
+    return AzureOpenAILiveSmokeResult(status=LiveSmokeProbeStatus.SUCCEEDED, output_text=response.output_text)
+
+
+def _request_for(
+    config: AgentRuntimeConfig,
+    *,
+    session: AgentSessionHandle,
+    run_input: AgentRunInput,
+    self_credential: str,
+) -> dict[str, object]:
+    _ = session
+    return {
+        "endpoint": config.endpoint,
+        "deployment": config.deployment,
+        "model": config.model,
+        "api_version": config.api_version,
+        "prompt": run_input.prompt,
+        "stage": run_input.stage.value,
+        "correlation_id": run_input.correlation_id,
+        "timeout_seconds": config.timeout_seconds if run_input.timeout_seconds is None else run_input.timeout_seconds,
+        "max_turns": config.max_turns if run_input.max_turns is None else run_input.max_turns,
+        "max_tool_calls": config.max_tool_calls if run_input.max_tool_calls is None else run_input.max_tool_calls,
+        "temperature": config.temperature,
+        "tool_names": run_input.allowed_tool_names,
+        "credential_present": bool(self_credential),
+    }
+
+
+def _extract_output_text(payload: object) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    output_text = payload.get("output_text")
+    if isinstance(output_text, str):
+        return output_text
+    output = payload.get("output")
+    if isinstance(output, list):
+        chunks: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for content_item in content:
+                if isinstance(content_item, dict) and isinstance(content_item.get("text"), str):
+                    chunks.append(content_item["text"])
+        return "".join(chunks)
+    return ""
+
+
+def _redact_secret(value: str, secret: str) -> str:
+    if not secret:
+        return value
+    return value.replace(secret, "<redacted>")

--- a/src/runtime/agent/health.py
+++ b/src/runtime/agent/health.py
@@ -26,6 +26,8 @@ class LiveSmokeProbeStatus(StrEnum):
 
     NOT_REQUESTED = "not_requested"
     NOT_IMPLEMENTED = "not_implemented"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
 
 
 @dataclass(frozen=True)

--- a/src/runtime/agent/openai_compatible.py
+++ b/src/runtime/agent/openai_compatible.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
+from src.runtime.agent.azure_openai import AzureOpenAIAgentRunner, AzureOpenAIChatClient
 from src.runtime.agent.health import AgentRuntimeHealthStatus, check_agent_runtime_health
 from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunResult, AgentRunStatus, AgentSessionHandle
 from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
@@ -102,6 +103,7 @@ def build_agent_runner(
     *,
     environ: Mapping[str, str] | None = None,
     openai_compatible_client: OpenAICompatibleChatClient | None = None,
+    azure_openai_client: AzureOpenAIChatClient | None = None,
 ) -> AgentRunner:
     """Build a provider-neutral runner from Agent Runtime configuration."""
 
@@ -118,6 +120,17 @@ def build_agent_runner(
         return OpenAICompatibleAgentRunner(
             config=config,
             client=openai_compatible_client,
+            credential=env.get(config.credential_env_var, ""),
+        )
+
+    if config.provider is AgentRuntimeProvider.AZURE_OPENAI:
+        if azure_openai_client is None:
+            raise UnsupportedAgentRuntimeProviderError(
+                "Azure OpenAI runner requires an injected client until a live adapter is configured."
+            )
+        return AzureOpenAIAgentRunner(
+            config=config,
+            client=azure_openai_client,
             credential=env.get(config.credential_env_var, ""),
         )
 

--- a/tests/runtime/test_azure_openai_provider.py
+++ b/tests/runtime/test_azure_openai_provider.py
@@ -1,0 +1,237 @@
+"""Tests for Azure OpenAI Agent Runtime provider adapter."""
+
+from __future__ import annotations
+
+from src.runtime.agent import (
+    AgentRunInput,
+    AgentRunStatus,
+    AgentSessionHandle,
+    AgentSessionScope,
+    AzureOpenAIAgentRunner,
+    AzureOpenAIChatClient,
+    AzureOpenAIClientResponse,
+    AzureOpenAILiveSmokeResult,
+    LiveSmokeProbeStatus,
+    build_agent_runner,
+    run_azure_openai_live_smoke,
+)
+from src.runtime.stages import WorkflowStage
+from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
+
+
+class RecordingAzureOpenAIClient(AzureOpenAIChatClient):
+    def __init__(self, response: AzureOpenAIClientResponse) -> None:
+        self.response = response
+        self.calls: list[dict[str, object]] = []
+
+    def complete(self, request: dict[str, object]) -> AzureOpenAIClientResponse:
+        self.calls.append(request)
+        return self.response
+
+
+class FailingAzureOpenAIClient(AzureOpenAIChatClient):
+    def complete(self, request: dict[str, object]) -> AzureOpenAIClientResponse:
+        _ = request
+        raise TimeoutError("azure timed out with credential super-secret-token")
+
+
+def _supported_config() -> AgentRuntimeConfig:
+    return AgentRuntimeConfig(
+        provider=AgentRuntimeProvider.AZURE_OPENAI,
+        endpoint="https://azure-openai.example.test/openai/v1",
+        deployment="review-deployment",
+        model="review-model",
+        api_version="preview",
+        credential_env_var="QAESTRO_AZURE_OPENAI_KEY",
+        supports_tool_calling=True,
+        supports_structured_output=True,
+        context_window_tokens=128_000,
+        timeout_seconds=45.0,
+        max_turns=4,
+        max_tool_calls=6,
+        temperature=0.1,
+    )
+
+
+def _session() -> AgentSessionHandle:
+    return AgentSessionHandle(
+        session_id="session-1",
+        scope=AgentSessionScope.WORKFLOW,
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=77,
+        head_sha="abc123",
+        trigger="manual",
+        correlation_id="corr-1",
+    )
+
+
+def test_azure_openai_runner_builds_provider_neutral_request_without_secret_value() -> None:
+    client = RecordingAzureOpenAIClient(AzureOpenAIClientResponse(output_text="azure analysis ok"))
+    runner = AzureOpenAIAgentRunner(
+        config=_supported_config(),
+        client=client,
+        credential="super-secret-token",
+    )
+    session = runner.start_session(_session())
+
+    result = runner.run(
+        session=session,
+        run_input=AgentRunInput(
+            stage=WorkflowStage.VALIDATOR,
+            prompt="Validate the PR",
+            correlation_id="corr-1",
+            max_turns=2,
+            max_tool_calls=3,
+            timeout_seconds=30.0,
+        ),
+    )
+
+    assert result.status is AgentRunStatus.SUCCEEDED
+    assert result.output_text == "azure analysis ok"
+    assert result.stage is WorkflowStage.VALIDATOR
+    assert client.calls == [
+        {
+            "endpoint": "https://azure-openai.example.test/openai/v1",
+            "deployment": "review-deployment",
+            "model": "review-model",
+            "api_version": "preview",
+            "prompt": "Validate the PR",
+            "stage": "validator",
+            "correlation_id": "corr-1",
+            "timeout_seconds": 30.0,
+            "max_turns": 2,
+            "max_tool_calls": 3,
+            "temperature": 0.1,
+            "tool_names": (),
+            "credential_present": True,
+        }
+    ]
+    assert "super-secret-token" not in repr(client.calls[0])
+
+
+def test_azure_openai_runner_preserves_explicit_zero_budgets() -> None:
+    client = RecordingAzureOpenAIClient(AzureOpenAIClientResponse(output_text="azure analysis ok"))
+    runner = AzureOpenAIAgentRunner(
+        config=_supported_config(),
+        client=client,
+        credential="super-secret-token",
+    )
+
+    result = runner.run(
+        session=_session(),
+        run_input=AgentRunInput(
+            stage=WorkflowStage.VALIDATOR,
+            prompt="Validate without tools",
+            correlation_id="corr-1",
+            timeout_seconds=0.0,
+            max_turns=0,
+            max_tool_calls=0,
+        ),
+    )
+
+    assert result.status is AgentRunStatus.SUCCEEDED
+    assert client.calls[0]["timeout_seconds"] == 0.0
+    assert client.calls[0]["max_turns"] == 0
+    assert client.calls[0]["max_tool_calls"] == 0
+
+
+def test_azure_openai_runner_normalizes_response_errors_without_secret_value() -> None:
+    client = RecordingAzureOpenAIClient(
+        AzureOpenAIClientResponse(output_text="", error="azure unavailable: super-secret-token")
+    )
+    runner = AzureOpenAIAgentRunner(
+        config=_supported_config(),
+        client=client,
+        credential="super-secret-token",
+    )
+
+    result = runner.run(
+        session=_session(),
+        run_input=AgentRunInput(stage=WorkflowStage.VALIDATOR, prompt="Validate", correlation_id="corr-1"),
+    )
+
+    assert result.status is AgentRunStatus.FAILED
+    assert result.error == "azure unavailable: <redacted>"
+
+
+def test_azure_openai_runner_normalizes_client_exceptions_without_secret_value() -> None:
+    runner = AzureOpenAIAgentRunner(
+        config=_supported_config(),
+        client=FailingAzureOpenAIClient(),
+        credential="super-secret-token",
+    )
+
+    result = runner.run(
+        session=_session(),
+        run_input=AgentRunInput(stage=WorkflowStage.VALIDATOR, prompt="Validate", correlation_id="corr-1"),
+    )
+
+    assert result.status is AgentRunStatus.FAILED
+    assert result.error == "azure timed out with credential <redacted>"
+
+
+def test_agent_runner_factory_builds_azure_openai_runner_from_env() -> None:
+    runner = build_agent_runner(
+        _supported_config(),
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        azure_openai_client=RecordingAzureOpenAIClient(AzureOpenAIClientResponse(output_text="ok")),
+    )
+
+    assert isinstance(runner, AzureOpenAIAgentRunner)
+
+
+def test_agent_runner_factory_requires_injected_azure_client_until_live_adapter_is_configured() -> None:
+    try:
+        build_agent_runner(_supported_config(), environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"})
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("Azure OpenAI runner should require injected client before live adapter wiring")
+
+    assert "Azure OpenAI runner requires an injected client until a live adapter is configured." in message
+    assert "super-secret-token" not in message
+
+
+def test_azure_openai_live_smoke_is_not_requested_by_default() -> None:
+    client = RecordingAzureOpenAIClient(AzureOpenAIClientResponse(output_text="pong"))
+
+    result = run_azure_openai_live_smoke(
+        _supported_config(),
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        client=client,
+        opt_in_live_smoke=False,
+    )
+
+    assert result.status is LiveSmokeProbeStatus.NOT_REQUESTED
+    assert result.ok is False
+    assert client.calls == []
+
+
+def test_azure_openai_live_smoke_executes_only_when_opted_in_without_leaking_secret() -> None:
+    client = RecordingAzureOpenAIClient(AzureOpenAIClientResponse(output_text="pong"))
+
+    result = run_azure_openai_live_smoke(
+        _supported_config(),
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        client=client,
+        opt_in_live_smoke=True,
+    )
+
+    assert result == AzureOpenAILiveSmokeResult(status=LiveSmokeProbeStatus.SUCCEEDED, output_text="pong")
+    assert client.calls[0]["prompt"] == "Respond with exactly: qaestro-live-smoke-ok"
+    assert client.calls[0]["max_turns"] == 1
+    assert client.calls[0]["max_tool_calls"] == 0
+    assert "super-secret-token" not in repr(client.calls[0])
+    assert "super-secret-token" not in repr(result)
+
+
+def test_azure_openai_live_smoke_normalizes_failures_without_secret_value() -> None:
+    result = run_azure_openai_live_smoke(
+        _supported_config(),
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        client=FailingAzureOpenAIClient(),
+        opt_in_live_smoke=True,
+    )
+
+    assert result.status is LiveSmokeProbeStatus.FAILED
+    assert result.error == "azure timed out with credential <redacted>"


### PR DESCRIPTION
## Summary

This PR completes the Azure OpenAI slice of Step 5 Agent Runtime Foundation. After the provider-neutral runtime contract, capability health policy, and OpenAI-compatible boundary were merged, qaestro still needed one concrete BYOK provider path that can be exercised without leaking provider SDK details into core/orchestrator contracts.

The Azure OpenAI adapter is intentionally split into two layers: the normal `AgentRunner` path still accepts an injected client protocol for deterministic tests, while a separate opt-in live smoke helper can perform a real `/responses` call against a configured Azure OpenAI v1 endpoint. That keeps CI credential-free but proves the provider path is not just a shell when local credentials are supplied.

GitHub Copilot is not implemented in this PR. It is tracked separately in #78 as a first-class provider follow-up, and GitHub Models is removed from the qaestro provider roadmap rather than being treated as a priority path.

## What changed

- Adds `AzureOpenAIAgentRunner` behind the existing provider-neutral `AgentRunner` contract.
- Adds a narrow `AzureOpenAIChatClient` protocol and normalized `AzureOpenAIClientResponse` so Azure SDK/HTTP details stay outside core contracts.
- Extends `build_agent_runner()` to construct Azure OpenAI runners with an injected client.
- Adds `AzureOpenAIHTTPClient` and `run_azure_openai_live_smoke()` for explicit opt-in `/responses` smoke calls.
- Preserves per-run explicit zero budgets such as `max_tool_calls=0`.
- Normalizes Azure client response errors and exceptions into credential-redacted failed `AgentRunResult` / live smoke results.
- Documents Azure OpenAI endpoint/deployment/API-version shape, Copilot follow-up separation, and GitHub Models removal from the provider roadmap.

## Review focus

- Check that Azure OpenAI request metadata remains provider-specific but does not leak into core/orchestrator contracts.
- Check that the opt-in live smoke path is explicit enough and cannot run accidentally in CI/default bootstrap.
- Check that credential values are never included in request snapshots, errors, docs, or PR text.

## Verification

- `uv run pytest tests/runtime/test_azure_openai_provider.py -q`
- Opt-in Azure OpenAI live smoke with local env outside the repo — succeeded (`qaestro-live-smoke-ok`)
- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest` — 265 passed
- Static security scan over staged diff — no findings
- Independent pre-commit review passed

Closes #67
Refs #78

---
🤖 *Created by Hermes Agent*
