### PR TITLE
feat(validator): add API contract probe MVP

### DIFF
--- a/src/runtime/validator/__init__.py
+++ b/src/runtime/validator/__init__.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 from .agent_runtime import (
     AgentRuntimePRValidator,
+    APIContractProbeExecutor,
+    APIContractProbeRequest,
+    APIContractProbeResult,
     RuntimeValidationBudget,
+    SkippingAPIContractProbeExecutor,
     build_agent_runtime_pr_validator,
     build_default_validation_tool_adapter,
 )
 
 __all__ = [
+    "APIContractProbeExecutor",
+    "APIContractProbeRequest",
+    "APIContractProbeResult",
     "AgentRuntimePRValidator",
     "RuntimeValidationBudget",
+    "SkippingAPIContractProbeExecutor",
     "build_agent_runtime_pr_validator",
     "build_default_validation_tool_adapter",
 ]

--- a/src/runtime/validator/agent_runtime.py
+++ b/src/runtime/validator/agent_runtime.py
@@ -238,14 +238,18 @@ class AgentRuntimePRValidator:
         try:
             result = self._session_manager.run_stage(session_handle, run_input)
         except Exception as exc:
-            return ValidationResult(action=action, outcome=ValidationOutcome.ERROR, details=str(exc))
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.ERROR,
+                details=_agent_runner_error_details(kind="agent_runner_exception", exc=exc),
+            )
 
         if result.status is AgentRunStatus.SUCCEEDED:
             return None
         return ValidationResult(
             action=action,
             outcome=ValidationOutcome.ERROR,
-            details=result.error or f"Agent Runtime validation ended with status {result.status.value}.",
+            details=_agent_runner_status_details(result.status),
         )
 
     def _run_api_contract_probe(self, *, action: StrategyAction, request: APIContractProbeRequest) -> ValidationResult:
@@ -267,11 +271,12 @@ class AgentRuntimePRValidator:
                 duration_seconds=monotonic() - start,
             )
 
+        elapsed = monotonic() - start
         return ValidationResult(
             action=action,
             outcome=result.outcome,
             details=result.details,
-            duration_seconds=result.duration_seconds,
+            duration_seconds=result.duration_seconds or elapsed,
             artifacts=result.artifacts,
         )
 
@@ -337,6 +342,16 @@ def _probe_error_details(*, kind: str, exc: Exception) -> str:
     # comments. Future live executors may include response bodies, tokens, or
     # endpoint details in exception strings.
     return f"{kind}: {type(exc).__name__} raised by API contract probe executor."
