### PR TITLE
fix(validation): sanitize PR-facing probe details

### DIFF
--- a/src/runtime/validator/agent_runtime.py
+++ b/src/runtime/validator/agent_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from time import monotonic
 from typing import Protocol
@@ -296,7 +297,7 @@ class AgentRuntimePRValidator:
         return ValidationResult(
             action=action,
             outcome=result.outcome,
-            details=result.details,
+            details=_sanitize_pr_facing_details(result.details),
             duration_seconds=result.duration_seconds or elapsed,
             artifacts=result.artifacts,
         )
@@ -402,6 +403,19 @@ def _agent_runner_error_details(*, kind: str, exc: Exception) -> str:
 
 def _agent_runner_status_details(status: AgentRunStatus) -> str:
     return f"agent_runner: Agent Runtime validation ended with status {status.name}."
+
+
+_SECRET_ASSIGNMENT_PATTERN = re.compile(r"(?i)\b(token|password|secret|api[_-]?key|credential)\s*=\s*[^\s,;]+")
+_URL_PATTERN = re.compile(r"https?://[^\s,;)]+")
+
+
+def _sanitize_pr_facing_details(details: str) -> str:
+    """Remove common credential and endpoint fragments from PR-facing details."""
+    sanitized = _SECRET_ASSIGNMENT_PATTERN.sub(
+        lambda match: f"{match.group(1)}=<redacted>",
+        details,
+    )
+    return _URL_PATTERN.sub("<redacted-url>", sanitized)
 
 
 def _api_contract_probe_request(

--- a/tests/runtime/test_api_contract_probe_validator.py
+++ b/tests/runtime/test_api_contract_probe_validator.py
@@ -110,6 +110,23 @@ class RaisingAgentRunner(FakeAgentRunner):
         raise RuntimeError(self._error)
 
 
+class StatusAgentRunner(FakeAgentRunner):
+    def __init__(self, *, status: AgentRunStatus, error: str) -> None:
+        super().__init__()
+        self._status = status
+        self._error = error
+
+    def run(self, *, session: AgentSessionHandle, run_input: AgentRunInput) -> AgentRunResult:
+        self.run_inputs.append(run_input)
+        return AgentRunResult(
+            session=session,
+            stage=run_input.stage,
+            status=self._status,
+            error=self._error,
+            allowed_tool_names=run_input.allowed_tool_names,
+        )
+
+
 def test_agent_runner_errors_are_sanitized_before_validation_details() -> None:
     executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
     failing_runner = FailingAgentRunner(error="provider failed token=secret-token endpoint=https://private.example")
@@ -138,6 +155,88 @@ def test_agent_runner_errors_are_sanitized_before_validation_details() -> None:
     assert "RuntimeError" in raised_result.details
     assert "hunter2" not in raised_result.details
     assert "private.example" not in raised_result.details
+
+
+def test_agent_runner_timeout_and_cancelled_statuses_are_validation_errors() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+    for status in (AgentRunStatus.TIMEOUT, AgentRunStatus.CANCELLED):
+        runner = StatusAgentRunner(status=status, error="token=secret-token endpoint=https://private.example")
+        validator = build_agent_runtime_pr_validator(runner=runner, api_contract_probe_executor=executor)
+
+        validation = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[
+            0
+        ]
+
+        assert validation.outcome is ValidationOutcome.ERROR
+        assert status.name in validation.details
+        assert "secret-token" not in validation.details
+        assert "private.example" not in validation.details
+        assert executor.requests == []
+
+
+def test_validation_session_closes_after_runner_failure_and_exception() -> None:
+    executor = RecordingProbeExecutor(APIContractProbeResult(outcome=ValidationOutcome.PASS, details="should not run"))
+
+    failing_runner = FailingAgentRunner(error="provider failed token=secret-token")
+    failing_validator = build_agent_runtime_pr_validator(runner=failing_runner, api_contract_probe_executor=executor)
+    failing_validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))
+
+    assert failing_runner.closed_sessions == [
+        (failing_runner.started_sessions[0].session_id, "validation stage complete")
+    ]
+
+    raising_runner = RaisingAgentRunner(error="transport crashed password=hunter2")
+    raising_validator = build_agent_runtime_pr_validator(runner=raising_runner, api_contract_probe_executor=executor)
+    raising_validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))
+
+    assert raising_runner.closed_sessions == [
+        (raising_runner.started_sessions[0].session_id, "validation stage complete")
+    ]
+
+
+def test_validation_session_closes_after_executor_timeout_and_exception() -> None:
+    timeout_runner = FakeAgentRunner(response="agent selected validation.api_contract.probe")
+    timeout_validator = build_agent_runtime_pr_validator(
+        runner=timeout_runner,
+        api_contract_probe_executor=RecordingProbeExecutor(TimeoutError("token=secret-token")),
+    )
+    timeout_validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))
+
+    assert timeout_runner.closed_sessions == [
+        (timeout_runner.started_sessions[0].session_id, "validation stage complete")
+    ]
+
+    exception_runner = FakeAgentRunner(response="agent selected validation.api_contract.probe")
+    exception_validator = build_agent_runtime_pr_validator(
+        runner=exception_runner,
+        api_contract_probe_executor=RecordingProbeExecutor(RuntimeError("password=hunter2")),
+    )
+    exception_validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))
+
+    assert exception_runner.closed_sessions == [
+        (exception_runner.started_sessions[0].session_id, "validation stage complete")
+    ]
+
+
+def test_executor_supplied_details_are_sanitized_before_pr_facing_validation_result() -> None:
+    executor = RecordingProbeExecutor(
+        APIContractProbeResult(
+            outcome=ValidationOutcome.FAIL,
+            details="probe failed token=secret-token endpoint=https://private.example password=hunter2",
+        )
+    )
+    validator = build_agent_runtime_pr_validator(
+        runner=FakeAgentRunner(response="agent selected validation.api_contract.probe"),
+        api_contract_probe_executor=executor,
+    )
+
+    validation = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[0]
+
+    assert validation.outcome is ValidationOutcome.FAIL
+    assert "probe failed" in validation.details
+    assert "secret-token" not in validation.details
+    assert "private.example" not in validation.details
+    assert "hunter2" not in validation.details
 
 
 def test_successful_probe_uses_wall_clock_duration_when_executor_duration_is_missing() -> None:


