### PR TITLE
feat(runtime): add agent-backed PR triage

### DIFF
--- a/src/app/worker/factory.py
+++ b/src/app/worker/factory.py
@@ -15,6 +15,7 @@ from src.runtime.agent import (
 )
 from src.runtime.agent.types import AgentRunner
 from src.runtime.orchestrator import (
+    AgentBackedPRWorkflowTriageClassifier,
     CIWorkflowOrchestrator,
     EventOrchestrator,
     InMemoryPRAggregateStore,
@@ -70,11 +71,13 @@ def build_worker(cfg: AppConfig) -> Worker:
     client = _build_github_client(cfg)
     tool_runtime = _build_github_tool_runtime(client)
     pr_aggregate_store = InMemoryPRAggregateStore()
+    agent_runner = _build_validation_agent_runner(cfg)
     return Worker(
         orchestrator=EventOrchestrator(
             pr_orchestrator=PRWorkflowOrchestrator(
                 context_provider=ToolRuntimePRContextProvider(tool_runtime),
-                validator=build_agent_runtime_pr_validator(runner=_build_validation_agent_runner(cfg)),
+                triage_classifier=AgentBackedPRWorkflowTriageClassifier(runner=agent_runner),
+                validator=build_agent_runtime_pr_validator(runner=agent_runner),
                 ci_feedback_provider=lambda event: _load_ci_feedback_for_pr_event(
                     event=event,
                     aggregate_store=pr_aggregate_store,

--- a/src/runtime/orchestrator/__init__.py
+++ b/src/runtime/orchestrator/__init__.py
@@ -29,7 +29,12 @@ from .pr_aggregate import (
 )
 from .pr_context import EventPRContextProvider, PRContextProvider
 from .pr_event_stubs import PRCommentWorkflowOrchestrator, PRReviewWorkflowOrchestrator
-from .pr_triage import PRWorkflowDepth, PRWorkflowTriage, RuleBasedPRWorkflowTriageClassifier
+from .pr_triage import (
+    AgentBackedPRWorkflowTriageClassifier,
+    PRWorkflowDepth,
+    PRWorkflowTriage,
+    RuleBasedPRWorkflowTriageClassifier,
+)
 from .pr_workflow import PRWorkflowOrchestrator, StubPRRuntimeValidator
 from .tool_context import (
     PRCheckSnapshotProvider,
@@ -51,6 +56,7 @@ from .types import (
 )
 
 __all__ = [
+    "AgentBackedPRWorkflowTriageClassifier",
     "CIContextProvider",
     "CIWorkflowDepth",
     "CIWorkflowOrchestrator",

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import re
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
 
-from src.core.analyzer import PRAnalysisContext, PRFileStatus
+from src.core.analyzer import PRAnalysisContext, PRFileDiff, PRFileStatus
+from src.runtime.agent import AgentRunInput, AgentRunStatus, AgentSessionHandle, AgentSessionScope
+from src.runtime.agent.types import AgentRunner
 from src.runtime.stages import WorkflowStage
 
 
@@ -79,6 +84,191 @@ class RuleBasedPRWorkflowTriageClassifier:
             rationale="Default PR workflow depth; run behaviour analysis and strategy planning.",
             allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
         )
+
+
+class AgentBackedPRWorkflowTriageClassifier:
+    """Agent Runtime-backed PR intent/depth classifier with conservative fallback.
+
+    The classifier asks the Agent Runtime to judge workflow depth from PR intent,
+    risk, and repository context rather than treating path categories such as
+    docs-only/config-only/test-only as perfect rules. The deterministic fallback
+    remains a safety net for unavailable or malformed agent responses.
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: AgentRunner,
+        fallback: RuleBasedPRWorkflowTriageClassifier | None = None,
+        max_turns: int = 1,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._runner = runner
+        self._fallback = fallback or RuleBasedPRWorkflowTriageClassifier()
+        self._max_turns = max_turns
+        self._timeout_seconds = timeout_seconds
+
+    def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage:
+        fallback = self._fallback.classify(context)
+        session_handle = _triage_session_handle(context)
+        session = session_handle
+        try:
+            session = self._runner.start_session(session_handle)
+            result = self._runner.run(
+                session=session,
+                run_input=AgentRunInput(
+                    stage=WorkflowStage.TRIAGE,
+                    prompt=_agent_triage_prompt(),
+                    correlation_id=session.correlation_id,
+                    context=_agent_triage_context(context),
+                    max_turns=self._max_turns,
+                    max_tool_calls=0,
+                    timeout_seconds=self._timeout_seconds,
+                ),
+            )
+        except Exception as exc:
+            return _fallback_triage(fallback, f"agent_runner_exception: {_safe_error(exc)}")
+        finally:
+            with suppress(Exception):
+                self._runner.close_session(session, reason="triage stage complete")
+
+        if result.status is not AgentRunStatus.SUCCEEDED:
+            return _fallback_triage(fallback, f"agent_runner_status: {result.status.value}")
+
+        try:
+            return _triage_from_agent_output(result.output_text)
+        except ValueError as exc:
+            return _fallback_triage(fallback, f"invalid_agent_output: {_safe_error(exc)}")
+
+
+def _agent_triage_prompt() -> str:
+    return """
+You are qaestro's PR workflow triage layer. Choose the bounded workflow depth for this pull request.
+
+Do not classify PRs from path taxonomies alone. docs-only, config-only, and test-only are imperfect labels:
+- documentation can describe deployment, security, migration, or runbook behaviour;
+- configuration can change CI, release, runtime, or provider policy;
+- tests can reveal intended behaviour or coverage gaps.
+
+Judge PR intent, behavioural impact, operational risk, and available evidence. Return only compact JSON:
+{"depth":"noop|lightweight|normal|deep","rationale":"short audit reason","allowed_stages":["analyzer","strategy","validator"]}
+
+Depth guide:
+- noop: qaestro should produce no output for irrelevant generated/metadata noise.
+- lightweight: low-signal changes where a short triage output is enough.
+- normal: behaviour analysis and strategy planning are needed.
+- deep: high-impact/security/deployment/migration changes require validation even if normal policy might skip it.
+""".strip()
+
+
+def _triage_session_handle(context: PRAnalysisContext) -> AgentSessionHandle:
+    return AgentSessionHandle(
+        session_id=f"triage-{_safe_session_part(context.repo_full_name)}-{context.pr_number}",
+        scope=AgentSessionScope.STAGE,
+        repo_full_name=context.repo_full_name,
+        pr_number=context.pr_number,
+        head_sha="unknown",
+        trigger="triage",
+        correlation_id=f"triage-{context.repo_full_name}-{context.pr_number}",
+    )
+
+
+def _agent_triage_context(context: PRAnalysisContext) -> Mapping[str, object]:
+    return {
+        "repo_full_name": context.repo_full_name,
+        "pr_number": context.pr_number,
+        "title": context.title,
+        "body": context.body,
+        "base_branch": context.base_branch,
+        "head_branch": context.head_branch,
+        "changed_lines": sum(file.additions + file.deletions for file in context.files),
+        "files": tuple(_file_summary(file) for file in context.files),
+        "unified_diff_excerpt": context.unified_diff[:8000],
+    }
+
+
+def _file_summary(file: PRFileDiff) -> Mapping[str, object]:
+    summary: dict[str, object] = {
+        "path": file.path,
+        "status": file.status.value,
+        "additions": file.additions,
+        "deletions": file.deletions,
+    }
+    if file.previous_filename:
+        summary["previous_filename"] = file.previous_filename
+    if file.patch:
+        summary["patch_excerpt"] = file.patch[:1200]
+    return summary
+
+
+def _triage_from_agent_output(output_text: str) -> PRWorkflowTriage:
+    data = _json_object_from_text(output_text)
+    depth = _parse_depth(data.get("depth"))
+    rationale = str(data.get("rationale") or "Agent triage selected workflow depth.").strip()
+    if not rationale:
+        rationale = "Agent triage selected workflow depth."
+    allowed_stages = _parse_allowed_stages(data.get("allowed_stages"), depth)
+    return PRWorkflowTriage(depth=depth, rationale=rationale, allowed_stages=allowed_stages)
+
+
+def _json_object_from_text(output_text: str) -> Mapping[str, object]:
+    try:
+        parsed = json.loads(output_text)
+    except json.JSONDecodeError as exc:
+        match = re.search(r"\{.*\}", output_text, flags=re.DOTALL)
+        if match is None:
+            raise ValueError("agent output did not contain a JSON object") from exc
+        parsed = json.loads(match.group(0))
+    if not isinstance(parsed, Mapping):
+        raise ValueError("agent output JSON must be an object")
+    return parsed
+
+
+def _parse_depth(value: object) -> PRWorkflowDepth:
+    try:
+        return PRWorkflowDepth(str(value).strip().lower())
+    except ValueError as exc:
+        raise ValueError(f"unsupported triage depth: {value!r}") from exc
+
+
+def _parse_allowed_stages(value: object, depth: PRWorkflowDepth) -> tuple[WorkflowStage, ...]:
+    if value is None:
+        return _default_allowed_stages(depth)
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        raise ValueError("allowed_stages must be a list of stage names")
+    stages: list[WorkflowStage] = []
+    for item in value:
+        try:
+            stage = WorkflowStage(str(item).strip().lower())
+        except ValueError as exc:
+            raise ValueError(f"unsupported allowed stage: {item!r}") from exc
+        if stage not in (WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR):
+            raise ValueError(f"triage cannot allow workflow stage: {stage.value}")
+        stages.append(stage)
+    return tuple(dict.fromkeys(stages))
+
+
+def _default_allowed_stages(depth: PRWorkflowDepth) -> tuple[WorkflowStage, ...]:
+    if depth in (PRWorkflowDepth.NORMAL, PRWorkflowDepth.DEEP):
+        return (WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR)
+    return ()
+
+
+def _fallback_triage(fallback: PRWorkflowTriage, reason: str) -> PRWorkflowTriage:
+    return PRWorkflowTriage(
+        depth=fallback.depth,
+        rationale=f"Agent triage unavailable ({reason}); fallback used: {fallback.rationale}",
+        allowed_stages=fallback.allowed_stages,
+    )
+
+
+def _safe_error(exc: Exception) -> str:
+    text = str(exc).replace("\n", " ").strip()
+    return text[:160] or exc.__class__.__name__
+
+
+def _safe_session_part(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-") or "repo"
 
 
 _LOW_SIGNAL_ROOT_FILES = {"readme.md", "changelog.md", "license", "notice"}

--- a/tests/app/worker/test_worker_factory.py
+++ b/tests/app/worker/test_worker_factory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from src.app.worker.factory import build_worker
 from src.app.worker.runner import NoopOutputPoster
 from src.runtime.orchestrator import (
+    AgentBackedPRWorkflowTriageClassifier,
     CIWorkflowOrchestrator,
     EventOrchestrator,
     ToolRuntimeCIContextProvider,
@@ -90,6 +91,7 @@ def test_build_worker_wires_github_tool_runtime_for_durable_queue(tmp_path: Path
     pr_orchestrator = orchestrator._pr_orchestrator
     ci_orchestrator = orchestrator._ci_orchestrator
     assert isinstance(pr_orchestrator._context_provider, ToolRuntimePRContextProvider)
+    assert isinstance(pr_orchestrator._triage_classifier, AgentBackedPRWorkflowTriageClassifier)
     assert isinstance(pr_orchestrator._validator, AgentRuntimePRValidator)
     assert pr_orchestrator._ci_feedback_provider is not None
     assert isinstance(ci_orchestrator, CIWorkflowOrchestrator)

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -30,7 +30,9 @@ from src.core.contracts import (
     ValidationOutcome,
     ValidationResult,
 )
+from src.runtime.agent import AgentRunInput, AgentRunResult, AgentRunStatus, AgentSessionHandle
 from src.runtime.orchestrator import (
+    AgentBackedPRWorkflowTriageClassifier,
     ChatWorkflowOrchestrator,
     CIWorkflowDepth,
     CIWorkflowOrchestrator,
@@ -593,6 +595,103 @@ def test_rule_based_triage_deep_signal_matching_uses_token_boundaries() -> None:
 
     assert false_positive_result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
     assert deep_signal_result.triage.depth is PRWorkflowDepth.DEEP
+
+
+def test_agent_backed_triage_uses_runner_depth_decision_for_docs_and_config_intent() -> None:
+    class TriageDecisionRunner:
+        def __init__(self) -> None:
+            self.run_inputs: list[AgentRunInput] = []
+
+        def start_session(self, handle: AgentSessionHandle) -> AgentSessionHandle:
+            return handle
+
+        def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+            self.run_inputs.append(run_input)
+            return AgentRunResult(
+                session=session,
+                stage=run_input.stage,
+                status=AgentRunStatus.SUCCEEDED,
+                output_text=(
+                    '{"depth":"normal","rationale":"Docs and config changes update release policy; '
+                    'run behaviour analysis instead of relying on path-only rules.",'
+                    '"allowed_stages":["analyzer","strategy","validator"]}'
+                ),
+            )
+
+        def close_session(self, handle: AgentSessionHandle, *, reason: str) -> None:
+            del handle, reason
+
+    event = PROpened(
+        meta=_event_meta("evt-agent-triage", EventType.PR_OPENED, "corr-agent-triage"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=48,
+        title="docs: update release process",
+        body="Clarifies deployment approval policy.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="docs/release-process",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/48.diff",
+        head_sha="abc1234",
+        files_changed=(FileChange(path="docs/release.md", status="modified", additions=2, deletions=1),),
+    )
+    runner = TriageDecisionRunner()
+    classifier = AgentBackedPRWorkflowTriageClassifier(runner=runner, fallback=RuleBasedPRWorkflowTriageClassifier())
+
+    result = PRWorkflowOrchestrator(triage_classifier=classifier).run(event)
+
+    assert result.triage.depth is PRWorkflowDepth.NORMAL
+    assert result.triage.rationale == (
+        "Docs and config changes update release policy; run behaviour analysis instead of relying on path-only rules."
+    )
+    assert result.stage_order[:3] == (WorkflowStage.CONTEXT, WorkflowStage.TRIAGE, WorkflowStage.ANALYZER)
+    assert len(runner.run_inputs) == 1
+    run_input = runner.run_inputs[0]
+    assert run_input.stage is WorkflowStage.TRIAGE
+    assert "Do not classify PRs from path taxonomies alone" in run_input.prompt
+    assert run_input.context is not None
+    assert run_input.context["files"] == (
+        {"path": "docs/release.md", "status": "modified", "additions": 2, "deletions": 1},
+    )
+
+
+def test_agent_backed_triage_falls_back_when_runner_response_is_invalid() -> None:
+    class InvalidTriageRunner:
+        def start_session(self, handle: AgentSessionHandle) -> AgentSessionHandle:
+            return handle
+
+        def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+            return AgentRunResult(
+                session=session,
+                stage=run_input.stage,
+                status=AgentRunStatus.SUCCEEDED,
+                output_text="not-json",
+            )
+
+        def close_session(self, handle: AgentSessionHandle, *, reason: str) -> None:
+            del handle, reason
+
+    event = PROpened(
+        meta=_event_meta("evt-agent-triage-invalid", EventType.PR_OPENED, "corr-agent-triage-invalid"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=49,
+        title="docs: update contributor guide",
+        body="Clarifies wording only.",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="docs/contributor-guide",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/49.diff",
+        files_changed=(FileChange(path="docs/CONTRIBUTING.md", status="modified", additions=3, deletions=1),),
+    )
+    classifier = AgentBackedPRWorkflowTriageClassifier(
+        runner=InvalidTriageRunner(),
+        fallback=RuleBasedPRWorkflowTriageClassifier(),
+    )
+
+    result = PRWorkflowOrchestrator(triage_classifier=classifier).run(event)
+
+    assert result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
+    assert "Agent triage unavailable" in result.triage.rationale
+    assert "Small low-signal documentation" in result.triage.rationale
 
 
 def test_pr_workflow_orchestrator_uses_renders_output_contract_for_noop() -> None:


### PR DESCRIPTION
## Summary
Agent Runtime 기반 PR triage classifier를 추가해 workflow depth를 path taxonomy만으로 판단하지 않고 PR intent, 행동 영향, 운영 위험 기준으로 판단할 수 있게 했습니다. 기존 rule-based classifier는 agent 실패나 비정상 응답 시 conservative fallback으로 남겨두었습니다.

Durable worker wiring도 새 classifier를 사용하도록 변경해 실제 redis-streams worker 경로에서 triage 단계가 Agent Runtime 판단을 거치도록 했습니다. docs-only/config-only/test-only 같은 분류는 prompt에서 불완전한 힌트로만 취급하고, rationale과 allowed stages를 구조화된 JSON으로 받도록 했습니다.

---
Co-worked by Hermes Agent