### PR TITLE
fix(strategy): reduce Step 6.5 recommendation noise

### DIFF
--- a/docs/MODULE_REQUIREMENTS.md
+++ b/docs/MODULE_REQUIREMENTS.md
@@ -317,6 +317,8 @@ qaestro를 구현할 때 참고할 수 있는 모듈 단위 요구사항 문서.
 - 위험 수준에 따라 검증 강도를 다르게 제안
 - MVP 범위에서 API contract, UI flow 중심 checklist 생성
 - knowledge가 연결되면 과거 패턴을 반영할 수 있어야 함
+- Step 6.5 기준으로 docs-only 같은 low-signal 변경은 검증 noise를 만들지 않고, config-only 변경은 설정 리뷰 action으로 분리하며, test-only 변경은 바뀐 test target 자체를 재실행 대상으로 삼는다.
+- `src/*` path group은 실제 `tests/*` 레이아웃으로 매핑하되, 보안 민감 변경은 별도 `CHECK_SECURITY` action을 남긴다.
 
 **제외 범위**
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -128,7 +128,7 @@ adapters.knowledge  → core.knowledge, shared
 
 - `core/contracts`: `PROpened`, `PRUpdated`, `PRCommented`, `PRReviewed`, `CICompleted`, `ChatMention` 같은 공통 이벤트 스키마와 domain type
 - `core/analyzer`: diff 분석, 영향 범위 추정, 리스크 분류
-- `core/strategy`: Behaviour Checklist 생성, 검증 전략 선택, 누락 테스트 제안
+- `core/strategy`: Behaviour Checklist 생성, 검증 전략 선택, 누락 테스트 제안. Step 6.5 기준으로 low-signal 변경 noise를 줄이고 실제 `tests/*` 레이아웃에 맞는 target을 제안한다.
 - `core/knowledge`: 고객 QA 지식 자산 접근을 위한 port, query model, in-memory mock
 
 ### `runtime/`
@@ -160,7 +160,7 @@ qaestro는 자유롭게 모든 것을 실행하는 agent가 아니라, 정해진
 
 이 관점은 그룹 구조에도 반영된다.
 
-- `core/strategy`: 규칙과 맥락 안에서 검증 전략을 선택하는 계층
+- `core/strategy`: 규칙과 맥락 안에서 검증 전략을 선택하는 계층. 현재 rule-based MVP는 confidence를 보정된 확률로 취급하지 않고, path group·CI·knowledge evidence를 바탕으로 한 deterministic 우선순위로만 사용한다.
 - `core/knowledge`: Agent가 참고하는 고객별 QA 지식 자산 접근 경계
 - `runtime/validator`: 허용된 probe만 실행하는 계층
 - `runtime/orchestrator`: confidence와 action type에 따라 제안, 검증, 승인 대기 흐름을 통제하는 계층
@@ -207,7 +207,7 @@ tests/e2e/
 
 ## 설계 포인트
 
-- 채널/provider별 코드는 `app/gateway`에 박아 넣기보다 `adapters/connectors/`로 분리하는 편이 확장에 유리하다.
+- 채널/provider별 코드는 `app/gateway`에 박아 넣기보다 `adapters/connectors/`로 분리하는 편이 확장에 유리하다. 현재 `ChatMention` contract와 dispatcher stub은 Step 0~6 foundation에 포함되어 있지만, Slack/Teams parser와 real connector는 Step 7에서 구현한다.
 - 고객별 QA knowledge는 `core/knowledge` port 뒤로 숨기고, 실제 저장소 구현은 `adapters/knowledge`로 미루는 편이 현재 배포 모델과 맞다.
 - Agent Runtime은 `runtime/agent`로 분리해 provider/session/runner 준비를 먼저 다룬다. validation workflow는 이 foundation 없이 먼저 확장하지 않는다.
 - Runtime Validation은 `runtime/validator`로 분리해야 이후 DB 정합성, 성능, multi-step behaviour probe를 붙이기 쉽다.

