### PR TITLE
feat(runtime): connect agent runner to validation stage

### DIFF
--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -114,7 +114,11 @@ class PRWorkflowOrchestrator:
             triage.depth is PRWorkflowDepth.DEEP or self._should_validate(event, impact, strategy)
         ):
             stages.append(WorkflowStage.VALIDATOR)
-            validations = self._validator.validate(strategy)
+            validate_for_event = getattr(self._validator, "validate_for_event", None)
+            if callable(validate_for_event):
+                validations = validate_for_event(event=event, strategy=strategy)
+            else:
+                validations = self._validator.validate(strategy)
         else:
             validations = ()
 

--- a/src/runtime/validator/__init__.py
+++ b/src/runtime/validator/__init__.py
@@ -1,1 +1,17 @@
-"""Runtime validator — probe execution for system behaviour verification."""
+"""Runtime validator public API."""
+
+from __future__ import annotations
+
+from .agent_runtime import (
+    AgentRuntimePRValidator,
+    RuntimeValidationBudget,
+    build_agent_runtime_pr_validator,
+    build_default_validation_tool_adapter,
+)
+
+__all__ = [
+    "AgentRuntimePRValidator",
+    "RuntimeValidationBudget",
+    "build_agent_runtime_pr_validator",
+    "build_default_validation_tool_adapter",
+]