### PR DESCRIPTION
## 요약

#92 점검 중 runtime validation의 현재 의미론은 대체로 맞았지만, executor가 반환한 `APIContractProbeResult.details`가 그대로 `ValidationResult.details`로 복사되는 경로가 남아 있었습니다. 이 값은 PR comment/review에 렌더링될 수 있으므로, live/probe executor가 실수로 token·endpoint·password 조각을 넣으면 PR-facing output으로 새어 나갈 수 있습니다.

이 PR은 executor-provided details에도 중앙 sanitization을 적용하고, #92 완료 기준에 맞춰 누락된 regression coverage를 추가합니다.

## 변경 내용

- API contract probe executor가 반환한 details에서 credential-like assignment와 URL endpoint 조각을 redaction합니다.
- `AgentRunStatus.TIMEOUT` / `CANCELLED`가 validation `ERROR`로 처리되고 raw runner error를 노출하지 않음을 검증합니다.
- runner failure/exception, executor timeout/exception 경로에서도 workflow session cleanup이 실행되는지 검증합니다.
- executor PASS/FAIL/SKIPPED 자체는 그대로 probe verdict로 유지하되, PR-facing details만 sanitize되도록 했습니다.

## 리뷰 포인트

- runner 성공은 여전히 validation PASS가 아니라 executor 실행으로 넘어가는 신호일 뿐입니다.
- exception 경로는 기존처럼 raw exception string을 복사하지 않고 coarse error kind/type만 남깁니다.
- 새 sanitizer는 final defense 용도이며, live executor가 sanitized details를 반환해야 한다는 기존 책임도 유지됩니다.

Closes #92

---
Co-worked by Hermes Agent
