### PR TITLE
feat(runtime): centralize agent prompts

### DIFF
--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -12,6 +12,7 @@ from enum import StrEnum
 from src.core.analyzer import PRAnalysisContext, PRFileDiff, PRFileStatus
 from src.runtime.agent import AgentRunInput, AgentRunStatus, AgentSessionHandle, AgentSessionScope
 from src.runtime.agent.types import AgentRunner
+from src.runtime.prompts import PromptId, load_prompt
 from src.runtime.stages import WorkflowStage
 
 
@@ -118,7 +119,7 @@ class AgentBackedPRWorkflowTriageClassifier:
                 session=session,
                 run_input=AgentRunInput(
                     stage=WorkflowStage.TRIAGE,
-                    prompt=_agent_triage_prompt(),
+                    prompt=load_prompt(PromptId.PR_WORKFLOW_TRIAGE).text,
                     correlation_id=session.correlation_id,
                     context=_agent_triage_context(context),
                     max_turns=self._max_turns,
@@ -139,26 +140,6 @@ class AgentBackedPRWorkflowTriageClassifier:
             return _triage_from_agent_output(result.output_text)
         except ValueError as exc:
             return _fallback_triage(fallback, f"invalid_agent_output: {_safe_error(exc)}")
-
-
-def _agent_triage_prompt() -> str:
-    return """
-You are qaestro's PR workflow triage layer. Choose the bounded workflow depth for this pull request.
-
-Do not classify PRs from path taxonomies alone. docs-only, config-only, and test-only are imperfect labels:
-- documentation can describe deployment, security, migration, or runbook behaviour;
-- configuration can change CI, release, runtime, or provider policy;
-- tests can reveal intended behaviour or coverage gaps.
-
-Judge PR intent, behavioural impact, operational risk, and available evidence. Return only compact JSON:
-{"depth":"noop|lightweight|normal|deep","rationale":"short audit reason","allowed_stages":["analyzer","strategy","validator"]}
-
-Depth guide:
-- noop: qaestro should produce no output for irrelevant generated/metadata noise.
-- lightweight: low-signal changes where a short triage output is enough.
-- normal: behaviour analysis and strategy planning are needed.
-- deep: high-impact/security/deployment/migration changes require validation even if normal policy might skip it.
-""".strip()
 
 
 def _triage_session_handle(context: PRAnalysisContext) -> AgentSessionHandle:

--- a/src/runtime/prompts/__init__.py
+++ b/src/runtime/prompts/__init__.py
@@ -1,0 +1,64 @@
+"""Central Agent Runtime prompt catalog loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class PromptCatalogError(RuntimeError):
+    """Raised when a centrally managed prompt cannot be loaded or rendered."""
+
+
+class PromptId(StrEnum):
+    """Stable prompt identifiers used by Agent Runtime stages."""
+
+    PR_WORKFLOW_TRIAGE = "pr-workflow-triage"
+    VALIDATION_API_CONTRACT_PROBE_SELECTION = "validation-api-contract-probe-selection"
+
+
+@dataclass(frozen=True)
+class PromptTemplate:
+    """Loaded prompt template text and source path for auditability."""
+
+    identifier: PromptId
+    path: str
+    text: str
+
+
+_PROMPT_DIR = Path(__file__).with_name("catalog")
+_PROMPT_FILES = {
+    PromptId.PR_WORKFLOW_TRIAGE: "pr-workflow-triage.md",
+    PromptId.VALIDATION_API_CONTRACT_PROBE_SELECTION: "validation-api-contract-probe-selection.md",
+}
+
+
+def load_prompt(identifier: PromptId | str) -> PromptTemplate:
+    """Load a markdown prompt template by stable identifier."""
+    prompt_id = _normalize_prompt_id(identifier)
+    path = _PROMPT_DIR / _PROMPT_FILES[prompt_id]
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise PromptCatalogError(f"prompt file not found for {prompt_id.value}: {path}") from exc
+    if not text:
+        raise PromptCatalogError(f"prompt file is empty for {prompt_id.value}: {path}")
+    return PromptTemplate(identifier=prompt_id, path=str(path), text=text)
+
+
+def render_prompt(identifier: PromptId | str, **variables: object) -> str:
+    """Load and render a prompt template with explicit runtime variables."""
+    template = load_prompt(identifier)
+    try:
+        return template.text.format(**{key: str(value) for key, value in variables.items()})
+    except KeyError as exc:
+        missing = str(exc).strip("'")
+        raise PromptCatalogError(f"missing template variable {missing!r} for {template.identifier.value}") from exc
+
+
+def _normalize_prompt_id(identifier: PromptId | str) -> PromptId:
+    try:
+        return identifier if isinstance(identifier, PromptId) else PromptId(identifier)
+    except ValueError as exc:
+        raise PromptCatalogError(f"unknown prompt id: {identifier!r}") from exc

--- a/src/runtime/prompts/catalog/pr-workflow-triage.md
+++ b/src/runtime/prompts/catalog/pr-workflow-triage.md
@@ -1,0 +1,15 @@
+You are qaestro's PR workflow triage layer. Choose the bounded workflow depth for this pull request.
+
+Do not classify PRs from path taxonomies alone. docs-only, config-only, and test-only are imperfect labels:
+- documentation can describe deployment, security, migration, or runbook behaviour;
+- configuration can change CI, release, runtime, or provider policy;
+- tests can reveal intended behaviour or coverage gaps.
+
+Judge PR intent, behavioural impact, operational risk, and available evidence. Return only compact JSON:
+{{"depth":"noop|lightweight|normal|deep","rationale":"short audit reason","allowed_stages":["analyzer","strategy","validator"]}}
+
+Depth guide:
+- noop: qaestro should produce no output for irrelevant generated/metadata noise.
+- lightweight: low-signal changes where a short triage output is enough.
+- normal: behaviour analysis and strategy planning are needed.
+- deep: high-impact/security/deployment/migration changes require validation even if normal policy might skip it.

--- a/src/runtime/prompts/catalog/validation-api-contract-probe-selection.md
+++ b/src/runtime/prompts/catalog/validation-api-contract-probe-selection.md
@@ -1,0 +1,6 @@
+Select qaestro's validation.api_contract.probe tool for API contract validation only.
+Do not perform destructive or live external API calls unless a configured probe executor does so.
+Action type: {action_type}
+Target: {target}
+Description: {description}
+Rationale: {rationale}

--- a/src/runtime/validator/agent_runtime.py
+++ b/src/runtime/validator/agent_runtime.py
@@ -16,6 +16,7 @@ from src.core.contracts import (
 )
 from src.runtime.agent.manager import WorkflowAgentSessionManager
 from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunStatus, AgentSessionHandle
+from src.runtime.prompts import PromptId, render_prompt
 from src.runtime.stages import WorkflowStage
 from src.runtime.tools import (
     AgentFrameworkToolAdapter,
@@ -439,11 +440,10 @@ def _parse_api_contract_target(target: str) -> tuple[str, str] | None:
 
 
 def _validation_prompt(action: StrategyAction) -> str:
-    return (
-        "Select qaestro's validation.api_contract.probe tool for API contract validation only.\n"
-        "Do not perform destructive or live external API calls unless a configured probe executor does so.\n"
-        f"Action type: {action.action_type.value}\n"
-        f"Target: {action.target}\n"
-        f"Description: {action.description}\n"
-        f"Rationale: {action.rationale}"
+    return render_prompt(
+        PromptId.VALIDATION_API_CONTRACT_PROBE_SELECTION,
+        action_type=action.action_type.value,
+        target=action.target,
+        description=action.description,
+        rationale=action.rationale,
     )

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -648,6 +648,7 @@ def test_agent_backed_triage_uses_runner_depth_decision_for_docs_and_config_inte
     run_input = runner.run_inputs[0]
     assert run_input.stage is WorkflowStage.TRIAGE
     assert "Do not classify PRs from path taxonomies alone" in run_input.prompt
+    assert "{depth}" not in run_input.prompt
     assert run_input.context is not None
     assert run_input.context["files"] == (
         {"path": "docs/release.md", "status": "modified", "additions": 2, "deletions": 1},

--- a/tests/runtime/test_prompt_catalog.py
+++ b/tests/runtime/test_prompt_catalog.py
@@ -1,0 +1,42 @@
+"""Tests for central Agent Runtime prompt catalog loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.runtime.prompts import PromptCatalogError, PromptId, load_prompt, render_prompt
+
+
+def test_prompt_catalog_loads_markdown_prompt_body_without_frontmatter() -> None:
+    prompt = load_prompt(PromptId.PR_WORKFLOW_TRIAGE)
+
+    assert prompt.identifier is PromptId.PR_WORKFLOW_TRIAGE
+    assert prompt.path.endswith("pr-workflow-triage.md")
+    assert prompt.text.startswith("You are qaestro's PR workflow triage layer.")
+    assert "Do not classify PRs from path taxonomies alone" in prompt.text
+    assert "---" not in prompt.text.splitlines()[0]
+
+
+def test_prompt_catalog_renders_runtime_variables_explicitly() -> None:
+    prompt_text = render_prompt(
+        PromptId.VALIDATION_API_CONTRACT_PROBE_SELECTION,
+        action_type="verify_api_contract",
+        target="GET /health",
+        description="Check health endpoint",
+        rationale="API contract changed",
+    )
+
+    assert "Action type: verify_api_contract" in prompt_text
+    assert "Target: GET /health" in prompt_text
+    assert "Description: Check health endpoint" in prompt_text
+    assert "Rationale: API contract changed" in prompt_text
+
+
+def test_prompt_catalog_rejects_missing_template_variables() -> None:
+    with pytest.raises(PromptCatalogError, match="missing template variable"):
+        render_prompt(
+            PromptId.VALIDATION_API_CONTRACT_PROBE_SELECTION,
+            action_type="verify_api_contract",
+            target="GET /health",
+            description="Check health endpoint",
+        )


### PR DESCRIPTION
## Summary
Agent Runtime stage prompt를 중앙 catalog에서 관리하도록 추가했습니다. prompt 본문은 markdown 파일로 두고, 코드에서는 stable `PromptId`로 load/render하도록 했습니다.

이번 PR에서는 PR workflow triage prompt와 API contract validation probe selection prompt를 inline 문자열에서 `src/runtime/prompts/catalog/*.md`로 이관했습니다. 동적 값이 필요한 prompt는 `render_prompt(...)`가 명시적인 template variable을 받아 렌더링하고, 누락 변수는 `PromptCatalogError`로 fail-fast합니다.

포맷은 YAML보다 Markdown을 선택했습니다. 실제 prompt 본문은 긴 자연어/지시문이 중심이라 diff와 리뷰가 쉽고, 필요하면 코드의 `PromptId`/파일 매핑으로 metadata를 관리하는 편이 현재 범위에서는 더 단순합니다.

---
Co-worked by Hermes Agent