--- a/docs/notes/STEP_0_6_FOUNDATION_AUDIT.md
+++ b/docs/notes/STEP_0_6_FOUNDATION_AUDIT.md
@@ -57,7 +57,7 @@ Cleanup:
 
 MVP stub / 의도된 제한:
 
-- `ChatMention` type은 존재하지만 Slack/Teams parser와 real connector는 Step 7 범위다.
+- `ChatMention` type은 존재하며 queue/replay/dispatcher에서 운반 가능하지만, Slack/Teams raw webhook parser와 real connector는 Step 7 범위다.
 - `PRClosed`는 `docs/BACKLOG.md`의 parking lot에 남아 있다.
 
 ### Step 2 — Event → Worker → Output skeleton
@@ -180,7 +180,7 @@ MVP stub / 의도된 제한:
 
 Step 6.5의 나머지 이슈는 다음 역할로 남긴다.
 
-- #91: analyzer/strategy golden case와 recommendation noise 정리
+- #91: analyzer/strategy golden case와 recommendation noise 정리 — 이번 PR에서 docs-only, config-only, test-only, 실제 `tests/*` target mapping, 보안 민감 변경의 1차 strategy golden case와 rule 보강을 반영했다. 남은 범위는 analyzer path/risk taxonomy 고도화와 더 넓은 runtime/provider case 확장이다.
 - #92: runtime validation outcome 의미론과 sanitization 보강
 - #93: GitHub review output surface guardrail 강화
 - #94: PR aggregate current-head lifecycle replay 보강

--- a/src/core/contracts/domain.py
+++ b/src/core/contracts/domain.py
@@ -147,7 +147,7 @@ class StrategyAction:
         RUN_TESTS               test file path or directory (e.g. ``tests/``)
         RUN_LINTER              source directory (e.g. ``src/``)
         TYPE_CHECK              source directory or package name
-        CHECK_SECURITY          ``path:line`` or a source file
+        CHECK_SECURITY          security review target, usually ``security:<path group>``
         VERIFY_API_CONTRACT     HTTP method + route (e.g. ``POST /api/login``)
         SMOKE_TEST              endpoint URL or scenario id
         CUSTOM                  free-form — see ``description``

--- a/src/core/contracts/events.py
+++ b/src/core/contracts/events.py
@@ -153,10 +153,12 @@ class CICompleted:
 
 @dataclass(frozen=True)
 class ChatMention:
-    """The bot was mentioned in a chat channel."""
+    """The bot was mentioned in a chat channel.
 
-    # TODO(Step 6): add `parse_slack_mention_event` / `parse_teams_mention_event`
-    # parsers to accompany this type.
+    The normalized event contract exists so queues, replay, and orchestrator
+    dispatch can carry ChatOps triggers. Provider-specific Slack/Teams webhook
+    parsers and real chat connectors are intentionally deferred to Step 7.
+    """
 
     meta: EventMeta
     platform: str  # "slack", "teams"