--- a/src/runtime/validator/agent_runtime.py
+++ b/src/runtime/validator/agent_runtime.py
@@ -1,0 +1,181 @@
+"""Agent Runtime-backed PR validation wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.contracts import PREvent, StrategyAction, StrategyResult, ValidationOutcome, ValidationResult
+from src.runtime.agent.manager import WorkflowAgentSessionManager
+from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunStatus, AgentSessionHandle
+from src.runtime.stages import WorkflowStage
+from src.runtime.tools import (
+    AgentFrameworkToolAdapter,
+    RegisteredToolRuntime,
+    StageToolPolicy,
+    ToolCall,
+    ToolCapability,
+    ToolDefinition,
+)
+
+_VALIDATION_API_CONTRACT_PROBE = "validation.api_contract.probe"
+
+
+@dataclass(frozen=True)
+class RuntimeValidationBudget:
+    """Bounded execution budget for one validation-stage agent turn."""
+
+    max_turns: int = 2
+    max_tool_calls: int = 1
+    timeout_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        if self.max_turns < 1:
+            raise ValueError("max_turns must be >= 1")
+        if self.max_tool_calls < 0:
+            raise ValueError("max_tool_calls must be >= 0")
+        if self.timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be > 0")
+
+
+class AgentRuntimePRValidator:
+    """Run PR validation actions through the provider-neutral Agent Runtime.
+
+    This is the first Step 6 wiring slice: it connects selected strategy actions
+    to the existing workflow-scoped ``WorkflowAgentSessionManager`` and passes
+    only validation-stage tool specs exposed by ``AgentFrameworkToolAdapter``.
+
+    The concrete API-contract probe verdict is intentionally not implemented in
+    this class yet. A successful agent turn proves the runner/session/tool seam
+    executed, but it is reported as ``SKIPPED`` until #62 adds deterministic probe
+    verdict parsing/execution so callers do not mistake runner completion for a
+    real validation pass.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_manager: WorkflowAgentSessionManager,
+        tool_adapter: AgentFrameworkToolAdapter,
+        budget: RuntimeValidationBudget | None = None,
+    ) -> None:
+        self._session_manager = session_manager
+        self._tool_adapter = tool_adapter
+        self._budget = budget or RuntimeValidationBudget()
+
+    def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+        """Fail closed when called without PR event context."""
+        return tuple(
+            ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.ERROR,
+                details="PR event context is required before Agent Runtime validation can run.",
+            )
+            for action in strategy.actions
+        )
+
+    def validate_for_event(self, *, event: PREvent, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+        """Run validation for one PR event without storing mutable event state."""
+        session = self._session_manager.start_workflow_session(
+            repo_full_name=event.repo_full_name,
+            pr_number=event.pr_number,
+            head_sha=event.head_sha,
+            trigger=event.meta.event_type.value,
+            correlation_id=event.meta.correlation_id,
+        )
+        try:
+            return tuple(
+                self._run_action(event=event, action=action, session_handle=session.handle)
+                for action in strategy.actions
+            )
+        finally:
+            self._session_manager.close_pr_sessions(
+                repo_full_name=event.repo_full_name,
+                pr_number=event.pr_number,
+                reason="validation stage complete",
+            )
+
+    def _run_action(
+        self,
+        *,
+        event: PREvent,
+        action: StrategyAction,
+        session_handle: AgentSessionHandle,
+    ) -> ValidationResult:
+        run_input = AgentRunInput(
+            stage=WorkflowStage.VALIDATOR,
+            prompt=_validation_prompt(action),
+            correlation_id=event.meta.correlation_id,
+            allowed_tools=self._tool_adapter.tool_specs_for_stage(WorkflowStage.VALIDATOR),
+            context={
+                "repo_full_name": event.repo_full_name,
+                "pr_number": event.pr_number,
+                "head_sha": event.head_sha,
+                "action_type": action.action_type.value,
+                "target": action.target,
+            },
+            max_turns=self._budget.max_turns,
+            max_tool_calls=self._budget.max_tool_calls,
+            timeout_seconds=self._budget.timeout_seconds,
+        )
+        try:
+            result = self._session_manager.run_stage(session_handle, run_input)
+        except Exception as exc:
+            return ValidationResult(action=action, outcome=ValidationOutcome.ERROR, details=str(exc))
+
+        if result.status is AgentRunStatus.SUCCEEDED:
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.SKIPPED,
+                details="Agent Runtime validation runner completed; concrete probe verdict is deferred to #62.",
+            )
+        return ValidationResult(
+            action=action,
+            outcome=ValidationOutcome.ERROR,
+            details=result.error or f"Agent Runtime validation ended with status {result.status.value}.",
+        )
+
+
+def build_agent_runtime_pr_validator(*, runner: AgentRunner) -> AgentRuntimePRValidator:
+    """Build the default provider-neutral validation runner wiring."""
+    return AgentRuntimePRValidator(
+        session_manager=WorkflowAgentSessionManager(runner=runner),
+        tool_adapter=build_default_validation_tool_adapter(),
+    )
+
+
+def build_default_validation_tool_adapter() -> AgentFrameworkToolAdapter:
+    """Expose validation-stage tool specs through the ToolRuntime seam.
+
+    The API contract probe handler is a deliberate placeholder for #62. It is
+    policy-gated and auditable, but returns an explicit skipped marker rather
+    than pretending to perform a live API contract check.
+    """
+    validation_tool = ToolDefinition(
+        name=_VALIDATION_API_CONTRACT_PROBE,
+        capabilities=(ToolCapability.EXECUTE,),
+        description="Run a deterministic API contract probe",
+        input_schema={"type": "object", "properties": {"target": {"type": "string"}}},
+        handler=_api_contract_probe_not_implemented,
+    )
+    policy = StageToolPolicy({WorkflowStage.VALIDATOR: (_VALIDATION_API_CONTRACT_PROBE,)})
+    runtime = RegisteredToolRuntime(tools=(validation_tool,), policy=policy)
+    return AgentFrameworkToolAdapter(runtime=runtime, tools=(validation_tool,), policy=policy)
+
+
+def _api_contract_probe_not_implemented(call: ToolCall) -> dict[str, object]:
+    return {
+        "status": "skipped",
+        "reason": "api_contract_probe_not_implemented",
+        "target": call.input.get("target", ""),
+    }
+
+
+def _validation_prompt(action: StrategyAction) -> str:
+    return (
+        "Run the validation action through qaestro's validation-stage tools only.\n"
+        "If the concrete probe tool reports that its implementation is not ready, report it as skipped.\n"
+        f"Action type: {action.action_type.value}\n"
+        f"Target: {action.target}\n"
+        f"Description: {action.description}\n"
+        f"Rationale: {action.rationale}"
+    )