+
+
+def _agent_runner_error_details(*, kind: str, exc: Exception) -> str:
+    # Keep provider/transport exception strings out of rendered validation
+    # details. They may include endpoints, token fragments, or credential hints.
+    return f"{kind}: {type(exc).__name__} raised during Agent Runtime validation."
+
+
+def _agent_runner_status_details(status: AgentRunStatus) -> str:
+    return f"agent_runner: Agent Runtime validation ended with status {status.name}."
 
 
 def _api_contract_probe_request(

--- a/src/runtime/validator/agent_runtime.py
+++ b/src/runtime/validator/agent_runtime.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from time import monotonic
+from typing import Protocol
 
-from src.core.contracts import PREvent, StrategyAction, StrategyResult, ValidationOutcome, ValidationResult
+from src.core.contracts import (
+    ActionType,
+    PREvent,
+    StrategyAction,
+    StrategyResult,
+    ValidationOutcome,
+    ValidationResult,
+)
 from src.runtime.agent.manager import WorkflowAgentSessionManager
 from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunStatus, AgentSessionHandle
 from src.runtime.stages import WorkflowStage
@@ -18,6 +27,7 @@ from src.runtime.tools import (
 )
 
 _VALIDATION_API_CONTRACT_PROBE = "validation.api_contract.probe"
+_SUPPORTED_API_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"})
 
 
 @dataclass(frozen=True)
@@ -37,18 +47,74 @@ class RuntimeValidationBudget:
             raise ValueError("timeout_seconds must be > 0")
 
 
+@dataclass(frozen=True)
+class APIContractProbeRequest:
+    """Deterministic request handed to an API contract probe executor."""
+
+    action: StrategyAction
+    target: str
+    method: str
+    path: str
+    repo_full_name: str
+    pr_number: int
+    head_sha: str
+    correlation_id: str
+    timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class APIContractProbeResult:
+    """Normalized API contract probe result mapped into ValidationResult."""
+
+    outcome: ValidationOutcome
+    details: str
+    duration_seconds: float = 0.0
+    artifacts: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.duration_seconds < 0:
+            raise ValueError("duration_seconds must be >= 0")
+
+
+class APIContractProbeExecutor(Protocol):
+    """Pluggable API contract probe executor.
+
+    Implementations must be deterministic and non-destructive by default. The
+    default MVP executor intentionally skips live external API calls; tests and
+    later adapters can inject fake or opt-in live executors behind this seam.
+    Executor-provided ``APIContractProbeResult.details`` may be rendered into PR
+    comments, so live executors must return sanitized details and put sensitive
+    raw evidence behind redacted artifact handles instead.
+    """
+
+    def execute(self, request: APIContractProbeRequest) -> APIContractProbeResult: ...
+
+
+class SkippingAPIContractProbeExecutor:
+    """Default non-live API contract probe executor.
+
+    This is a real executor seam, not the final probe implementation: it returns
+    an explicit SKIPPED result so the PR report shows unsupported execution
+    instead of silently passing. Concrete fake/pluggable executors can be injected
+    by tests, smoke scripts, or later provider/probe hardening work.
+    """
+
+    def execute(self, request: APIContractProbeRequest) -> APIContractProbeResult:
+        return APIContractProbeResult(
+            outcome=ValidationOutcome.SKIPPED,
+            details=(
+                f"api_contract_probe_skipped: no non-live executor configured for {request.method} {request.path}."
+            ),
+        )
+
+
 class AgentRuntimePRValidator:
     """Run PR validation actions through the provider-neutral Agent Runtime.
 
-    This is the first Step 6 wiring slice: it connects selected strategy actions
-    to the existing workflow-scoped ``WorkflowAgentSessionManager`` and passes
-    only validation-stage tool specs exposed by ``AgentFrameworkToolAdapter``.
-
-    The concrete API-contract probe verdict is intentionally not implemented in
-    this class yet. A successful agent turn proves the runner/session/tool seam
-    executed, but it is reported as ``SKIPPED`` until #62 adds deterministic probe
-    verdict parsing/execution so callers do not mistake runner completion for a
-    real validation pass.
+    The validator keeps the Step 5 runner/session/tool boundary and now maps the
+    API-contract strategy action into a deterministic pluggable probe executor.
+    Live external API calls are intentionally not performed by default: callers
+    must inject an executor when they want concrete probe semantics.
     """
 
     def __init__(
@@ -56,10 +122,12 @@ class AgentRuntimePRValidator:
         *,
         session_manager: WorkflowAgentSessionManager,
         tool_adapter: AgentFrameworkToolAdapter,
+        api_contract_probe_executor: APIContractProbeExecutor | None = None,
         budget: RuntimeValidationBudget | None = None,
     ) -> None:
         self._session_manager = session_manager
         self._tool_adapter = tool_adapter
+        self._api_contract_probe_executor = api_contract_probe_executor or SkippingAPIContractProbeExecutor()
         self._budget = budget or RuntimeValidationBudget()
 
     def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
@@ -75,6 +143,16 @@ class AgentRuntimePRValidator:
 
     def validate_for_event(self, *, event: PREvent, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
         """Run validation for one PR event without storing mutable event state."""
+        if not _has_complete_pr_event_context(event):
+            return tuple(
+                ValidationResult(
+                    action=action,
+                    outcome=ValidationOutcome.ERROR,
+                    details="complete PR event context is required before API contract probes can run.",
+                )
+                for action in strategy.actions
+            )
+
         session = self._session_manager.start_workflow_session(
             repo_full_name=event.repo_full_name,
             pr_number=event.pr_number,
@@ -101,6 +179,46 @@ class AgentRuntimePRValidator:
         action: StrategyAction,
         session_handle: AgentSessionHandle,
     ) -> ValidationResult:
+        if action.action_type is not ActionType.VERIFY_API_CONTRACT:
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.SKIPPED,
+                details=f"unsupported validation action: {action.action_type.value}",
+            )
+
+        probe_request = _api_contract_probe_request(
+            event=event,
+            action=action,
+            timeout_seconds=self._budget.timeout_seconds,
+        )
+        if probe_request is None:
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.SKIPPED,
+                details=f"unsupported API contract target: {action.target}",
+            )
+
+        allowed_tool_names = self._tool_adapter.tool_specs_for_stage(WorkflowStage.VALIDATOR)
+        if not any(tool.name == _VALIDATION_API_CONTRACT_PROBE for tool in allowed_tool_names):
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.ERROR,
+                details=f"{_VALIDATION_API_CONTRACT_PROBE} is not allowed during validator stage.",
+            )
+
+        run_result = self._run_agent_selection(event=event, action=action, session_handle=session_handle)
+        if run_result is not None:
+            return run_result
+
+        return self._run_api_contract_probe(action=action, request=probe_request)
+
+    def _run_agent_selection(
+        self,
+        *,
+        event: PREvent,
+        action: StrategyAction,
+        session_handle: AgentSessionHandle,
+    ) -> ValidationResult | None:
         run_input = AgentRunInput(
             stage=WorkflowStage.VALIDATOR,
             prompt=_validation_prompt(action),
@@ -123,57 +241,143 @@ class AgentRuntimePRValidator:
             return ValidationResult(action=action, outcome=ValidationOutcome.ERROR, details=str(exc))
 
         if result.status is AgentRunStatus.SUCCEEDED:
-            return ValidationResult(
-                action=action,
-                outcome=ValidationOutcome.SKIPPED,
-                details="Agent Runtime validation runner completed; concrete probe verdict is deferred to #62.",
-            )
+            return None
         return ValidationResult(
             action=action,
             outcome=ValidationOutcome.ERROR,
             details=result.error or f"Agent Runtime validation ended with status {result.status.value}.",
         )
 
+    def _run_api_contract_probe(self, *, action: StrategyAction, request: APIContractProbeRequest) -> ValidationResult:
+        start = monotonic()
+        try:
+            result = self._api_contract_probe_executor.execute(request)
+        except TimeoutError as exc:
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.ERROR,
+                details=_probe_error_details(kind="timeout", exc=exc),
+                duration_seconds=monotonic() - start,
+            )
+        except Exception as exc:
+            return ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.ERROR,
+                details=_probe_error_details(kind="exception", exc=exc),
+                duration_seconds=monotonic() - start,
+            )
 