--- a/src/core/strategy/rules.py
+++ b/src/core/strategy/rules.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath
+
 from src.core.contracts import (
     ActionType,
     BehaviourImpact,
@@ -44,6 +46,8 @@ class RuleBasedPRStrategyEngine:
         )
         actions = (
             *_area_actions(impact),
+            *_configuration_actions(impact),
+            *_security_actions(impact),
             *_baseline_actions(impact),
             *_ci_feedback_actions(ci_feedback),
             *_knowledge_actions(matches),
@@ -58,22 +62,34 @@ class RuleBasedPRStrategyEngine:
 
 def _area_actions(impact: BehaviourImpact) -> tuple[StrategyAction, ...]:
     """Create one focused check suggestion per observed path group."""
-    return tuple(
-        _action(
-            action_type=ActionType.RUN_TESTS,
-            description="Run focused tests or review checks for the observed path group",
-            target=f"tests/{area.module}",
-            area=area,
-            base_priority=2 if area.risk_level is RiskLevel.MEDIUM else 1,
+    actions: list[StrategyAction] = []
+    for area in impact.areas:
+        if _is_low_signal_doc_group(area.module) or _is_configuration_group(area.module):
+            continue
+        target = _test_target_for_area(area)
+        if target is None:
+            continue
+        actions.append(
+            _action(
+                action_type=ActionType.RUN_TESTS,
+                description=_test_action_description(area),
+                target=target,
+                area=area,
+                base_priority=2 if area.risk_level is RiskLevel.MEDIUM else 1,
+            )
         )
-        for area in impact.areas
-        if not _is_low_signal_doc_group(area.module)
-    )
+    return tuple(actions)
 
 
 def _baseline_actions(impact: BehaviourImpact) -> tuple[StrategyAction, ...]:
     actions: list[StrategyAction] = []
-    executable_groups = {area.module for area in impact.areas if not _is_low_signal_doc_group(area.module)}
+    executable_groups = {
+        area.module
+        for area in impact.areas
+        if not _is_low_signal_doc_group(area.module)
+        and not _is_configuration_group(area.module)
+        and not _is_test_only_group(area)
+    }
     if executable_groups:
         actions.append(
             StrategyAction(
@@ -98,6 +114,41 @@ def _knowledge_actions(matches: tuple[KnowledgeEntry, ...]) -> tuple[StrategyAct
                 target=f"knowledge:{entry.key}",
                 priority=4,
                 rationale=entry.summary,
+            )
+        )
+    return tuple(actions)
+
+
+def _configuration_actions(impact: BehaviourImpact) -> tuple[StrategyAction, ...]:
+    actions: list[StrategyAction] = []
+    for area in impact.areas:
+        if not _is_configuration_group(area.module):
+            continue
+        actions.append(
+            StrategyAction(
+                action_type=ActionType.CUSTOM,
+                description="Review configuration or workflow changes for policy and runtime impact",
+                target=f"config:{area.module}",
+                priority=_review_priority(area.risk_level),
+                rationale=f"Configuration-only path group changed: {_affected_files_text(area)}",
+            )
+        )
+    return tuple(actions)
+
+
+def _security_actions(impact: BehaviourImpact) -> tuple[StrategyAction, ...]:
+    """Add explicit security review actions for security-sensitive changes."""
+    actions: list[StrategyAction] = []
+    for area in impact.areas:
+        if _is_low_signal_doc_group(area.module) or not _is_security_sensitive_area(area):
+            continue
+        actions.append(
+            StrategyAction(
+                action_type=ActionType.CHECK_SECURITY,
+                description="Review auth, credential, permission, or secret-handling changes",
+                target=f"security:{area.module}",
+                priority=4 if _is_high(area.risk_level) else 3,
+                rationale=f"Security-sensitive signal observed in {area.module}: {_affected_files_text(area)}",
             )
         )
     return tuple(actions)
@@ -163,14 +214,50 @@ def _action(
     base_priority: int,
 ) -> StrategyAction:
     priority = base_priority + (1 if _is_high(area.risk_level) else 0)
-    files = ", ".join(area.affected_files[:3])
     return StrategyAction(
         action_type=action_type,
         description=description,
         target=target,
         priority=priority,
-        rationale=f"{area.module} path group is {area.risk_level.value} risk; affected files: {files}",
+        rationale=_area_action_rationale(area),
     )
+
+
+def _test_action_description(area: ImpactArea) -> str:
+    if _is_test_only_group(area):
+        return "Run the changed test target directly"
+    return "Run focused tests or review checks for the observed path group"
+
+
+def _area_action_rationale(area: ImpactArea) -> str:
+    prefix = "Test-only path group" if _is_test_only_group(area) else f"{area.module} path group"
+    return f"{prefix} is {area.risk_level.value} risk; affected files: {_affected_files_text(area)}"
+
+
+def _affected_files_text(area: ImpactArea) -> str:
+    return ", ".join(area.affected_files[:3]) or "none"
+
+
+def _test_target_for_area(area: ImpactArea) -> str | None:
+    module = area.module.strip("/")
+    if not module:
+        return None
+    if _is_test_only_group(area):
+        return module
+    if module.startswith("src/"):
+        return _test_target_for_src_module(module)
+    return f"tests/{module}"
+
+
+def _test_target_for_src_module(module: str) -> str:
+    parts = PurePosixPath(module).parts
+    if len(parts) == 1:
+        return "tests/"
+    if len(parts) >= 3 and parts[1] == "adapters" and parts[2] in {"connectors", "renderers"}:
+        return "/".join(("tests", parts[1], parts[2]))
+    if len(parts) >= 2 and parts[1] in {"app", "core", "runtime"}:
+        return "/".join(("tests", parts[1]))
+    return "/".join(("tests", *parts[1:]))
 
 
 def _reasoning(
@@ -272,7 +359,47 @@ def _query_text_from_title_and_impact(title: str, impact: BehaviourImpact) -> st
 
 
 def _is_low_signal_doc_group(path_group: str) -> bool:
-    return path_group.lower() in {"readme.md", "docs", "changelog.md"}
+    normalized = path_group.strip("/").lower()
+    if normalized in {"readme.md", "changelog.md", "contributing.md"}:
+        return True
+    return normalized == "docs" or normalized.startswith("docs/")
+
+
+def _is_test_only_group(area: ImpactArea) -> bool:
+    module = area.module.strip("/").lower()
+    return module == "tests" or module.startswith("tests/")
+
+
+def _is_configuration_group(path_group: str) -> bool:
+    normalized = path_group.strip("/").lower()
+    return normalized in {".github", ".github/workflows", "config", "infra"} or normalized.startswith(
+        (".github/", "config/", "infra/")
+    )
+
+
+def _is_security_sensitive_area(area: ImpactArea) -> bool:
+    haystack = " ".join((area.module, area.description, " ".join(area.affected_files))).lower()
+    return any(
+        signal in haystack
+        for signal in (
+            "auth",
+            "credential",
+            "permission",
+            "private_key",
+            "secret",
+            "signature",
+            "token",
+            "webhook",
+        )
+    )
+
+
+def _review_priority(risk: RiskLevel) -> int:
+    if _is_high(risk):
+        return 4
+    if risk is RiskLevel.MEDIUM:
+        return 2
+    return 1
 
 
 def _is_high(risk: RiskLevel) -> bool:

--- a/tests/core/test_strategy.py
+++ b/tests/core/test_strategy.py
@@ -11,6 +11,7 @@ from src.core.contracts import (
     CIReadinessState,
     ImpactArea,
     RiskLevel,
+    StrategyAction,
 )
 from src.core.knowledge import InMemoryKnowledgeBase, KnowledgeEntry, KnowledgeQuery
 from src.core.strategy import RuleBasedPRStrategyEngine
@@ -86,13 +87,20 @@ def test_strategy_generates_deterministic_actions_from_risk_areas_and_knowledge(
     assert result.knowledge_refs == ("refund-regression",)
     assert result.reasoning.startswith("Medium risk")
     assert [(action.action_type, action.target) for action in result.actions] == [
-        (ActionType.RUN_TESTS, "tests/src/api"),
-        (ActionType.RUN_TESTS, "tests/src/web/checkout"),
+        (ActionType.RUN_TESTS, "tests/api"),
+        (ActionType.RUN_TESTS, "tests/web/checkout"),
         (ActionType.RUN_TESTS, "tests/"),
         (ActionType.CUSTOM, "knowledge:refund-regression"),
     ]
     assert [action.priority for action in result.actions] == [2, 2, 2, 4]
     assert "zero-amount" in result.actions[-1].description
+
+
+def _action_by_target(actions: tuple[StrategyAction, ...], target: str) -> StrategyAction:
+    for action in actions:
+        if action.target == target:
+            return action
+    raise AssertionError(f"No action found for target {target!r}: {actions!r}")
 
 
 def test_strategy_generates_generic_actions_for_repo_observed_groups() -> None:
@@ -118,7 +126,7 @@ def test_strategy_generates_generic_actions_for_repo_observed_groups() -> None:
 
     assert result.actions
     assert result.actions[0].action_type is ActionType.RUN_TESTS
-    assert result.actions[0].target == "tests/src/adapters/connectors/github"
+    assert result.actions[0].target == "tests/adapters/connectors"
     assert result.actions[1].target == "tests/"
 
 
@@ -127,10 +135,16 @@ def test_strategy_skips_low_signal_doc_groups_for_step3_test_actions() -> None:
         summary="Changed documentation only",
         areas=(
             ImpactArea(
-                module="docs",
-                description="modified docs/ARCHITECTURE.md",
+                module="docs/notes",
+                description="modified docs/notes/ARCHITECTURE.md",
                 risk_level=RiskLevel.LOW,
-                affected_files=("docs/ARCHITECTURE.md",),
+                affected_files=("docs/notes/ARCHITECTURE.md",),
+            ),
+            ImpactArea(
+                module="README.md",
+                description="modified README.md",
+                risk_level=RiskLevel.LOW,
+                affected_files=("README.md",),
             ),
             ImpactArea(
                 module="CHANGELOG.md",
@@ -150,6 +164,144 @@ def test_strategy_skips_low_signal_doc_groups_for_step3_test_actions() -> None:
     )
 
     assert result.actions == ()
+
+
+def test_strategy_maps_runtime_and_adapter_changes_to_existing_test_roots() -> None:
+    impact = BehaviourImpact(
+        summary="Changed runtime validation and renderer output",
+        areas=(
+            ImpactArea(
+                module="src/runtime/validator",
+                description="modified src/runtime/validator/agent_runtime.py",
+                risk_level=RiskLevel.MEDIUM,
+                affected_files=("src/runtime/validator/agent_runtime.py",),
+            ),
+            ImpactArea(
+                module="src/adapters/renderers",
+                description="modified src/adapters/renderers/pr_comment.py",
+                risk_level=RiskLevel.MEDIUM,
+                affected_files=("src/adapters/renderers/pr_comment.py",),
+            ),
+        ),
+        overall_risk=RiskLevel.MEDIUM,
+    )
+
+    result = RuleBasedPRStrategyEngine().plan(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=41,
+        title="fix: harden validation output",
+        impact=impact,
+    )
+
+    assert _action_by_target(result.actions, "tests/adapters/renderers").action_type is ActionType.RUN_TESTS
+    assert _action_by_target(result.actions, "tests/runtime").action_type is ActionType.RUN_TESTS
+    assert all("tests/src/" not in action.target for action in result.actions)
+
+
+def test_strategy_keeps_test_only_changes_from_creating_nested_test_targets() -> None:
+    impact = BehaviourImpact(
+        summary="Changed tests only",
+        areas=(
+            ImpactArea(
+                module="tests/runtime",
+                description="modified tests/runtime/test_validation_agent_runner.py",
+                risk_level=RiskLevel.LOW,
+                affected_files=("tests/runtime/test_validation_agent_runner.py",),
+            ),
+        ),
+        overall_risk=RiskLevel.LOW,
+    )
+
+    result = RuleBasedPRStrategyEngine().plan(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        title="test: add runtime regression coverage",
+        impact=impact,
+    )
+
+    assert [(action.action_type, action.target) for action in result.actions] == [
+        (ActionType.RUN_TESTS, "tests/runtime"),
+    ]
+    assert result.actions[0].priority == 1
+    assert "Test-only" in result.actions[0].rationale
+
+
+def test_strategy_uses_config_review_instead_of_nested_test_targets_for_config_only_changes() -> None:
+    impact = BehaviourImpact(
+        summary="Changed CI workflow only",
+        areas=(
+            ImpactArea(
+                module=".github/workflows",
+                description="modified .github/workflows/ci.yml",
+                risk_level=RiskLevel.LOW,
+                affected_files=(".github/workflows/ci.yml",),
+            ),
+        ),
+        overall_risk=RiskLevel.LOW,
+    )
+
+    result = RuleBasedPRStrategyEngine().plan(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=43,
+        title="ci: update workflow trigger",
+        impact=impact,
+    )
+
+    assert [(action.action_type, action.target) for action in result.actions] == [
+        (ActionType.CUSTOM, "config:.github/workflows"),
+    ]
+    assert "configuration" in result.actions[0].description.lower()
+
+
+def test_strategy_prioritizes_high_risk_config_review_and_security_signal() -> None:
+    impact = BehaviourImpact(
+        summary="Changed workflow permissions",
+        areas=(
+            ImpactArea(
+                module=".github/workflows",
+                description="modified .github/workflows/deploy.yml with permission changes",
+                risk_level=RiskLevel.HIGH,
+                affected_files=(".github/workflows/deploy.yml",),
+            ),
+        ),
+        overall_risk=RiskLevel.HIGH,
+    )
+
+    result = RuleBasedPRStrategyEngine().plan(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=44,
+        title="ci: update deployment permissions",
+        impact=impact,
+    )
+
+    assert _action_by_target(result.actions, "config:.github/workflows").priority == 4
+    assert _action_by_target(result.actions, "security:.github/workflows").priority == 4
+
+
+def test_strategy_adds_security_review_for_security_sensitive_changes() -> None:
+    impact = BehaviourImpact(
+        summary="Changed webhook auth handling",
+        areas=(
+            ImpactArea(
+                module="src/adapters/connectors/github",
+                description="modified src/adapters/connectors/github/auth.py",
+                risk_level=RiskLevel.HIGH,
+                affected_files=("src/adapters/connectors/github/auth.py",),
+            ),
+        ),
+        overall_risk=RiskLevel.HIGH,
+    )
+
+    result = RuleBasedPRStrategyEngine().plan(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=43,
+        title="fix: update auth token handling",
+        impact=impact,
+    )
+
+    assert (ActionType.CHECK_SECURITY, "security:src/adapters/connectors/github") in [
+        (action.action_type, action.target) for action in result.actions
+    ]
 
 
 def test_strategy_includes_current_head_ci_failure_without_mixing_stale_history() -> None:


### PR DESCRIPTION
## 요약

Step 6.5에서 남아 있던 문서/구현 정렬 범위와 analyzer/strategy recommendation noise 1차 보강을 같이 묶었습니다.

이번 변경은 Step 7 ChatOps로 넘어가기 전에 rule-based Strategy Engine이 저신호 변경을 과하게 검증 대상으로 만들지 않도록 정리하는 작업입니다. docs-only 변경은 action을 만들지 않고, config-only 변경은 존재하지 않는 `tests/.github/...` 같은 target 대신 설정 리뷰 action으로 분리합니다. test-only 변경은 전체 regression action을 추가하지 않고 변경된 test target 자체를 다시 실행하도록 했습니다.

## 리뷰 포인트

- `src/*` path group을 실제 repo의 `tests/*` 레이아웃에 맞춰 매핑하는 규칙이 너무 과하거나 부족하지 않은지 봐주세요.
- `.github/workflows`, `config`, `infra` 변경은 test target이 아니라 config review action으로 분리했고, high-risk workflow/permission 변경은 security action도 함께 남기도록 했습니다.
- `ChatMention`은 Step 0~6 foundation에서 운반 가능한 contract/stub까지 존재하지만, Slack/Teams raw parser와 real connector는 Step 7로 명확히 defer했습니다.

## 범위

이 PR은 rule-based MVP의 noise를 줄이는 1차 hardening입니다. analyzer의 path/risk taxonomy 전체 고도화, runtime/provider 변경 유형의 더 넓은 golden case, LLM 기반 strategy 개선은 후속 범위로 남깁니다.

Closes #90
Closes #91

---
Co-worked by Hermes Agent
