### PR TITLE
fix: 근거 약한 rule-based recommendation 제거

### DIFF
--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -160,17 +160,17 @@ qaestro는 자유롭게 모든 것을 실행하는 agent가 아니라, 정해진
 
 이 관점은 그룹 구조에도 반영된다.
 
-- `core/strategy`: 규칙과 맥락 안에서 검증 전략을 선택하는 계층
+- `core/strategy`: 관측된 evidence와 agent/repo knowledge 안에서 검증 전략을 선택하는 계층
 - `core/knowledge`: Agent가 참고하는 고객별 QA 지식 자산 접근 경계
 - `runtime/validator`: 허용된 probe만 실행하는 계층
-- `runtime/orchestrator`: confidence와 action type에 따라 제안, 검증, 승인 대기 흐름을 통제하는 계층
+- `runtime/orchestrator`: triage 결과, validation policy, action type에 따라 제안, 검증, 승인 대기 흐름을 통제하는 계층
 - `adapters/*`: 외부 세계와 포맷을 연결하지만 core policy를 소유하지 않는 계층
 
-예를 들면 다음과 같은 정책이 가능하다.
+confidence 값이 존재하더라도 hand-picked numeric heuristic을 자동 실행 정책의 근거로 사용하지 않는다. 검증 실행 여부는 현재 head CI/check evidence, 명시적 triage 결과, validation policy, 사용자/운영 승인 경계에 의해 결정되어야 한다. 예를 들면 다음과 같은 정책이 가능하다.
 
-- 낮은 confidence: 전략 제안만 수행
-- 중간 confidence: 런타임 검증까지 수행
-- 높은 confidence: CI 반영 후보까지 제안하되 자동 반영은 승인 후 수행
+- Agent/repo knowledge가 특정 runtime probe 필요성을 설명하고 policy가 허용하면 런타임 검증까지 수행
+- current-head CI failure나 failed job처럼 관측된 evidence는 validation 우선순위에 반영
+- agent triage가 실패하거나 malformed response를 내면 path/token rule로 lightweight/deep을 찍지 않고 normal workflow로 보수적 fallback
 - destructive action: 수행하지 않음
 
 즉, 이 구조는 단순 기능 분리가 아니라 판단, 규칙, 실행, 통제를 서로 분리해 QA Agent의 자율성을 안전하게 제한하기 위한 구조다.

--- a/docs/notes/STEP_0_6_FOUNDATION_AUDIT.md
+++ b/docs/notes/STEP_0_6_FOUNDATION_AUDIT.md
@@ -83,8 +83,8 @@ MVP stub / 의도된 제한:
 
 근거:
 
-- `src/core/analyzer/*`가 diff/file metadata 기반 impact와 risk를 산출한다.
-- `src/core/strategy/*`가 deterministic strategy/checklist/action을 산출한다.
+- `src/core/analyzer/*`가 diff/file metadata 기반 impact facts와 path group을 산출하되 risk는 `NOT_ASSESSED`로 남긴다.
+- `src/core/strategy/*`가 path/knowledge token match를 product-facing action으로 만들지 않고 context로만 노출하며, current-head CI evidence만 action 우선순위에 반영한다.
 - `src/core/knowledge/memory.py`가 strategy에서 사용할 knowledge port와 in-memory mock을 제공한다.
 - `src/adapters/renderers/pr_comment.py`가 Behaviour Impact Report를 managed PR comment 형태로 렌더링한다.
 - `tests/core/test_analyzer.py`, `tests/core/test_strategy.py`, `tests/adapters/renderers/test_pr_comment.py`, `tests/runtime/test_orchestrator.py`가 vertical slice를 검증한다.
@@ -92,7 +92,7 @@ MVP stub / 의도된 제한:
 후속 deferred:
 
 - 실제 backing Knowledge Store adapter는 Step 8 범위다.