-def build_agent_runtime_pr_validator(*, runner: AgentRunner) -> AgentRuntimePRValidator:
+        return ValidationResult(
+            action=action,
+            outcome=result.outcome,
+            details=result.details,
+            duration_seconds=result.duration_seconds,
+            artifacts=result.artifacts,
+        )
+
+
+def build_agent_runtime_pr_validator(
+    *,
+    runner: AgentRunner,
+    api_contract_probe_executor: APIContractProbeExecutor | None = None,
+) -> AgentRuntimePRValidator:
     """Build the default provider-neutral validation runner wiring."""
     return AgentRuntimePRValidator(
         session_manager=WorkflowAgentSessionManager(runner=runner),
         tool_adapter=build_default_validation_tool_adapter(),
+        api_contract_probe_executor=api_contract_probe_executor,
     )
 
 
 def build_default_validation_tool_adapter() -> AgentFrameworkToolAdapter:
     """Expose validation-stage tool specs through the ToolRuntime seam.
 
-    The API contract probe handler is a deliberate placeholder for #62. It is
-    policy-gated and auditable, but returns an explicit skipped marker rather
-    than pretending to perform a live API contract check.
+    The API contract probe handler is deliberately non-live. It provides the
+    policy-gated Agent Framework-facing tool shape while concrete probe verdicts
+    are executed through the pluggable executor seam in ``AgentRuntimePRValidator``.
     """
     validation_tool = ToolDefinition(
         name=_VALIDATION_API_CONTRACT_PROBE,
         capabilities=(ToolCapability.EXECUTE,),
         description="Run a deterministic API contract probe",
-        input_schema={"type": "object", "properties": {"target": {"type": "string"}}},
-        handler=_api_contract_probe_not_implemented,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "target": {"type": "string"},
+                "method": {"type": "string"},
+                "path": {"type": "string"},
+            },
+        },
+        handler=_api_contract_probe_not_configured,
     )
     policy = StageToolPolicy({WorkflowStage.VALIDATOR: (_VALIDATION_API_CONTRACT_PROBE,)})
     runtime = RegisteredToolRuntime(tools=(validation_tool,), policy=policy)
     return AgentFrameworkToolAdapter(runtime=runtime, tools=(validation_tool,), policy=policy)
 
 