--- a/tests/runtime/test_validation_agent_runner.py
+++ b/tests/runtime/test_validation_agent_runner.py
@@ -1,0 +1,200 @@
+"""Tests for validation-stage Agent Runtime runner wiring."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from src.core.contracts import (
+    ActionType,
+    BehaviourImpact,
+    EventMeta,
+    EventSource,
+    EventType,
+    FileChange,
+    PROpened,
+    RiskLevel,
+    StrategyAction,
+    StrategyResult,
+    ValidationOutcome,
+)
+from src.runtime.agent.fake import FakeAgentRunner
+from src.runtime.agent.manager import WorkflowAgentSessionManager
+from src.runtime.orchestrator import PRWorkflowOrchestrator
+from src.runtime.stages import WorkflowStage
+from src.runtime.tools import (
+    AgentFrameworkToolAdapter,
+    RegisteredToolRuntime,
+    StageToolPolicy,
+    ToolCapability,
+    ToolDefinition,
+)
+from src.runtime.validator import AgentRuntimePRValidator, build_agent_runtime_pr_validator
+
+
+def _event_meta(event_id: str, event_type: EventType, correlation_id: str) -> EventMeta:
+    return EventMeta(
+        event_id=event_id,
+        event_type=event_type,
+        correlation_id=correlation_id,
+        timestamp=datetime(2026, 4, 25, 12, 0, tzinfo=UTC),
+        source=EventSource.GITHUB,
+    )
+
+
+def _pr_opened_event(*, pr_number: int = 61, correlation_id: str = "corr-validation-runner") -> PROpened:
+    return PROpened(
+        meta=_event_meta("evt-validation-runner", EventType.PR_OPENED, correlation_id),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=pr_number,
+        title="feat(runtime): validation runner wiring",
+        body="Connects the Agent Runtime runner to validation.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/runtime-validation-agent-runner",
+        diff_url=f"https://github.com/Kimcheolhui/qaestro/pull/{pr_number}.diff",
+        files_changed=(FileChange(path="src/runtime/validator/__init__.py", status="modified", additions=80),),
+        head_sha=f"abc123validation-{pr_number}",
+    )
+
+
+def _strategy() -> StrategyResult:
+    return StrategyResult(
+        actions=(
+            StrategyAction(
+                action_type=ActionType.VERIFY_API_CONTRACT,
+                description="Validate the API contract probe",
+                target="GET /health",
+                priority=2,
+                rationale="The PR changes runtime validation code.",
+            ),
+        ),
+        reasoning="API contract changed.",
+        confidence=0.9,
+    )
+
+
+def test_validation_stage_runs_provider_neutral_agent_runner_with_bounded_tools() -> None:
+    fake_runner = FakeAgentRunner(response="contract probe evidence")
+    session_manager = WorkflowAgentSessionManager(runner=fake_runner)
+    validator = AgentRuntimePRValidator(
+        session_manager=session_manager,
+        tool_adapter=_validation_tool_adapter(),
+    )
+    strategy = _strategy()
+    event = _pr_opened_event()
+    orchestrator = PRWorkflowOrchestrator(
+        analyzer=_StaticAnalyzer(),
+        strategy_engine=_StaticStrategy(strategy),
+        validator=validator,
+    )
+
+    result = orchestrator.run(event)
+
+    assert result.validations[0].outcome is ValidationOutcome.SKIPPED
+    assert (
+        result.validations[0].details
+        == "Agent Runtime validation runner completed; concrete probe verdict is deferred to #62."
+    )
+    assert len(fake_runner.started_sessions) == 1
+    assert fake_runner.started_sessions[0].scope.value == "workflow"
+    assert fake_runner.started_sessions[0].repo_full_name == "Kimcheolhui/qaestro"
+    assert fake_runner.started_sessions[0].pr_number == 61
+    assert fake_runner.started_sessions[0].head_sha == "abc123validation-61"
+    assert fake_runner.closed_sessions == [(fake_runner.started_sessions[0].session_id, "validation stage complete")]
+    assert fake_runner.run_inputs[0].stage is WorkflowStage.VALIDATOR
+    assert fake_runner.run_inputs[0].correlation_id == "corr-validation-runner"
+    assert fake_runner.run_inputs[0].allowed_tool_names == ("validation.api_contract.probe",)
+    assert fake_runner.run_inputs[0].max_turns == 2
+    assert fake_runner.run_inputs[0].max_tool_calls == 1
+    assert fake_runner.run_inputs[0].timeout_seconds == 30.0
+    assert fake_runner.run_inputs[0].context == {
+        "repo_full_name": "Kimcheolhui/qaestro",
+        "pr_number": 61,
+        "head_sha": "abc123validation-61",
+        "action_type": "verify_api_contract",
+        "target": "GET /health",
+    }
+    assert "github.pr.comment.create_or_update" not in fake_runner.run_inputs[0].allowed_tool_names
+
+
+def test_validation_agent_runner_requires_pr_event_context() -> None:
+    validator = AgentRuntimePRValidator(
+        session_manager=WorkflowAgentSessionManager(runner=FakeAgentRunner()),
+        tool_adapter=_validation_tool_adapter(),
+    )
+
+    validations = validator.validate(_strategy())
+
+    assert validations[0].outcome is ValidationOutcome.ERROR
+    assert "PR event context is required" in validations[0].details
+
+
+def test_validation_agent_runner_does_not_reuse_stale_event_context() -> None:
+    fake_runner = FakeAgentRunner(response="runner completed")
+    validator = AgentRuntimePRValidator(
+        session_manager=WorkflowAgentSessionManager(runner=fake_runner),
+        tool_adapter=_validation_tool_adapter(),
+    )
+
+    first = validator.validate_for_event(
+        event=_pr_opened_event(pr_number=61, correlation_id="corr-61"), strategy=_strategy()
+    )
+    second = validator.validate_for_event(
+        event=_pr_opened_event(pr_number=62, correlation_id="corr-62"), strategy=_strategy()
+    )
+
+    assert first[0].outcome is ValidationOutcome.SKIPPED
+    assert second[0].outcome is ValidationOutcome.SKIPPED
+    assert [run.context["pr_number"] for run in fake_runner.run_inputs if run.context is not None] == [61, 62]
+    assert [run.correlation_id for run in fake_runner.run_inputs] == ["corr-61", "corr-62"]
+
+
+def test_default_agent_runtime_validator_exposes_only_validation_tool_specs() -> None:
+    fake_runner = FakeAgentRunner(response="runner completed")
+    validator = build_agent_runtime_pr_validator(runner=fake_runner)
+
+    validations = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy())
+
+    assert validations[0].outcome is ValidationOutcome.SKIPPED
+    assert fake_runner.run_inputs[0].allowed_tool_names == ("validation.api_contract.probe",)
+
+
+def _validation_tool_adapter() -> AgentFrameworkToolAdapter:
+    validation_tool = ToolDefinition(
+        name="validation.api_contract.probe",
+        capabilities=(ToolCapability.EXECUTE,),
+        description="Run a deterministic API contract probe",
+        input_schema={"type": "object", "properties": {"target": {"type": "string"}}},
+        handler=lambda call: {"target": call.input.get("target"), "ok": True},
+    )
+    output_tool = ToolDefinition(
+        name="github.pr.comment.create_or_update",
+        capabilities=(ToolCapability.WRITE,),
+        description="Write a managed PR comment",
+        handler=lambda call: {"comment": "written"},
+    )
+    policy = StageToolPolicy(
+        {
+            WorkflowStage.VALIDATOR: ("validation.api_contract.probe",),
+            WorkflowStage.OUTPUT: ("github.pr.comment.create_or_update",),
+        }
+    )
+    runtime = RegisteredToolRuntime(tools=(validation_tool, output_tool), policy=policy)
+    return AgentFrameworkToolAdapter(runtime=runtime, tools=(validation_tool, output_tool), policy=policy)
+
+
+class _StaticAnalyzer:
+    def analyze(self, context: object) -> BehaviourImpact:
+        return BehaviourImpact(
+            summary="runtime validation wiring change",
+            areas=(),
+            overall_risk=RiskLevel.MEDIUM,
+        )
+
+
+class _StaticStrategy:
+    def __init__(self, result: StrategyResult) -> None:
+        self._result = result
+
+    def plan(self, **kwargs: object) -> StrategyResult:
+        return self._result


### PR DESCRIPTION
## Summary

This PR starts Step 6 / #61 by wiring runtime validation to the Step 5 provider-neutral Agent Runtime foundation. The important boundary is that validation now has an event-aware path that can build a `WorkflowStage.VALIDATOR` `AgentRunInput` with PR identity, current head SHA, correlation id, bounded budget, and stage-approved tool specs.

The concrete API contract probe verdict is intentionally still deferred to #62. Runner completion is therefore reported as `ValidationOutcome.SKIPPED`, not `PASS`, so this PR proves the Agent Runtime/session/tool seam without pretending to execute a real API probe.

## Review focus

Please check the boundary around `AgentRuntimePRValidator`:

- validation-stage tools come from `AgentFrameworkToolAdapter.tool_specs_for_stage(WorkflowStage.VALIDATOR)` instead of raw tool handlers or all registered tools;
- `validate_for_event(...)` passes event context explicitly and avoids mutable/stale PR context on the validator instance;
- missing event context fails closed as `ERROR` through the legacy `validate(strategy)` path;
- a successful agent turn remains `SKIPPED` until #62 implements deterministic probe verdict semantics;
- sessions are closed in `finally` so the provider-neutral session manager does not accumulate active workflow sessions.

## Design notes

The orchestrator keeps backward compatibility with existing validators by detecting `validate_for_event(...)` only when available and falling back to `validate(strategy)` otherwise. This lets Step 6 introduce the event-aware runner path without breaking existing custom/stub validator tests.

A default validation tool adapter is included, but its API contract probe handler is an explicit placeholder: it is policy-gated and auditable, yet returns a skipped marker rather than doing live external API work. That keeps #61 focused on runner wiring while #62 owns fake/pluggable API contract probe execution.

## Verification

Local verification passed on commit `1a0bd2c9ded73bcb337783f3308e46806536b7f3`:

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `uv run pytest tests -q`

Test VM and real-repository smoke verification will be reported in a follow-up PR comment after the PR is opened.

Closes #61

---
🤖 *Created by Hermes Agent*