-- strategy 품질은 MVP first pass로 충분하지만, docs-only/config-only/test-only 등 low-signal 변경 noise는 #91에서 Step 6.5 hardening으로 다룬다.
+- strategy 품질은 MVP first pass에서 Step 6.5-A(#91)로 정리했다. 남은 전략 고도화는 path/test-target heuristic 복구가 아니라 Agent Runtime-backed strategy planning과 Step 8 Knowledge Store evidence 품질 개선으로 다룬다.
 
 ### Step 3.5 — Tool Runtime boundary
 

--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -136,7 +136,7 @@ class GitHubPRCommentRenderer:
                 "### Impact Areas",
                 *_impact_lines(report),
                 "",
-                "### Recommended Checklist",
+                "### Strategy Evidence",
                 report.strategy.reasoning or "No strategy reasoning provided.",
                 *_action_lines(report),
                 "",
@@ -359,8 +359,8 @@ def _impact_lines(report: QAReport) -> list[str]:
 
 def _action_lines(report: QAReport) -> list[str]:
     if not report.strategy.actions:
-        return ["", "Recommended actions: none."]
-    lines = ["", "Recommended actions:"]
+        return ["", "Evidence-backed actions: none."]
+    lines = ["", "Evidence-backed actions:"]
     lines.extend(
         (
             f"- P{action.priority} **{action.description}** "

--- a/src/core/analyzer/rules.py
+++ b/src/core/analyzer/rules.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from collections.abc import Iterable
 from pathlib import PurePosixPath
 
 from src.core.contracts import BehaviourImpact, ImpactArea, RiskLevel
@@ -14,14 +12,15 @@ from .types import PRAnalysisContext, PRFileDiff, PRFileStatus
 class RuleBasedPRBehaviourAnalyzer:
     """Deterministic first-pass PR analyzer for the Step 3 vertical slice.
 
-    The analyzer reports observed path groups and simple diff signals. It does
-    not try to define customer modules; adaptive ownership/risk learning belongs
-    in later knowledge/agent workflows.
+    The analyzer reports observed path groups and provider-neutral diff stats.
+    It deliberately does not turn path names, changed-line thresholds, or patch
+    tokens into risk judgments; strategy/agent layers can interpret these facts
+    with repository knowledge and runtime evidence.
     """
 
     def analyze(self, context: PRAnalysisContext) -> BehaviourImpact:
         areas = tuple(_build_impact_areas(context.files))
-        overall_risk = _max_risk((area.risk_level for area in areas), default=RiskLevel.LOW)
+        overall_risk = RiskLevel.NOT_ASSESSED
         stats = _diff_stats(context.files)
         return BehaviourImpact(
             summary=_summary(context, areas, overall_risk, stats),
@@ -32,20 +31,19 @@ class RuleBasedPRBehaviourAnalyzer:
 
 
 def _build_impact_areas(files: tuple[PRFileDiff, ...]) -> list[ImpactArea]:
-    """Group files by observed repository path prefixes."""
-    grouped: dict[str, list[PRFileDiff]] = defaultdict(list)
+    """Group files by observed repository path prefixes without judging risk."""
+    grouped: dict[str, list[PRFileDiff]] = {}
     for file in files:
-        grouped[_path_group_for_file(file.path)].append(file)
+        grouped.setdefault(_path_group_for_file(file.path), []).append(file)
 
     areas: list[ImpactArea] = []
     for path_group in sorted(grouped):
         group_files = tuple(grouped[path_group])
-        risk = _risk_for_path_group_files(group_files)
         areas.append(
             ImpactArea(
                 module=path_group,
                 description=_area_description(path_group, group_files),
-                risk_level=risk,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=tuple(file.path for file in group_files),
             )
         )
@@ -69,36 +67,6 @@ def _path_group_for_file(path: str) -> str:
     if len(parts) > 2:
         return "/".join(parts[:-1])
     return parts[0]
-
-
-def _risk_for_path_group_files(files: tuple[PRFileDiff, ...]) -> RiskLevel:
-    """Estimate initial risk from file status, size, and diff content only."""
-    changed_lines = sum(file.additions + file.deletions for file in files)
-    removed_files = any(file.status is PRFileStatus.REMOVED for file in files)
-    risky_patch = any(_patch_contains_risky_signal(file.patch or "") for file in files)
-
-    if removed_files or changed_lines >= 120 or risky_patch:
-        return RiskLevel.HIGH
-    if changed_lines >= 40:
-        return RiskLevel.MEDIUM
-    return RiskLevel.LOW
-
-
-def _patch_contains_risky_signal(patch: str) -> bool:
-    """Detect small, high-signal tokens in a per-file unified diff hunk."""
-    lowered = patch.lower()
-    return any(
-        signal in lowered
-        for signal in (
-            "permission",
-            "auth",
-            "token",
-            "secret",
-            "migration",
-            "drop table",
-            "delete from",
-        )
-    )
 
 
 def _diff_stats(files: tuple[PRFileDiff, ...]) -> dict[str, int | str]:
@@ -177,7 +145,7 @@ def _summary(
     return (
         f"PR #{context.pr_number} ({context.title}) changes {stats['files_changed']} files "
         f"(+{stats['additions']}/-{stats['deletions']}) across {path_groups}. "
-        f"Overall risk is {overall_risk.value}. Lead files: {lead_files}."
+        f"Risk is not assessed by the path-group analyzer. Lead files: {lead_files}."
     )
 
 
@@ -186,18 +154,3 @@ def _area_description(path_group: str, files: tuple[PRFileDiff, ...]) -> str:
     statuses = ", ".join(sorted({file.status.value for file in files}))
     changed_lines = sum(file.additions + file.deletions for file in files)
     return f"{statuses} {len(files)} file(s) under {path_group}, {changed_lines} changed line(s)"
-
-
-def _max_risk(risks: Iterable[RiskLevel], *, default: RiskLevel) -> RiskLevel:
-    """Return the highest risk while keeping empty inputs deterministic."""
-    order = {
-        RiskLevel.NOT_ASSESSED: -1,
-        RiskLevel.LOW: 0,
-        RiskLevel.MEDIUM: 1,
-        RiskLevel.HIGH: 2,
-        RiskLevel.CRITICAL: 3,
-    }
-    risk_values = tuple(risks)
-    if not risk_values:
-        return default
-    return max(risk_values, key=lambda risk: order[risk])

--- a/src/core/analyzer/rules.py
+++ b/src/core/analyzer/rules.py
@@ -20,6 +20,8 @@ class RuleBasedPRBehaviourAnalyzer:
 
     def analyze(self, context: PRAnalysisContext) -> BehaviourImpact:
         areas = tuple(_build_impact_areas(context.files))
+        # Transitional value: Agent/LLM-backed evaluation should replace this
+        # with real PR risk once semantic risk judgment is implemented.
         overall_risk = RiskLevel.NOT_ASSESSED
         stats = _diff_stats(context.files)
         return BehaviourImpact(
@@ -43,6 +45,8 @@ def _build_impact_areas(files: tuple[PRFileDiff, ...]) -> list[ImpactArea]:
             ImpactArea(
                 module=path_group,
                 description=_area_description(path_group, group_files),
+                # Transitional value: observed path groups are not per-area
+                # risk decisions until Agent/LLM-backed evaluation replaces it.
                 risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=tuple(file.path for file in group_files),
             )

--- a/src/core/strategy/__init__.py
+++ b/src/core/strategy/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from .rules import RuleBasedPRStrategyEngine
+from .rules import EvidenceBackedPRStrategyEngine, RuleBasedPRStrategyEngine
 
-__all__ = ["RuleBasedPRStrategyEngine"]
+__all__ = ["EvidenceBackedPRStrategyEngine", "RuleBasedPRStrategyEngine"]

--- a/src/core/strategy/rules.py
+++ b/src/core/strategy/rules.py
@@ -1,4 +1,4 @@
-"""Rule-based Strategy Engine for Behaviour Impact Reports."""
+"""Evidence-backed Strategy Engine for Behaviour Impact Reports."""
 
 from __future__ import annotations
 
@@ -8,19 +8,20 @@ from src.core.contracts import (
     CIFeedbackContext,
     CIHistoricalEvidence,
     CIObservation,
-    ImpactArea,
-    RiskLevel,
     StrategyAction,
     StrategyResult,
 )
 from src.core.knowledge import InMemoryKnowledgeBase, KnowledgeBase, KnowledgeEntry, KnowledgeQuery
 
 
-class RuleBasedPRStrategyEngine:
-    """Deterministic strategy generator for Step 3.
+class EvidenceBackedPRStrategyEngine:
+    """Strategy seam that exposes evidence without fabricating QA actions.
 
-    It converts analyzer facts into review/checklist actions. It does not run
-    validation; runtime execution remains a later milestone.
+    Step 6.5 keeps deterministic CI/current-head normalization because it is
+    observed evidence. Path groups, token-overlap knowledge hits, and numeric
+    risk/confidence heuristics are not treated as executable recommendations;
+    an agent/repo-knowledge-backed strategy planner should turn this context
+    into product-facing validation actions later.
     """
 
     def __init__(self, *, knowledge: KnowledgeBase | None = None) -> None:
@@ -42,75 +43,23 @@ class RuleBasedPRStrategyEngine:
                 query_text=_query_text_from_title_and_impact(title, impact),
             )
         )
-        actions = (
-            *_area_actions(impact),
-            *_baseline_actions(impact),
-            *_ci_feedback_actions(ci_feedback),
-            *_knowledge_actions(matches),
-        )
+        actions = _ci_feedback_actions(ci_feedback)
         return StrategyResult(
             actions=actions,
             reasoning=_reasoning(impact, matches, ci_feedback),
-            confidence=_confidence(impact.overall_risk, matches, ci_feedback),
+            confidence=0.0,
             knowledge_refs=tuple(entry.key for entry in matches),
         )
 
 
-def _area_actions(impact: BehaviourImpact) -> tuple[StrategyAction, ...]:
-    """Create one focused check suggestion per observed path group."""
-    return tuple(
-        _action(
-            action_type=ActionType.RUN_TESTS,
-            description="Run focused tests or review checks for the observed path group",
-            target=f"tests/{area.module}",
-            area=area,
-            base_priority=2 if area.risk_level is RiskLevel.MEDIUM else 1,
-        )
-        for area in impact.areas
-        if not _is_low_signal_doc_group(area.module)
-    )
-
-
-def _baseline_actions(impact: BehaviourImpact) -> tuple[StrategyAction, ...]:
-    actions: list[StrategyAction] = []
-    executable_groups = {area.module for area in impact.areas if not _is_low_signal_doc_group(area.module)}
-    if executable_groups:
-        actions.append(
-            StrategyAction(
-                action_type=ActionType.RUN_TESTS,
-                description="Run focused regression tests for changed behaviour",
-                target="tests/",
-                priority=2 if impact.overall_risk is RiskLevel.MEDIUM else 3 if _is_high(impact.overall_risk) else 1,
-                rationale="Non-document path groups changed.",
-            )
-        )
-    return tuple(actions)
-
-
-def _knowledge_actions(matches: tuple[KnowledgeEntry, ...]) -> tuple[StrategyAction, ...]:
-    actions: list[StrategyAction] = []
-    for entry in matches:
-        checklist = "; ".join(entry.checklist_items) or entry.summary
-        actions.append(
-            StrategyAction(
-                action_type=ActionType.CUSTOM,
-                description=f"Apply knowledge rule '{entry.key}': {checklist}",
-                target=f"knowledge:{entry.key}",
-                priority=4,
-                rationale=entry.summary,
-            )
-        )
-    return tuple(actions)
+# Backward-compatible import name while Step 7 agent-backed strategy planning is
+# introduced. The implementation no longer emits rule/path-derived validation
+# recommendations.
+RuleBasedPRStrategyEngine = EvidenceBackedPRStrategyEngine
 
 
 def _ci_feedback_actions(ci_feedback: CIFeedbackContext | None) -> tuple[StrategyAction, ...]:
-    """Prioritize validation from current-head CI feedback.
-
-    This deterministic mapping is a temporary strategy seam for Step 4. It uses
-    observed current-head CI/check facts without diagnosing root cause; later
-    Agent Framework + repository knowledge can replace the prioritization logic
-    while preserving the CI feedback contract.
-    """
+    """Prioritize validation from observed current-head CI feedback only."""
     if ci_feedback is None:
         return ()
     actions: list[StrategyAction] = []
@@ -120,7 +69,7 @@ def _ci_feedback_actions(ci_feedback: CIFeedbackContext | None) -> tuple[Strateg
             continue
         actions.append(
             StrategyAction(
-                action_type=ActionType.RUN_TESTS,
+                action_type=ActionType.CUSTOM,
                 description=f"Review current-head CI workflow '{observation.workflow_name}' result",
                 target=f"ci:{observation.workflow_name}",
                 priority=4 if conclusion in {"failure", "timed_out", "action_required", "startup_failure"} else 3,
@@ -133,43 +82,12 @@ def _ci_feedback_actions(ci_feedback: CIFeedbackContext | None) -> tuple[Strateg
 
 
 def _ci_job_action(observation: CIObservation, job: str) -> StrategyAction:
-    action_type = _ci_job_action_type(job)
     return StrategyAction(
-        action_type=action_type,
+        action_type=ActionType.CUSTOM,
         description=f"Prioritize failed CI job '{job}' from workflow '{observation.workflow_name}'",
         target=f"ci:{observation.workflow_name}/{job}",
         priority=5,
         rationale="Current-head failed job is observed evidence and should drive validation priority.",
-    )
-
-
-def _ci_job_action_type(job: str) -> ActionType:
-    normalized = job.strip().lower()
-    if any(token in normalized for token in ("mypy", "pyright", "type")):
-        return ActionType.TYPE_CHECK
-    if any(token in normalized for token in ("lint", "ruff", "eslint", "flake")):
-        return ActionType.RUN_LINTER
-    if any(token in normalized for token in ("security", "sast", "secret", "bandit")):
-        return ActionType.CHECK_SECURITY
-    return ActionType.RUN_TESTS
-
-
-def _action(
-    *,
-    action_type: ActionType,
-    description: str,
-    target: str,
-    area: ImpactArea,
-    base_priority: int,
-) -> StrategyAction:
-    priority = base_priority + (1 if _is_high(area.risk_level) else 0)
-    files = ", ".join(area.affected_files[:3])
-    return StrategyAction(
-        action_type=action_type,
-        description=description,
-        target=target,
-        priority=priority,
-        rationale=f"{area.module} path group is {area.risk_level.value} risk; affected files: {files}",
     )
 
 
@@ -178,11 +96,16 @@ def _reasoning(
     matches: tuple[KnowledgeEntry, ...],
     ci_feedback: CIFeedbackContext | None,
 ) -> str:
-    risk_label = impact.overall_risk.value.capitalize()
     path_groups = ", ".join(area.module for area in impact.areas) or "none"
-    knowledge_text = f" Knowledge matches: {', '.join(entry.key for entry in matches)}." if matches else ""
-    ci_text = f" {_ci_reasoning(ci_feedback)}" if ci_feedback is not None else ""
-    return f"{risk_label} risk based on observed path groups: {path_groups}.{knowledge_text}{ci_text}"
+    segments = [
+        "Uncalibrated strategy context only; path groups and knowledge token matches are not executable recommendations.",
+        f"Observed path groups: {path_groups}.",
+    ]
+    if matches:
+        segments.append(f"Knowledge refs: {', '.join(entry.key for entry in matches)}.")
+    if ci_feedback is not None:
+        segments.append(_ci_reasoning(ci_feedback))
+    return " ".join(segments)
 
 
 def _ci_reasoning(ci_feedback: CIFeedbackContext) -> str:
@@ -219,61 +142,8 @@ def _historical_summary(evidence: CIHistoricalEvidence) -> str:
     )
 
 
-def _confidence(
-    risk: RiskLevel,
-    matches: tuple[KnowledgeEntry, ...],
-    ci_feedback: CIFeedbackContext | None,
-) -> float:
-    """Return the Step 4 placeholder confidence score.
-
-    This is not a calibrated probability and must not be read as "qaestro is
-    N% likely to be correct." The constants below are a deterministic
-    evidence-strength heuristic used only to keep the current StrategyResult
-    contract populated while the rule-based strategy engine is still a
-    temporary implementation.
-
-    Replacement direction:
-    - Replace the hand-picked constants with a typed confidence/evidence model
-      that records factors such as risk source, knowledge match strength, CI
-      signal freshness, CI outcome severity, and missing-signal penalties.
-    - Calibrate any numeric score from observed review/validation outcomes, or
-      remove the numeric field from decision-making and expose the factors for
-      policy ranking instead.
-    - Keep a conservative cap or explicit uncertainty band if a future Agent
-      Framework strategy engine still emits a scalar confidence value.
-    """
-    if _is_high(risk):
-        # High-risk changes start lower because the rule-based engine has less
-        # context than a real validation loop. This value is intentionally
-        # arbitrary and should disappear when confidence is calibrated.
-        base = 0.72
-    elif risk is RiskLevel.MEDIUM:
-        base = 0.76
-    else:
-        base = 0.82
-    if matches:
-        # Knowledge hits are treated as a weak positive signal for now; future
-        # scoring should weight the relevance and historical reliability of the
-        # matched rule instead of blindly adding a constant.
-        base += 0.02
-    if ci_feedback is not None and (ci_feedback.current_observations or ci_feedback.pending_checks):
-        # CI/check feedback makes the strategy better grounded, but the current
-        # rule does not distinguish fresh failures, pending checks, skipped jobs,
-        # or flaky checks. A replacement should model those factors separately.
-        base += 0.02
-    return min(base, 0.9)
-
-
 def _query_text_from_title_and_impact(title: str, impact: BehaviourImpact) -> str:
     """Build the Step 3 free-text knowledge query from available PR facts."""
     files = " ".join(file for area in impact.areas for file in area.affected_files)
     path_groups = " ".join(area.module for area in impact.areas)
     return " ".join((title, impact.summary, path_groups, files))
-
-
-def _is_low_signal_doc_group(path_group: str) -> bool:
-    return path_group.lower() in {"readme.md", "docs", "changelog.md"}
-
-
-def _is_high(risk: RiskLevel) -> bool:
-    return risk in {RiskLevel.HIGH, RiskLevel.CRITICAL}

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -68,6 +68,8 @@ class RuleBasedPRWorkflowTriageClassifier:
 
     def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage:
         del context
+        # Transitional default: until Agent-backed triage is authoritative,
+        # keep the full NORMAL path instead of faking LIGHTWEIGHT/DEEP choices.
         return PRWorkflowTriage(
             depth=PRWorkflowDepth.NORMAL,
             rationale="Conservative default PR workflow depth; run behaviour analysis and strategy planning.",

--- a/src/runtime/orchestrator/pr_triage.py
+++ b/src/runtime/orchestrator/pr_triage.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
 
-from src.core.analyzer import PRAnalysisContext, PRFileDiff, PRFileStatus
+from src.core.analyzer import PRAnalysisContext, PRFileDiff
 from src.runtime.agent import AgentRunInput, AgentRunStatus, AgentSessionHandle, AgentSessionScope
 from src.runtime.agent.types import AgentRunner
 from src.runtime.prompts import PromptId, load_prompt
@@ -58,31 +58,19 @@ class PRWorkflowTriage:
 
 
 class RuleBasedPRWorkflowTriageClassifier:
-    """Deterministic placeholder for PR intent/depth classification.
+    """Conservative deterministic fallback for PR workflow depth.
 
-    This is intentionally conservative and portable. It only chooses a
-    lightweight path for very small, low-signal documentation/metadata changes,
-    escalates obvious high-impact signals to deep, and otherwise preserves the
-    normal Step 3 analysis path. It is only a temporary seam and must be replaced
-    by Agent Framework + repo-knowledge/instruction based classification.
+    The fallback no longer treats path taxonomies, changed-line thresholds, or
+    keyword tokens as reliable PR intent/risk classification. When an agent or
+    explicit policy is unavailable, it keeps the normal analyzer/strategy path
+    instead of skipping analysis or forcing deep validation from weak signals.
     """
 
     def classify(self, context: PRAnalysisContext) -> PRWorkflowTriage:
-        if _requires_deep_workflow(context):
-            return PRWorkflowTriage(
-                depth=PRWorkflowDepth.DEEP,
-                rationale="High-impact change signals require full analysis and validation.",
-                allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
-            )
-        if _is_lightweight_change(context):
-            return PRWorkflowTriage(
-                depth=PRWorkflowDepth.LIGHTWEIGHT,
-                rationale="Small low-signal documentation or metadata change; full analysis was skipped.",
-                allowed_stages=(),
-            )
+        del context
         return PRWorkflowTriage(
             depth=PRWorkflowDepth.NORMAL,
-            rationale="Default PR workflow depth; run behaviour analysis and strategy planning.",
+            rationale="Conservative default PR workflow depth; run behaviour analysis and strategy planning.",
             allowed_stages=(WorkflowStage.ANALYZER, WorkflowStage.STRATEGY, WorkflowStage.VALIDATOR),
         )
 
@@ -250,66 +238,3 @@ def _safe_error(exc: Exception) -> str:
 
 def _safe_session_part(value: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-") or "repo"
-
-
-_LOW_SIGNAL_ROOT_FILES = {"readme.md", "changelog.md", "license", "notice"}
-_LOW_SIGNAL_DIRS = {"docs"}
-_DEEP_SIGNAL_TOKENS = (
-    "api",
-    "auth",
-    "authorization",
-    "breaking",
-    "deploy",
-    "deployment",
-    "migration",
-    "permission",
-    "runbook",
-    "secret",
-    "security",
-)
-_GENERATED_PATH_PARTS = {"generated", "dist", "build"}
-
-
-def _is_lightweight_change(context: PRAnalysisContext) -> bool:
-    """Return true for tiny low-signal changes safe for summary-only output."""
-    if not context.files:
-        return False
-    changed_lines = sum(file.additions + file.deletions for file in context.files)
-    if changed_lines > 30 or len(context.files) > 5:
-        return False
-    return all(_is_low_signal_file(file.path) for file in context.files) and not _contains_deep_signal(context)
-
-
-def _requires_deep_workflow(context: PRAnalysisContext) -> bool:
-    """Escalate obvious semantic or risky signals without path taxonomies."""
-    if any(file.status is PRFileStatus.REMOVED for file in context.files):
-        return True
-    changed_lines = sum(file.additions + file.deletions for file in context.files)
-    if changed_lines >= 250:
-        return True
-    return _contains_deep_signal(context)
-
-
-def _contains_deep_signal(context: PRAnalysisContext) -> bool:
-    haystacks = [context.title, context.body, context.unified_diff]
-    haystacks.extend(file.path for file in context.files)
-    haystacks.extend(file.patch or "" for file in context.files)
-    # Temporary seam hygiene only: match whole path/text tokens so short signals
-    # like "api" and "auth" do not fire on unrelated words such as "capital"
-    # or "author". This is not a permanent programmatic PR-depth classifier.
-    observed_tokens = set(re.split(r"[^a-z0-9]+", "\n".join(haystacks).lower()))
-    return any(token in observed_tokens for token in _DEEP_SIGNAL_TOKENS)
-
-
-def _is_low_signal_file(path: str) -> bool:
-    normalized = path.strip("/").lower()
-    if not normalized:
-        return True
-    parts = tuple(part for part in normalized.split("/") if part)
-    if not parts:
-        return True
-    if any(part in _GENERATED_PATH_PARTS for part in parts):
-        return True
-    if len(parts) == 1:
-        return parts[0] in _LOW_SIGNAL_ROOT_FILES or parts[0].endswith((".md", ".rst", ".txt"))
-    return parts[0] in _LOW_SIGNAL_DIRS

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -285,6 +285,8 @@ def _triage_only_report(event: PREvent, context: PRAnalysisContext, triage: PRWo
     impact = BehaviourImpact(
         summary=triage.rationale,
         areas=(),
+        # Transitional value: triage-only output skipped analysis, so later
+        # Agent/LLM-backed evaluation must supply any real risk judgment.
         overall_risk=RiskLevel.NOT_ASSESSED,
         raw_diff_stats={
             "files_changed": len(context.files),

--- a/tests/adapters/renderers/test_pr_comment.py
+++ b/tests/adapters/renderers/test_pr_comment.py
@@ -85,6 +85,7 @@ def test_github_pr_comment_renderer_turns_qa_report_into_pr_comment_payload():
     assert "Overall risk: **MEDIUM**" in payload.body
     assert "Connector files changed." in payload.body
     assert "Connector files changed" in payload.body
+    assert "### Strategy Evidence" in payload.body
     assert "Run connector tests" in payload.body
     assert "Files changed: `4`" in payload.body
     assert (

--- a/tests/core/test_analyzer.py
+++ b/tests/core/test_analyzer.py
@@ -20,7 +20,7 @@ def test_pr_file_diff_normalizes_status_and_documents_path_semantics() -> None:
     assert file.status is PRFileStatus.RENAMED
 
 
-def test_analyzer_groups_files_by_observed_path_groups_and_aggregates_risk() -> None:
+def test_analyzer_groups_files_by_observed_path_groups_without_risk_judgment() -> None:
     context = PRAnalysisContext(
         repo_full_name="acme-corp/web-api",
         pr_number=123,
@@ -56,7 +56,7 @@ def test_analyzer_groups_files_by_observed_path_groups_and_aggregates_risk() -> 
 
     impact = RuleBasedPRBehaviourAnalyzer().analyze(context)
 
-    assert impact.overall_risk is RiskLevel.MEDIUM
+    assert impact.overall_risk is RiskLevel.NOT_ASSESSED
     assert impact.raw_diff_stats == {
         "files_changed": 3,
         "additions": 75,
@@ -74,9 +74,9 @@ def test_analyzer_groups_files_by_observed_path_groups_and_aggregates_risk() -> 
     assert "src/api/payments.py" in impact.summary
     assert "3 files" in impact.summary
     assert [(area.module, area.risk_level) for area in impact.areas] == [
-        ("README.md", RiskLevel.LOW),
-        ("src/api", RiskLevel.MEDIUM),
-        ("tests/api", RiskLevel.LOW),
+        ("README.md", RiskLevel.NOT_ASSESSED),
+        ("src/api", RiskLevel.NOT_ASSESSED),
+        ("tests/api", RiskLevel.NOT_ASSESSED),
     ]
 
 
@@ -171,18 +171,18 @@ def test_analyzer_uses_actual_repo_path_groups_instead_of_fixed_module_labels() 
     assert [(area.module, area.risk_level, area.affected_files) for area in impact.areas] == [
         (
             "src/adapters/connectors/github",
-            RiskLevel.MEDIUM,
+            RiskLevel.NOT_ASSESSED,
             ("src/adapters/connectors/github/client.py",),
         ),
         (
             "src/runtime/orchestrator",
-            RiskLevel.LOW,
+            RiskLevel.NOT_ASSESSED,
             ("src/runtime/orchestrator/pr_workflow.py",),
         ),
     ]
 
 
-def test_analyzer_escalates_high_risk_from_diff_signals_and_change_size_not_module_names() -> None:
+def test_analyzer_preserves_diff_signals_as_raw_stats_not_risk_judgment() -> None:
     context = PRAnalysisContext(
         repo_full_name="acme-corp/web-api",
         pr_number=124,
@@ -218,8 +218,12 @@ def test_analyzer_escalates_high_risk_from_diff_signals_and_change_size_not_modu
 
     impact = RuleBasedPRBehaviourAnalyzer().analyze(context)
 
-    assert impact.overall_risk is RiskLevel.HIGH
-    risks_by_group = {area.module: area.risk_level for area in impact.areas}
-    assert risks_by_group[".github/workflows"] is RiskLevel.HIGH
-    assert risks_by_group["infra/terraform"] is RiskLevel.HIGH
-    assert risks_by_group["config"] is RiskLevel.MEDIUM
+    assert impact.overall_risk is RiskLevel.NOT_ASSESSED
+    assert impact.raw_diff_stats["additions"] == 295
+    assert impact.raw_diff_stats["deletions"] == 70
+    assert impact.raw_diff_stats["files_changed"] == 3
+    assert {area.module: area.risk_level for area in impact.areas} == {
+        ".github/workflows": RiskLevel.NOT_ASSESSED,
+        "config": RiskLevel.NOT_ASSESSED,
+        "infra/terraform": RiskLevel.NOT_ASSESSED,
+    }

--- a/tests/core/test_strategy.py
+++ b/tests/core/test_strategy.py
@@ -13,7 +13,7 @@ from src.core.contracts import (
     RiskLevel,
 )
 from src.core.knowledge import InMemoryKnowledgeBase, KnowledgeEntry, KnowledgeQuery
-from src.core.strategy import RuleBasedPRStrategyEngine
+from src.core.strategy import EvidenceBackedPRStrategyEngine
 
 
 def test_in_memory_knowledge_base_matches_repo_and_query_text_deterministically() -> None:
@@ -44,24 +44,24 @@ def test_in_memory_knowledge_base_matches_repo_and_query_text_deterministically(
     assert tuple(entry.key for entry in matches) == ("payments-refund-contract",)
 
 
-def test_strategy_generates_deterministic_actions_from_risk_areas_and_knowledge() -> None:
+def test_strategy_keeps_path_and_knowledge_signals_as_context_not_actions() -> None:
     impact = BehaviourImpact(
         summary="Changed payment API and checkout UI",
         areas=(
             ImpactArea(
                 module="src/api",
                 description="modified src/api/payments.py",
-                risk_level=RiskLevel.MEDIUM,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=("src/api/payments.py",),
             ),
             ImpactArea(
                 module="src/web/checkout",
                 description="modified src/web/checkout/RefundForm.tsx",
-                risk_level=RiskLevel.MEDIUM,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=("src/web/checkout/RefundForm.tsx",),
             ),
         ),
-        overall_risk=RiskLevel.MEDIUM,
+        overall_risk=RiskLevel.NOT_ASSESSED,
         raw_diff_stats={"files_changed": 2, "additions": 50, "deletions": 10},
     )
     knowledge = InMemoryKnowledgeBase(
@@ -75,74 +75,67 @@ def test_strategy_generates_deterministic_actions_from_risk_areas_and_knowledge(
         )
     )
 
-    result = RuleBasedPRStrategyEngine(knowledge=knowledge).plan(
+    result = EvidenceBackedPRStrategyEngine(knowledge=knowledge).plan(
         repo_full_name="acme-corp/web-api",
         pr_number=123,
         title="feat: add refund flow",
         impact=impact,
     )
 
-    assert result.confidence == 0.78
+    assert result.confidence == 0.0
     assert result.knowledge_refs == ("refund-regression",)
-    assert result.reasoning.startswith("Medium risk")
-    assert [(action.action_type, action.target) for action in result.actions] == [
-        (ActionType.RUN_TESTS, "tests/src/api"),
-        (ActionType.RUN_TESTS, "tests/src/web/checkout"),
-        (ActionType.RUN_TESTS, "tests/"),
-        (ActionType.CUSTOM, "knowledge:refund-regression"),
-    ]
-    assert [action.priority for action in result.actions] == [2, 2, 2, 4]
-    assert "zero-amount" in result.actions[-1].description
+    assert result.reasoning.startswith("Uncalibrated strategy context")
+    assert "Observed path groups: src/api, src/web/checkout" in result.reasoning
+    assert "Knowledge refs: refund-regression" in result.reasoning
+    assert result.actions == ()
 
 
-def test_strategy_generates_generic_actions_for_repo_observed_groups() -> None:
+def test_strategy_does_not_invent_path_derived_test_targets_for_repo_observed_groups() -> None:
     impact = BehaviourImpact(
         summary="Changed adapter module",
         areas=(
             ImpactArea(
                 module="src/adapters/connectors/github",
                 description="modified src/adapters/connectors/github/client.py",
-                risk_level=RiskLevel.LOW,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=("src/adapters/connectors/github/client.py",),
             ),
         ),
-        overall_risk=RiskLevel.LOW,
+        overall_risk=RiskLevel.NOT_ASSESSED,
     )
 
-    result = RuleBasedPRStrategyEngine().plan(
+    result = EvidenceBackedPRStrategyEngine().plan(
         repo_full_name="Kimcheolhui/qaestro",
         pr_number=39,
         title="feat: update connector",
         impact=impact,
     )
 
-    assert result.actions
-    assert result.actions[0].action_type is ActionType.RUN_TESTS
-    assert result.actions[0].target == "tests/src/adapters/connectors/github"
-    assert result.actions[1].target == "tests/"
+    assert result.actions == ()
+    assert "src/adapters/connectors/github" in result.reasoning
 
 
-def test_strategy_skips_low_signal_doc_groups_for_step3_test_actions() -> None:
+def test_strategy_does_not_need_low_signal_doc_rules_to_avoid_test_actions() -> None:
     impact = BehaviourImpact(
         summary="Changed documentation only",
         areas=(
             ImpactArea(
                 module="docs",
                 description="modified docs/ARCHITECTURE.md",
-                risk_level=RiskLevel.LOW,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=("docs/ARCHITECTURE.md",),
             ),
             ImpactArea(
                 module="CHANGELOG.md",
                 description="modified CHANGELOG.md",
-                risk_level=RiskLevel.LOW,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=("CHANGELOG.md",),
             ),
         ),
-        overall_risk=RiskLevel.LOW,
+        overall_risk=RiskLevel.NOT_ASSESSED,
     )
 
-    result = RuleBasedPRStrategyEngine().plan(
+    result = EvidenceBackedPRStrategyEngine().plan(
         repo_full_name="Kimcheolhui/qaestro",
         pr_number=40,
         title="docs: update architecture notes",
@@ -159,11 +152,11 @@ def test_strategy_includes_current_head_ci_failure_without_mixing_stale_history(
             ImpactArea(
                 module="src/api",
                 description="modified src/api/payments.py",
-                risk_level=RiskLevel.MEDIUM,
+                risk_level=RiskLevel.NOT_ASSESSED,
                 affected_files=("src/api/payments.py",),
             ),
         ),
-        overall_risk=RiskLevel.MEDIUM,
+        overall_risk=RiskLevel.NOT_ASSESSED,
     )
     ci_feedback = CIFeedbackContext(
         current_head_sha="sha-current",
@@ -193,7 +186,7 @@ def test_strategy_includes_current_head_ci_failure_without_mixing_stale_history(
         ),
     )
 
-    result = RuleBasedPRStrategyEngine().plan(
+    result = EvidenceBackedPRStrategyEngine().plan(
         repo_full_name="acme-corp/web-api",
         pr_number=123,
         title="feat: update payment API",
@@ -203,9 +196,9 @@ def test_strategy_includes_current_head_ci_failure_without_mixing_stale_history(
 
     ci_actions = [action for action in result.actions if action.target.startswith("ci:")]
     assert [(action.action_type, action.target, action.priority) for action in ci_actions] == [
-        (ActionType.RUN_TESTS, "ci:Tests", 4),
-        (ActionType.RUN_TESTS, "ci:Tests/pytest", 5),
-        (ActionType.TYPE_CHECK, "ci:Tests/mypy", 5),
+        (ActionType.CUSTOM, "ci:Tests", 4),
+        (ActionType.CUSTOM, "ci:Tests/pytest", 5),
+        (ActionType.CUSTOM, "ci:Tests/mypy", 5),
     ]
     assert "current-head CI/check feedback: Tests=failure" in result.reasoning
     assert "failed jobs: pytest, mypy" in result.reasoning
@@ -214,7 +207,7 @@ def test_strategy_includes_current_head_ci_failure_without_mixing_stale_history(
 
 
 def test_strategy_represents_success_cancelled_timed_out_and_pending_ci_feedback() -> None:
-    impact = BehaviourImpact(summary="Changed runtime worker", areas=(), overall_risk=RiskLevel.LOW)
+    impact = BehaviourImpact(summary="Changed runtime worker", areas=(), overall_risk=RiskLevel.NOT_ASSESSED)
     ci_feedback = CIFeedbackContext(
         current_head_sha="sha-current",
         readiness=CIReadinessState.WAITING_FOR_CHECKS,
@@ -242,7 +235,7 @@ def test_strategy_represents_success_cancelled_timed_out_and_pending_ci_feedback
         pending_checks=("Security",),
     )
 
-    result = RuleBasedPRStrategyEngine().plan(
+    result = EvidenceBackedPRStrategyEngine().plan(
         repo_full_name="acme-corp/web-api",
         pr_number=124,
         title="feat: update worker",
@@ -256,3 +249,36 @@ def test_strategy_represents_success_cancelled_timed_out_and_pending_ci_feedback
     assert "pending checks: Security" in result.reasoning
     assert any(action.target == "ci:E2E/browser" and action.priority == 5 for action in result.actions)
     assert any(action.target == "ci:Deploy" and action.priority == 3 for action in result.actions)
+
+
+def test_strategy_does_not_map_ci_job_names_to_validation_action_types() -> None:
+    impact = BehaviourImpact(summary="Changed runtime worker", areas=(), overall_risk=RiskLevel.NOT_ASSESSED)
+    ci_feedback = CIFeedbackContext(
+        current_head_sha="sha-current",
+        readiness=CIReadinessState.CHECKS_FAILED,
+        current_observations=(
+            CIObservation(
+                workflow_name="CI",
+                conclusion="failure",
+                run_url="https://github.com/acme/web/actions/runs/5",
+                failed_jobs=("mypy", "eslint", "secret scan"),
+                commit_sha="sha-current",
+            ),
+        ),
+    )
+
+    result = EvidenceBackedPRStrategyEngine().plan(
+        repo_full_name="acme-corp/web-api",
+        pr_number=125,
+        title="fix: update worker",
+        impact=impact,
+        ci_feedback=ci_feedback,
+    )
+
+    assert [action.action_type for action in result.actions] == [ActionType.CUSTOM] * 4
+    assert [action.target for action in result.actions] == [
+        "ci:CI",
+        "ci:CI/mypy",
+        "ci:CI/eslint",
+        "ci:CI/secret scan",
+    ]

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -362,8 +362,10 @@ def test_pr_workflow_orchestrator_runs_stub_flow_and_renders_pr_comment_payload(
         WorkflowStage.RENDERER,
     )
     assert result.impact.summary.startswith("PR #31 (feat: add connector) changes 2 files")
-    assert result.strategy.reasoning.startswith("High risk")
-    assert len(result.validations) == 3
+    assert result.impact.overall_risk is RiskLevel.NOT_ASSESSED
+    assert result.strategy.reasoning.startswith("Uncalibrated strategy context")
+    assert result.strategy.actions == ()
+    assert result.validations == ()
     assert result.comment_payload is not None
     assert result.comment_payload.repo_full_name == "Kimcheolhui/qaestro"
     assert result.comment_payload.pr_number == 31
@@ -486,20 +488,25 @@ def test_pr_workflow_orchestrator_can_emit_lightweight_triage_output_without_ful
         files_changed=(FileChange(path="docs/CONTRIBUTING.md", status="modified", additions=3, deletions=1),),
     )
 
-    orchestrator = PRWorkflowOrchestrator()
-    result = orchestrator.run(event)
+    result = PRWorkflowOrchestrator().run(event)
 
-    assert result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
-    assert result.stage_order == (WorkflowStage.CONTEXT, WorkflowStage.TRIAGE, WorkflowStage.RENDERER)
-    assert result.impact.areas == ()
+    assert result.triage.depth is PRWorkflowDepth.NORMAL
+    assert result.stage_order == (
+        WorkflowStage.CONTEXT,
+        WorkflowStage.TRIAGE,
+        WorkflowStage.ANALYZER,
+        WorkflowStage.STRATEGY,
+        WorkflowStage.VALIDATOR,
+        WorkflowStage.RENDERER,
+    )
+    assert result.impact.areas
     assert result.strategy.actions == ()
     assert result.validations == ()
     assert result.comment_payload is not None
-    assert "Workflow depth: **LIGHTWEIGHT**" in result.comment_payload.body
+    assert "Workflow depth: **NORMAL**" in result.comment_payload.body
     assert "Overall risk: **NOT ASSESSED**" in result.comment_payload.body
-    assert "Triaged analysis/validation stages: `none`" in result.comment_payload.body
-    assert "Allowed stages after triage" not in result.comment_payload.body
-    assert "full analysis was skipped" in result.comment_payload.body
+    assert "Triaged analysis/validation stages: `analyzer, strategy, validator`" in result.comment_payload.body
+    assert "Conservative default PR workflow depth" in result.comment_payload.body
     assert "docs/CONTRIBUTING.md" in result.comment_payload.body
 
     assert result.impact.overall_risk is RiskLevel.NOT_ASSESSED
@@ -593,8 +600,10 @@ def test_rule_based_triage_deep_signal_matching_uses_token_boundaries() -> None:
     false_positive_result = PRWorkflowOrchestrator(triage_classifier=classifier).run(false_positive_event)
     deep_signal_result = PRWorkflowOrchestrator(triage_classifier=classifier).run(deep_signal_event)
 
-    assert false_positive_result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
-    assert deep_signal_result.triage.depth is PRWorkflowDepth.DEEP
+    assert false_positive_result.triage.depth is PRWorkflowDepth.NORMAL
+    assert deep_signal_result.triage.depth is PRWorkflowDepth.NORMAL
+    assert "Conservative default PR workflow depth" in false_positive_result.triage.rationale
+    assert "Conservative default PR workflow depth" in deep_signal_result.triage.rationale
 
 
 def test_agent_backed_triage_uses_runner_depth_decision_for_docs_and_config_intent() -> None:
@@ -690,9 +699,10 @@ def test_agent_backed_triage_falls_back_when_runner_response_is_invalid() -> Non
 
     result = PRWorkflowOrchestrator(triage_classifier=classifier).run(event)
 
-    assert result.triage.depth is PRWorkflowDepth.LIGHTWEIGHT
+    assert result.triage.depth is PRWorkflowDepth.NORMAL
     assert "Agent triage unavailable" in result.triage.rationale
-    assert "Small low-signal documentation" in result.triage.rationale
+    assert "Conservative default PR workflow depth" in result.triage.rationale
+    assert result.stage_order[:3] == (WorkflowStage.CONTEXT, WorkflowStage.TRIAGE, WorkflowStage.ANALYZER)
 
 
 def test_pr_workflow_orchestrator_uses_renders_output_contract_for_noop() -> None:

--- a/tests/runtime/test_pr_context_provider.py
+++ b/tests/runtime/test_pr_context_provider.py
@@ -92,7 +92,7 @@ def test_pr_workflow_uses_context_provider_instead_of_webhook_file_placeholders(
 
     result = PRWorkflowOrchestrator(context_provider=StaticContextProvider()).run(_event())
 
-    assert result.impact.overall_risk is RiskLevel.LOW
+    assert result.impact.overall_risk is RiskLevel.NOT_ASSESSED
     assert result.impact.areas[0].module == "src/api"
     assert "placeholder.txt" not in result.report.summary_markdown
     assert result.comment_payload is not None


### PR DESCRIPTION
## 요약

Step 6.5 #91 범위에서 근거 약한 rule-based QA recommendation을 product-facing 판단에서 제거했습니다.

- analyzer는 path group과 diff stats만 남기고, path/changed-lines/patch token 기반 risk 판단을 `NOT_ASSESSED`로 정리했습니다.
- strategy는 path-derived `tests/...` 추천, baseline `tests/` 추천, knowledge token match action, hand-picked numeric confidence를 제거하고 evidence context만 노출합니다.
- current-head CI/check failure와 failed job은 관측된 evidence이므로 action 우선순위에 남기되, job-name token으로 `TYPE_CHECK`/`RUN_LINTER`/`CHECK_SECURITY`를 추정하지 않고 `CUSTOM` evidence action으로만 다룹니다.
- agent triage 실패 fallback은 docs/generated/token/size rule로 lightweight/deep을 찍지 않고 normal workflow로 보수적으로 진행합니다.
- PR comment renderer의 “Recommended Checklist” 표현을 “Strategy Evidence”로 바꿔 추천처럼 보이는 표면을 줄였습니다.

Closes #91

---
Co-worked by Hermes Agent
