### PR TITLE
fix(output): keep validation evidence out of inline reviews

### DIFF
--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -79,9 +79,13 @@ class PRReviewPayload:
 
     def prepared_for_submission(self) -> PRReviewPayload:
         mapped = tuple(
-            _validated_review_comment(comment).with_attribution() for comment in self.comments if comment.is_mapped
+            _validated_review_comment(comment).with_attribution()
+            for comment in self.comments
+            if comment.is_mapped and not _is_general_validation_evidence(comment)
         )
-        unmapped = tuple(comment for comment in self.comments if not comment.is_mapped)
+        unmapped = tuple(
+            comment for comment in self.comments if not comment.is_mapped or _is_general_validation_evidence(comment)
+        )
         body = self.body
         if unmapped:
             body = _append_unmapped_findings(body, unmapped)
@@ -168,6 +172,11 @@ def _validated_review_comment(comment: PRReviewComment) -> PRReviewComment:
         if comment.start_side and comment.start_side != "RIGHT":
             raise ValueError("review comment start_side must be RIGHT for qaestro output")
     return comment
+
+
+def _is_general_validation_evidence(comment: PRReviewComment) -> bool:
+    body = comment.body.strip().lower()
+    return body.startswith("runtime validation passed") or body.startswith("runtime validation skipped")
 
 
 def _review_comment_from_raw(raw: object) -> PRReviewComment:

--- a/tests/runtime/test_github_review_output.py
+++ b/tests/runtime/test_github_review_output.py
@@ -238,7 +238,7 @@ def test_review_payload_rejects_invalid_inline_comment_shapes() -> None:
         raise AssertionError("invalid inline review comment shape was not rejected")
 
 
-def test_output_poster_preflights_review_before_summary_comment() -> None:
+def test_output_poster_preflights_review_create_before_summary_comment() -> None:
     runtime = RecordingRuntime(current_head_sha="new-head")
     poster = ToolRuntimePROutputPoster(runtime)
     comment_payload = PRCommentPayload(repo_full_name="octocat/hello-world", pr_number=7, body="summary body")
@@ -280,3 +280,47 @@ def test_output_poster_adds_correlation_marker_before_duplicate_lookup() -> None
 
     assert result == existing
     assert [call.name for call in runtime.calls] == ["github.pr.view", "github.pr.review.list"]
+
+
+def test_output_poster_preflights_duplicate_review_before_summary_comment() -> None:
+    existing = ReviewResult(
+        id=77,
+        html_url="https://github.com/octocat/hello-world/pull/7#pullrequestreview-77",
+        state="COMMENTED",
+        body="review body\n\nCorrelation ID: `corr-existing`",
+        commit_id="abc123",
+    )
+    runtime = RecordingRuntime(existing_reviews=(existing,))
+    poster = ToolRuntimePROutputPoster(runtime)
+    comment_payload = PRCommentPayload(repo_full_name="octocat/hello-world", pr_number=7, body="summary body")
+    review_payload = PRReviewPayload(
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        head_sha="abc123",
+        body="review body",
+    )
+
+    result = poster.post_outputs(comment_payload, review_payload=review_payload, correlation_id="corr-existing")
+
+    assert result.review == existing
+    assert [call.name for call in runtime.calls] == [
+        "github.pr.view",
+        "github.pr.review.list",
+        "github.pr.comment.create_or_update",
+    ]
+
+
+def test_pass_validation_evidence_stays_in_review_body_without_inline_comment() -> None:
+    payload = PRReviewPayload(
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        head_sha="abc123",
+        body="review body",
+        comments=(PRReviewComment(path="src/app.py", body="Runtime validation passed for `GET /health`: ok", line=12),),
+    )
+
+    prepared = payload.prepared_for_submission()
+
+    assert prepared.comments == ()
+    assert "Runtime validation passed" in prepared.body
+    assert "Unmapped inline findings" in prepared.body

--- a/tests/runtime/test_llm_pr_review_e2e_smoke.py
+++ b/tests/runtime/test_llm_pr_review_e2e_smoke.py
@@ -182,7 +182,7 @@ def test_llm_pr_review_e2e_smoke_runs_live_provider_workflow_and_posts_outputs()
     assert result.comment_url
     assert result.review_url
     assert result.head_sha == "head123"
-    assert result.inline_comment_submitted is True
+    assert result.inline_comment_submitted is False
     assert len(live_client.requests) == 1
     prompt = str(live_client.requests[0]["prompt"])
     assert "PR description" in prompt


### PR DESCRIPTION
## 요약

Step 6.5 #93 범위에서 official GitHub review/inline comment surface의 guardrail을 보강합니다. 핵심 변경은 일반 runtime validation evidence를 임의의 diff line inline comment로 보내지 않고 review body로만 남기도록 제한한 것입니다.

## 변경 내용

- `Runtime validation passed/skipped...` 형태의 일반 validation evidence는 mapped inline comment 후보여도 review body의 unmapped section으로 degrade합니다.
- 기존 stale-head preflight, duplicate review lookup, correlation marker, `COMMENT` event 강제, invalid inline shape 검증이 유지되는지 regression coverage를 보강했습니다.
- LLM PR review E2E smoke test 기대값을 inline comment 미제출로 정렬했습니다. 현재 slice에서는 일반 validation evidence를 inline comment로 달지 않는 것이 의도입니다.

## 리뷰 포인트

- 일반 validation PASS/SKIPPED evidence가 GitHub inline comment noise로 나가지 않는지 확인해주세요.
- mapped finding과 general validation evidence의 경계가 너무 넓거나 좁지 않은지 봐주세요.
- managed summary comment와 official review surface가 여전히 분리되어 있고, stale head/duplicate review preflight가 유지되는지 확인해주세요.

Closes #93

---
Co-worked by Hermes Agent