-def _api_contract_probe_not_implemented(call: ToolCall) -> dict[str, object]:
+def _api_contract_probe_not_configured(call: ToolCall) -> dict[str, object]:
     return {
         "status": "skipped",
-        "reason": "api_contract_probe_not_implemented",
+        "reason": "api_contract_probe_executor_not_configured",
         "target": call.input.get("target", ""),
     }
 
 
+def _has_complete_pr_event_context(event: PREvent) -> bool:
+    return bool(
+        event.repo_full_name.strip()
+        and event.pr_number > 0
+        and event.head_sha.strip()
+        and event.meta.correlation_id.strip()
+    )
+
+
+def _probe_error_details(*, kind: str, exc: Exception) -> str:
+    # Do not copy raw executor exception messages into externally rendered PR
+    # comments. Future live executors may include response bodies, tokens, or
+    # endpoint details in exception strings.
+    return f"{kind}: {type(exc).__name__} raised by API contract probe executor."
+
+
+def _api_contract_probe_request(
+    *,
+    event: PREvent,
+    action: StrategyAction,
+    timeout_seconds: float,
+) -> APIContractProbeRequest | None:
+    parsed = _parse_api_contract_target(action.target)
+    if parsed is None:
+        return None
+    method, path = parsed
+    return APIContractProbeRequest(
+        action=action,
+        target=action.target,
+        method=method,
+        path=path,
+        repo_full_name=event.repo_full_name,
+        pr_number=event.pr_number,
+        head_sha=event.head_sha,
+        correlation_id=event.meta.correlation_id,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _parse_api_contract_target(target: str) -> tuple[str, str] | None:
+    parts = target.strip().split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    method, path = parts[0].upper(), parts[1].strip()
+    if method not in _SUPPORTED_API_METHODS:
+        return None
+    if not path.startswith("/"):
+        return None
+    return method, path
+
+
 def _validation_prompt(action: StrategyAction) -> str:
     return (
-        "Run the validation action through qaestro's validation-stage tools only.\n"
-        "If the concrete probe tool reports that its implementation is not ready, report it as skipped.\n"
+        "Select qaestro's validation.api_contract.probe tool for API contract validation only.\n"
+        "Do not perform destructive or live external API calls unless a configured probe executor does so.\n"
         f"Action type: {action.action_type.value}\n"
         f"Target: {action.target}\n"
         f"Description: {action.description}\n"

--- a/tests/runtime/test_api_contract_probe_validator.py
+++ b/tests/runtime/test_api_contract_probe_validator.py
@@ -16,6 +16,7 @@ from src.core.contracts import (
     ValidationOutcome,
 )
 from src.runtime.agent.fake import FakeAgentRunner
+from src.runtime.agent.types import AgentRunInput, AgentRunResult, AgentRunStatus, AgentSessionHandle
 from src.runtime.stages import WorkflowStage
 from src.runtime.tools import AgentFrameworkToolAdapter, RegisteredToolRuntime, StageToolPolicy
 from src.runtime.validator import (
@@ -75,6 +76,80 @@ class RecordingProbeExecutor:
         if isinstance(self._result, BaseException):
             raise self._result
         return self._result
+
+
+class FailingAgentRunner(FakeAgentRunner):
+    def __init__(self, *, error: str) -> None:
+        super().__init__()
+        self._error = error
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        self.run_inputs.append(run_input)
+        return AgentRunResult(
+            session=session,
+            stage=run_input.stage,
+            status=AgentRunStatus.FAILED,
+            error=self._error,
+            allowed_tool_names=run_input.allowed_tool_names,
+        )
+
+
+class RaisingAgentRunner(FakeAgentRunner):
+    def __init__(self, *, error: str) -> None:
+        super().__init__()
+        self._error = error
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        self.run_inputs.append(run_input)
+        raise RuntimeError(self._error)
+
+
+def test_agent_runner_errors_are_sanitized_before_validation_details() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+    failing_runner = FailingAgentRunner(error="provider failed token=secret-token endpoint=https://private.example")
+    validator = build_agent_runtime_pr_validator(runner=failing_runner, api_contract_probe_executor=executor)
+
+    failed_result = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[
+        0
+    ]
+
+    assert failed_result.outcome is ValidationOutcome.ERROR
+    assert "agent_runner" in failed_result.details
+    assert "FAILED" in failed_result.details
+    assert "secret-token" not in failed_result.details
+    assert "private.example" not in failed_result.details
+    assert executor.requests == []
+
+    raising_runner = RaisingAgentRunner(error="transport crashed password=hunter2 endpoint=https://private.example")
+    validator = build_agent_runtime_pr_validator(runner=raising_runner, api_contract_probe_executor=executor)
+
+    raised_result = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[
+        0
+    ]
+
+    assert raised_result.outcome is ValidationOutcome.ERROR
+    assert "agent_runner_exception" in raised_result.details
+    assert "RuntimeError" in raised_result.details
+    assert "hunter2" not in raised_result.details
+    assert "private.example" not in raised_result.details
+
+
+def test_successful_probe_uses_wall_clock_duration_when_executor_duration_is_missing() -> None:
+    executor = RecordingProbeExecutor(
+        APIContractProbeResult(
+            outcome=ValidationOutcome.PASS,
+            details="probe passed but executor did not report duration",
+        )
+    )
+    validator = build_agent_runtime_pr_validator(
+        runner=FakeAgentRunner(response="agent selected validation.api_contract.probe"),
+        api_contract_probe_executor=executor,
+    )
+
+    validation = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[0]
+
+    assert validation.outcome is ValidationOutcome.PASS
+    assert validation.duration_seconds > 0.0
 
 
 def test_api_contract_action_executes_pluggable_probe_and_maps_pass_result() -> None:

--- a/tests/runtime/test_api_contract_probe_validator.py
+++ b/tests/runtime/test_api_contract_probe_validator.py
@@ -1,0 +1,240 @@
+"""Tests for deterministic API contract probe validation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from src.core.contracts import (
+    ActionType,
+    EventMeta,
+    EventSource,
+    EventType,
+    FileChange,
+    PROpened,
+    StrategyAction,
+    StrategyResult,
+    ValidationOutcome,
+)
+from src.runtime.agent.fake import FakeAgentRunner
+from src.runtime.stages import WorkflowStage
+from src.runtime.tools import AgentFrameworkToolAdapter, RegisteredToolRuntime, StageToolPolicy
+from src.runtime.validator import (
+    APIContractProbeRequest,
+    APIContractProbeResult,
+    build_agent_runtime_pr_validator,
+)
+
+
+def _event_meta(event_id: str, event_type: EventType, correlation_id: str) -> EventMeta:
+    return EventMeta(
+        event_id=event_id,
+        event_type=event_type,
+        correlation_id=correlation_id,
+        timestamp=datetime(2026, 5, 17, 12, 0, tzinfo=UTC),
+        source=EventSource.GITHUB,
+    )
+
+
+def _pr_opened_event(*, pr_number: int = 62, correlation_id: str = "corr-api-probe") -> PROpened:
+    return PROpened(
+        meta=_event_meta("evt-api-probe", EventType.PR_OPENED, correlation_id),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=pr_number,
+        title="feat(validator): API contract probe MVP",
+        body="Adds deterministic API contract probe execution.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/api-contract-probe-mvp",
+        diff_url=f"https://github.com/Kimcheolhui/qaestro/pull/{pr_number}.diff",
+        files_changed=(FileChange(path="src/runtime/validator/agent_runtime.py", status="modified", additions=80),),
+        head_sha=f"abc123probe-{pr_number}",
+    )
+
+
+def _strategy(*actions: StrategyAction) -> StrategyResult:
+    return StrategyResult(actions=actions, reasoning="Probe selected by test strategy.", confidence=0.92)
+
+
+def _api_contract_action(target: str = "GET /health") -> StrategyAction:
+    return StrategyAction(
+        action_type=ActionType.VERIFY_API_CONTRACT,
+        description="Validate API contract for health endpoint",
+        target=target,
+        priority=3,
+        rationale="API surface changed.",
+    )
+
+
+class RecordingProbeExecutor:
+    def __init__(self, result: APIContractProbeResult | BaseException) -> None:
+        self._result = result
+        self.requests: list[APIContractProbeRequest] = []
+
+    def execute(self, request: APIContractProbeRequest) -> APIContractProbeResult:
+        self.requests.append(request)
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+
+def test_api_contract_action_executes_pluggable_probe_and_maps_pass_result() -> None:
+    executor = RecordingProbeExecutor(
+        APIContractProbeResult(
+            outcome=ValidationOutcome.PASS,
+            details="probe passed: GET /health returned 200 with expected schema",
+            duration_seconds=0.42,
+            artifacts=("probe://api-contract/health-pass",),
+        )
+    )
+    fake_runner = FakeAgentRunner(response="agent selected validation.api_contract.probe")
+    validator = build_agent_runtime_pr_validator(runner=fake_runner, api_contract_probe_executor=executor)
+    event = _pr_opened_event()
+    action = _api_contract_action()
+
+    validations = validator.validate_for_event(event=event, strategy=_strategy(action))
+
+    assert len(validations) == 1
+    result = validations[0]
+    assert result.outcome is ValidationOutcome.PASS
+    assert result.details == "probe passed: GET /health returned 200 with expected schema"
+    assert result.duration_seconds == 0.42
+    assert result.artifacts == ("probe://api-contract/health-pass",)
+    assert fake_runner.run_inputs[0].allowed_tool_names == ("validation.api_contract.probe",)
+    assert len(executor.requests) == 1
+    request = executor.requests[0]
+    assert request.method == "GET"
+    assert request.path == "/health"
+    assert request.target == "GET /health"
+    assert request.repo_full_name == "Kimcheolhui/qaestro"
+    assert request.pr_number == 62
+    assert request.head_sha == "abc123probe-62"
+    assert request.correlation_id == "corr-api-probe"
+    assert request.action is action
+
+
+def test_unsupported_strategy_action_is_skipped_without_probe_execution() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+    validator = build_agent_runtime_pr_validator(runner=FakeAgentRunner(), api_contract_probe_executor=executor)
+    unsupported = StrategyAction(
+        action_type=ActionType.RUN_LINTER,
+        description="Run linter",
+        target="src/",
+        priority=1,
+        rationale="Non-probe action should be handled elsewhere.",
+    )
+
+    validations = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(unsupported))
+
+    assert validations[0].outcome is ValidationOutcome.SKIPPED
+    assert "unsupported validation action" in validations[0].details
+    assert "run_linter" in validations[0].details
+    assert executor.requests == []
+
+
+def test_invalid_api_contract_target_is_skipped_before_executor_runs() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+    validator = build_agent_runtime_pr_validator(runner=FakeAgentRunner(), api_contract_probe_executor=executor)
+
+    validations = validator.validate_for_event(
+        event=_pr_opened_event(), strategy=_strategy(_api_contract_action(target="health endpoint"))
+    )
+
+    assert validations[0].outcome is ValidationOutcome.SKIPPED
+    assert "unsupported API contract target" in validations[0].details
+    assert executor.requests == []
+
+
+def test_probe_failures_timeouts_and_partial_failures_are_distinguishable() -> None:
+    partial_executor = RecordingProbeExecutor(
+        APIContractProbeResult(
+            outcome=ValidationOutcome.FAIL,
+            details="partial_failure: 1 of 3 API contract checks failed",
+            duration_seconds=1.25,
+            artifacts=("probe://api-contract/partial-failure",),
+        )
+    )
+    partial_validator = build_agent_runtime_pr_validator(
+        runner=FakeAgentRunner(response="agent selected validation.api_contract.probe"),
+        api_contract_probe_executor=partial_executor,
+    )
+
+    partial = partial_validator.validate_for_event(
+        event=_pr_opened_event(), strategy=_strategy(_api_contract_action())
+    )[0]
+
+    assert partial.outcome is ValidationOutcome.FAIL
+    assert "partial_failure" in partial.details
+    assert partial.duration_seconds == 1.25
+    assert partial.artifacts == ("probe://api-contract/partial-failure",)
+
+    timeout_executor = RecordingProbeExecutor(TimeoutError("probe exceeded 30s budget token=secret-token"))
+    timeout_validator = build_agent_runtime_pr_validator(
+        runner=FakeAgentRunner(response="agent selected validation.api_contract.probe"),
+        api_contract_probe_executor=timeout_executor,
+    )
+
+    timeout = timeout_validator.validate_for_event(
+        event=_pr_opened_event(), strategy=_strategy(_api_contract_action())
+    )[0]
+
+    assert timeout.outcome is ValidationOutcome.ERROR
+    assert "timeout" in timeout.details
+    assert "TimeoutError" in timeout.details
+    assert "secret-token" not in timeout.details
+
+    exception_executor = RecordingProbeExecutor(RuntimeError("executor transport crashed password=hunter2"))
+    exception_validator = build_agent_runtime_pr_validator(
+        runner=FakeAgentRunner(response="agent selected validation.api_contract.probe"),
+        api_contract_probe_executor=exception_executor,
+    )
+
+    exception = exception_validator.validate_for_event(
+        event=_pr_opened_event(), strategy=_strategy(_api_contract_action())
+    )[0]
+
+    assert exception.outcome is ValidationOutcome.ERROR
+    assert "exception" in exception.details
+    assert "RuntimeError" in exception.details
+    assert "hunter2" not in exception.details
+
+
+def test_probe_requires_stage_approved_validation_tool_before_executor_runs() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+    validator = build_agent_runtime_pr_validator(runner=FakeAgentRunner(), api_contract_probe_executor=executor)
+    validator._tool_adapter = _empty_validation_tool_adapter()
+
+    validation = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[0]
+
+    assert validation.outcome is ValidationOutcome.ERROR
+    assert "validation.api_contract.probe is not allowed" in validation.details
+    assert executor.requests == []
+
+
+def test_probe_requires_complete_pr_event_context_before_executor_runs() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+    validator = build_agent_runtime_pr_validator(runner=FakeAgentRunner(), api_contract_probe_executor=executor)
+    event = PROpened(
+        meta=_event_meta("evt-missing-context", EventType.PR_OPENED, ""),
+        repo_full_name="",
+        pr_number=62,
+        title="feat(validator): missing context",
+        body="",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/api-contract-probe-mvp",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/62.diff",
+        files_changed=(),
+        head_sha="",
+    )
+
+    validation = validator.validate_for_event(event=event, strategy=_strategy(_api_contract_action()))[0]
+
+    assert validation.outcome is ValidationOutcome.ERROR
+    assert "complete PR event context is required" in validation.details
+    assert executor.requests == []
+
+
+def _empty_validation_tool_adapter() -> AgentFrameworkToolAdapter:
+    policy = StageToolPolicy({WorkflowStage.VALIDATOR: ()})
+    runtime = RegisteredToolRuntime(tools=(), policy=policy)
+    return AgentFrameworkToolAdapter(runtime=runtime, tools=(), policy=policy)

--- a/tests/runtime/test_validation_agent_runner.py
+++ b/tests/runtime/test_validation_agent_runner.py
@@ -92,8 +92,7 @@ def test_validation_stage_runs_provider_neutral_agent_runner_with_bounded_tools(
 
     assert result.validations[0].outcome is ValidationOutcome.SKIPPED
     assert (
-        result.validations[0].details
-        == "Agent Runtime validation runner completed; concrete probe verdict is deferred to #62."
+        result.validations[0].details == "api_contract_probe_skipped: no non-live executor configured for GET /health."
     )
     assert len(fake_runner.started_sessions) == 1
     assert fake_runner.started_sessions[0].scope.value == "workflow"


### PR DESCRIPTION
## Summary

This PR implements the Step 6 / #62 API contract probe MVP on top of the validation-stage Agent Runtime wiring from #81. The key boundary change is that `VERIFY_API_CONTRACT` strategy actions now become deterministic `APIContractProbeRequest`s and are executed through an injected `APIContractProbeExecutor`, instead of treating a successful agent turn as validation evidence.

The default executor remains non-live and non-destructive: without an injected probe executor, qaestro reports an explicit `SKIPPED` result rather than making external API calls or pretending validation passed. Fake/pluggable executors can now return structured `PASS`/`FAIL`/`ERROR`/`SKIPPED` outcomes with duration and artifact handles.

## Review focus

- Check that probe execution still preserves the validation-stage tool boundary: `validation.api_contract.probe` must be exposed by the stage-approved tool adapter before the executor can run.
- Check the fail-closed behavior for missing PR event context and runner failures.
- Check the mapping of unsupported actions, invalid API targets, partial failures, timeouts, exceptions, duration, and artifacts into `ValidationResult`.
- Check that exception details from executors are sanitized before they can appear in PR comments.

## Design notes

The executor is deliberately pluggable rather than live by default. That keeps #62 focused on the deterministic validator/probe contract while leaving opt-in live API probing for later hardening. The Agent Runtime runner is still used as the provider-neutral validation-stage selection seam, but the concrete probe verdict comes from the executor result, not from raw LLM/runner completion.

## Verification

Local verification completed before opening this PR:

- RED: `uv run pytest tests/runtime/test_api_contract_probe_validator.py -q` failed because the probe contracts/executor injection did not exist yet.
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- `uv run pytest tests -q`
- Independent fail-closed code review: passed after fixing tool-boundary, missing-context, and executor-error sanitization concerns.

Test VM, real-repository smoke, and remote CI results will be posted as a PR comment after the branch is pushed and the PR exists.

Closes #62

---
🤖 *Created by Hermes Agent*
