### PR TITLE
fix(output): restrict validation inline review comments

### DIFF
--- a/src/core/contracts/__init__.py
+++ b/src/core/contracts/__init__.py
@@ -19,6 +19,7 @@ from .domain import (
     RiskLevel,
     StrategyAction,
     StrategyResult,
+    ValidationLocation,
     ValidationOutcome,
     ValidationResult,
 )
@@ -67,6 +68,7 @@ __all__ = [
     "RiskLevel",
     "StrategyAction",
     "StrategyResult",
+    "ValidationLocation",
     "ValidationOutcome",
     "ValidationResult",
     "parse_github_ci_event",

--- a/src/core/contracts/domain.py
+++ b/src/core/contracts/domain.py
@@ -190,6 +190,20 @@ class ValidationOutcome(Enum):
 
 
 @dataclass(frozen=True)
+class ValidationLocation:
+    """A concrete code location that validation evidence can be attached to.
+
+    Runtime validation results are PR/run-level evidence by default. Populate this
+    only when the validator can explicitly tie the result to a file/line/range;
+    output code must not infer a location from generic primary-file fallbacks.
+    """
+
+    path: str
+    line: int
+    start_line: int | None = None
+
+
+@dataclass(frozen=True)
 class ValidationResult:
     """Result of a single validation action."""
 
@@ -198,6 +212,7 @@ class ValidationResult:
     details: str = ""
     duration_seconds: float = 0.0
     artifacts: tuple[str, ...] = ()
+    locations: tuple[ValidationLocation, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -175,43 +175,25 @@ def _review_payload_for_draft(draft: PRWorkflowDraft) -> PRReviewPayload | None:
 
 
 def _review_inline_comments(draft: PRWorkflowDraft) -> tuple[PRReviewComment, ...]:
-    if not draft.validations:
-        return ()
+    comments: list[PRReviewComment] = []
     for result in draft.validations:
-        if result.outcome is ValidationOutcome.PASS and result.action.target:
-            path = _review_comment_path(draft)
-            if not path:
-                return ()
-            return (
+        if result.outcome is not ValidationOutcome.FAIL:
+            continue
+        for location in result.locations:
+            if not location.path.strip() or location.line <= 0:
+                continue
+            target = result.action.target or result.action.description
+            detail = result.details or result.action.rationale
+            suffix = f": {detail}" if detail else ""
+            comments.append(
                 PRReviewComment(
-                    path=path,
-                    body=f"Runtime validation passed for `{result.action.target}`: {result.details}",
-                    line=_review_comment_line(draft),
-                ),
+                    path=location.path,
+                    body=f"Runtime validation failed for `{target}`{suffix}",
+                    line=location.line,
+                    start_line=location.start_line,
+                )
             )
-    if any(result.outcome is ValidationOutcome.SKIPPED for result in draft.validations):
-        return ()
-    return (
-        PRReviewComment(
-            path=_review_comment_path(draft),
-            body="Runtime validation did not pass; see the review body for details.",
-            line=None,
-        ),
-    )
-
-
-def _review_comment_path(draft: PRWorkflowDraft) -> str:
-    stats = draft.report.impact.raw_diff_stats
-    for key in ("primary_file", "first_file"):
-        value = stats.get(key)
-        if isinstance(value, str) and value.strip():
-            return value
-    return ""
-
-
-def _review_comment_line(draft: PRWorkflowDraft) -> int | None:
-    value = draft.report.impact.raw_diff_stats.get("primary_line")
-    return value if isinstance(value, int) and value > 0 else None
+    return tuple(comments)
 
 
 def _review_validation_lines(validations: tuple[ValidationResult, ...]) -> list[str]:

--- a/tests/runtime/test_llm_pr_review_e2e_smoke.py
+++ b/tests/runtime/test_llm_pr_review_e2e_smoke.py
@@ -182,7 +182,7 @@ def test_llm_pr_review_e2e_smoke_runs_live_provider_workflow_and_posts_outputs()
     assert result.comment_url
     assert result.review_url
     assert result.head_sha == "head123"
-    assert result.inline_comment_submitted is True
+    assert result.inline_comment_submitted is False
     assert len(live_client.requests) == 1
     prompt = str(live_client.requests[0]["prompt"])
     assert "PR description" in prompt

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -27,6 +27,7 @@ from src.core.contracts import (
     RiskLevel,
     StrategyAction,
     StrategyResult,
+    ValidationLocation,
     ValidationOutcome,
     ValidationResult,
 )
@@ -152,7 +153,7 @@ def test_event_orchestrator_dispatches_pr_events_to_pr_sub_orchestrator():
     assert result.comment_payload.pr_number == 31
 
 
-def test_pr_workflow_orchestrator_produces_official_review_payload_for_output_stage() -> None:
+def test_pr_workflow_orchestrator_keeps_passing_validation_evidence_out_of_inline_comments() -> None:
     event = PROpened(
         meta=_event_meta("evt-review-output", EventType.PR_OPENED, "corr-review-output"),
         repo_full_name="Kimcheolhui/qaestro",
@@ -172,7 +173,7 @@ def test_pr_workflow_orchestrator_produces_official_review_payload_for_output_st
         description="verify api",
         target="GET /health",
         priority=5,
-        rationale="exercise inline review mapping",
+        rationale="exercise validation review evidence",
     )
 
     class PassingValidator:
@@ -206,9 +207,168 @@ def test_pr_workflow_orchestrator_produces_official_review_payload_for_output_st
     assert result.review_payload.event == "COMMENT"
     assert "Correlation ID: `corr-review-output`" in result.review_payload.body
     assert "Runtime Validation Review" in result.review_payload.body
-    assert result.review_payload.comments
+    assert "**PASS** `GET /health`: probe passed" in result.review_payload.body
+    assert result.review_payload.comments == ()
+
+
+def test_pr_workflow_orchestrator_keeps_skipped_validation_evidence_out_of_inline_comments() -> None:
+    event = PROpened(
+        meta=_event_meta("evt-review-skipped-output", EventType.PR_OPENED, "corr-review-skipped-output"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=31,
+        title="feat: add validation",
+        body="",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/review-output",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
+        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
+        head_sha="abc123",
+    )
+
+    action = StrategyAction(
+        action_type=ActionType.VERIFY_API_CONTRACT,
+        description="verify api",
+        target="POST /orders",
+        priority=5,
+        rationale="write-like probe requires approval",
+    )
+
+    class SkippedValidator:
+        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+            return (
+                ValidationResult(
+                    action=action,
+                    outcome=ValidationOutcome.SKIPPED,
+                    details="needs approval",
+                ),
+            )
+
+    class SingleActionStrategy:
+        def plan(
+            self,
+            *,
+            repo_full_name: str,
+            pr_number: int,
+            title: str,
+            impact: BehaviourImpact,
+            ci_feedback: CIFeedbackContext | None = None,
+        ) -> StrategyResult:
+            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
+
+    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=SkippedValidator()).run(event)
+
+    assert isinstance(result.review_payload, PRReviewPayload)
+    assert "**SKIPPED** `POST /orders`: needs approval" in result.review_payload.body
+    assert result.review_payload.comments == ()
+
+
+def test_pr_workflow_orchestrator_creates_inline_comment_for_mapped_validation_failure() -> None:
+    event = PROpened(
+        meta=_event_meta("evt-review-fail-output", EventType.PR_OPENED, "corr-review-fail-output"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=31,
+        title="feat: add validation",
+        body="",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/review-output",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
+        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
+        head_sha="abc123",
+    )
+
+    action = StrategyAction(
+        action_type=ActionType.VERIFY_API_CONTRACT,
+        description="verify api",
+        target="GET /health",
+        priority=5,
+        rationale="exercise mapped validation failure",
+    )
+
+    class FailingValidator:
+        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+            return (
+                ValidationResult(
+                    action=action,
+                    outcome=ValidationOutcome.FAIL,
+                    details="expected 200, got 500",
+                    locations=(ValidationLocation(path="src/app.py", line=12),),
+                ),
+            )
+
+    class SingleActionStrategy:
+        def plan(
+            self,
+            *,
+            repo_full_name: str,
+            pr_number: int,
+            title: str,
+            impact: BehaviourImpact,
+            ci_feedback: CIFeedbackContext | None = None,
+        ) -> StrategyResult:
+            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
+
+    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=FailingValidator()).run(event)
+
+    assert isinstance(result.review_payload, PRReviewPayload)
+    assert len(result.review_payload.comments) == 1
     assert result.review_payload.comments[0].path == "src/app.py"
-    assert result.review_payload.comments[0].line is None
+    assert result.review_payload.comments[0].line == 12
+    assert "Runtime validation failed" in result.review_payload.comments[0].body
+    assert "expected 200, got 500" in result.review_payload.comments[0].body
+
+
+def test_pr_workflow_orchestrator_degrades_unmapped_validation_failure_into_review_body() -> None:
+    event = PROpened(
+        meta=_event_meta("evt-review-unmapped-fail", EventType.PR_OPENED, "corr-review-unmapped-fail"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=31,
+        title="feat: add validation",
+        body="",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/review-output",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
+        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
+        head_sha="abc123",
+    )
+
+    action = StrategyAction(
+        action_type=ActionType.VERIFY_API_CONTRACT,
+        description="verify api",
+        target="GET /health",
+        priority=5,
+        rationale="exercise unmapped validation failure",
+    )
+
+    class FailingValidator:
+        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+            return (
+                ValidationResult(
+                    action=action,
+                    outcome=ValidationOutcome.FAIL,
+                    details="expected 200, got 500",
+                ),
+            )
+
+    class SingleActionStrategy:
+        def plan(
+            self,
+            *,
+            repo_full_name: str,
+            pr_number: int,
+            title: str,
+            impact: BehaviourImpact,
+            ci_feedback: CIFeedbackContext | None = None,
+        ) -> StrategyResult:
+            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
+
+    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=FailingValidator()).run(event)
+
+    assert isinstance(result.review_payload, PRReviewPayload)
+    assert "**FAIL** `GET /health`: expected 200, got 500" in result.review_payload.body
+    assert result.review_payload.comments == ()
 
 
 def test_event_orchestrator_dispatches_ci_to_ci_sub_orchestrator():

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -131,6 +131,67 @@ def _pr_reviewed_event() -> PRReviewed:
     )
 
 
+def _review_output_event() -> PROpened:
+    return PROpened(
+        meta=_event_meta("evt-review-output", EventType.PR_OPENED, "corr-review-output"),
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=31,
+        title="feat: add validation",
+        body="",
+        author="Kimcheolhui",
+        base_branch="main",
+        head_branch="feat/review-output",
+        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
+        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
+        head_sha="abc123",
+    )
+
+
+def _validation_action(target: str = "GET /health") -> StrategyAction:
+    return StrategyAction(
+        action_type=ActionType.VERIFY_API_CONTRACT,
+        description="verify api",
+        target=target,
+        priority=5,
+        rationale="exercise validation review output",
+    )
+
+
+class StaticStrategyEngine:
+    def __init__(self, actions: tuple[StrategyAction, ...]) -> None:
+        self._actions = actions
+
+    def plan(
+        self,
+        *,
+        repo_full_name: str,
+        pr_number: int,
+        title: str,
+        impact: BehaviourImpact,
+        ci_feedback: CIFeedbackContext | None = None,
+    ) -> StrategyResult:
+        del repo_full_name, pr_number, title, impact, ci_feedback
+        return StrategyResult(actions=self._actions, reasoning="verify API contract", confidence=1.0)
+
+
+class StaticValidator:
+    def __init__(self, validations: tuple[ValidationResult, ...]) -> None:
+        self._validations = validations
+
+    def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
+        assert strategy.actions == tuple(validation.action for validation in self._validations)
+        return self._validations
+
+
+def _review_payload_for_validations(*validations: ValidationResult) -> PRReviewPayload:
+    result = PRWorkflowOrchestrator(
+        strategy_engine=StaticStrategyEngine(tuple(validation.action for validation in validations)),
+        validator=StaticValidator(tuple(validations)),
+    ).run(_review_output_event())
+    assert isinstance(result.review_payload, PRReviewPayload)
+    return result.review_payload
+
+
 def test_event_orchestrator_dispatches_pr_events_to_pr_sub_orchestrator():
     event = _pr_opened_event()
     orchestrator = EventOrchestrator()
@@ -153,222 +214,66 @@ def test_event_orchestrator_dispatches_pr_events_to_pr_sub_orchestrator():
     assert result.comment_payload.pr_number == 31
 
 
+def test_pr_workflow_orchestrator_sets_basic_official_review_payload_fields() -> None:
+    action = _validation_action()
+    review = _review_payload_for_validations(
+        ValidationResult(action=action, outcome=ValidationOutcome.PASS, details="probe passed")
+    )
+
+    assert review.repo_full_name == "Kimcheolhui/qaestro"
+    assert review.pr_number == 31
+    assert review.head_sha == "abc123"
+    assert review.event == "COMMENT"
+    assert "Correlation ID: `corr-review-output`" in review.body
+    assert "Runtime Validation Review" in review.body
+
+
 def test_pr_workflow_orchestrator_keeps_passing_validation_evidence_out_of_inline_comments() -> None:
-    event = PROpened(
-        meta=_event_meta("evt-review-output", EventType.PR_OPENED, "corr-review-output"),
-        repo_full_name="Kimcheolhui/qaestro",
-        pr_number=31,
-        title="feat: add validation",
-        body="",
-        author="Kimcheolhui",
-        base_branch="main",
-        head_branch="feat/review-output",
-        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
-        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
-        head_sha="abc123",
+    action = _validation_action()
+    review = _review_payload_for_validations(
+        ValidationResult(action=action, outcome=ValidationOutcome.PASS, details="probe passed")
     )
 
-    action = StrategyAction(
-        action_type=ActionType.VERIFY_API_CONTRACT,
-        description="verify api",
-        target="GET /health",
-        priority=5,
-        rationale="exercise validation review evidence",
-    )
-
-    class PassingValidator:
-        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
-            return (
-                ValidationResult(
-                    action=action,
-                    outcome=ValidationOutcome.PASS,
-                    details="probe passed",
-                ),
-            )
-
-    class SingleActionStrategy:
-        def plan(
-            self,
-            *,
-            repo_full_name: str,
-            pr_number: int,
-            title: str,
-            impact: BehaviourImpact,
-            ci_feedback: CIFeedbackContext | None = None,
-        ) -> StrategyResult:
-            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
-
-    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=PassingValidator()).run(event)
-
-    assert isinstance(result.review_payload, PRReviewPayload)
-    assert result.review_payload.repo_full_name == "Kimcheolhui/qaestro"
-    assert result.review_payload.pr_number == 31
-    assert result.review_payload.head_sha == "abc123"
-    assert result.review_payload.event == "COMMENT"
-    assert "Correlation ID: `corr-review-output`" in result.review_payload.body
-    assert "Runtime Validation Review" in result.review_payload.body
-    assert "**PASS** `GET /health`: probe passed" in result.review_payload.body
-    assert result.review_payload.comments == ()
+    assert "**PASS** `GET /health`: probe passed" in review.body
+    assert review.comments == ()
 
 
 def test_pr_workflow_orchestrator_keeps_skipped_validation_evidence_out_of_inline_comments() -> None:
-    event = PROpened(
-        meta=_event_meta("evt-review-skipped-output", EventType.PR_OPENED, "corr-review-skipped-output"),
-        repo_full_name="Kimcheolhui/qaestro",
-        pr_number=31,
-        title="feat: add validation",
-        body="",
-        author="Kimcheolhui",
-        base_branch="main",
-        head_branch="feat/review-output",
-        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
-        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
-        head_sha="abc123",
+    action = _validation_action("POST /orders")
+    review = _review_payload_for_validations(
+        ValidationResult(action=action, outcome=ValidationOutcome.SKIPPED, details="needs approval")
     )
 
-    action = StrategyAction(
-        action_type=ActionType.VERIFY_API_CONTRACT,
-        description="verify api",
-        target="POST /orders",
-        priority=5,
-        rationale="write-like probe requires approval",
-    )
-
-    class SkippedValidator:
-        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
-            return (
-                ValidationResult(
-                    action=action,
-                    outcome=ValidationOutcome.SKIPPED,
-                    details="needs approval",
-                ),
-            )
-
-    class SingleActionStrategy:
-        def plan(
-            self,
-            *,
-            repo_full_name: str,
-            pr_number: int,
-            title: str,
-            impact: BehaviourImpact,
-            ci_feedback: CIFeedbackContext | None = None,
-        ) -> StrategyResult:
-            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
-
-    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=SkippedValidator()).run(event)
-
-    assert isinstance(result.review_payload, PRReviewPayload)
-    assert "**SKIPPED** `POST /orders`: needs approval" in result.review_payload.body
-    assert result.review_payload.comments == ()
+    assert "**SKIPPED** `POST /orders`: needs approval" in review.body
+    assert review.comments == ()
 
 
 def test_pr_workflow_orchestrator_creates_inline_comment_for_mapped_validation_failure() -> None:
-    event = PROpened(
-        meta=_event_meta("evt-review-fail-output", EventType.PR_OPENED, "corr-review-fail-output"),
-        repo_full_name="Kimcheolhui/qaestro",
-        pr_number=31,
-        title="feat: add validation",
-        body="",
-        author="Kimcheolhui",
-        base_branch="main",
-        head_branch="feat/review-output",
-        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
-        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
-        head_sha="abc123",
+    action = _validation_action()
+    review = _review_payload_for_validations(
+        ValidationResult(
+            action=action,
+            outcome=ValidationOutcome.FAIL,
+            details="expected 200, got 500",
+            locations=(ValidationLocation(path="src/app.py", line=12),),
+        )
     )
 
-    action = StrategyAction(
-        action_type=ActionType.VERIFY_API_CONTRACT,
-        description="verify api",
-        target="GET /health",
-        priority=5,
-        rationale="exercise mapped validation failure",
-    )
-
-    class FailingValidator:
-        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
-            return (
-                ValidationResult(
-                    action=action,
-                    outcome=ValidationOutcome.FAIL,
-                    details="expected 200, got 500",
-                    locations=(ValidationLocation(path="src/app.py", line=12),),
-                ),
-            )
-
-    class SingleActionStrategy:
-        def plan(
-            self,
-            *,
-            repo_full_name: str,
-            pr_number: int,
-            title: str,
-            impact: BehaviourImpact,
-            ci_feedback: CIFeedbackContext | None = None,
-        ) -> StrategyResult:
-            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
-
-    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=FailingValidator()).run(event)
-
-    assert isinstance(result.review_payload, PRReviewPayload)
-    assert len(result.review_payload.comments) == 1
-    assert result.review_payload.comments[0].path == "src/app.py"
-    assert result.review_payload.comments[0].line == 12
-    assert "Runtime validation failed" in result.review_payload.comments[0].body
-    assert "expected 200, got 500" in result.review_payload.comments[0].body
+    assert len(review.comments) == 1
+    assert review.comments[0].path == "src/app.py"
+    assert review.comments[0].line == 12
+    assert "Runtime validation failed" in review.comments[0].body
+    assert "expected 200, got 500" in review.comments[0].body
 
 
 def test_pr_workflow_orchestrator_degrades_unmapped_validation_failure_into_review_body() -> None:
-    event = PROpened(
-        meta=_event_meta("evt-review-unmapped-fail", EventType.PR_OPENED, "corr-review-unmapped-fail"),
-        repo_full_name="Kimcheolhui/qaestro",
-        pr_number=31,
-        title="feat: add validation",
-        body="",
-        author="Kimcheolhui",
-        base_branch="main",
-        head_branch="feat/review-output",
-        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
-        files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
-        head_sha="abc123",
+    action = _validation_action()
+    review = _review_payload_for_validations(
+        ValidationResult(action=action, outcome=ValidationOutcome.FAIL, details="expected 200, got 500")
     )
 
-    action = StrategyAction(
-        action_type=ActionType.VERIFY_API_CONTRACT,
-        description="verify api",
-        target="GET /health",
-        priority=5,
-        rationale="exercise unmapped validation failure",
-    )
-
-    class FailingValidator:
-        def validate(self, strategy: StrategyResult) -> tuple[ValidationResult, ...]:
-            return (
-                ValidationResult(
-                    action=action,
-                    outcome=ValidationOutcome.FAIL,
-                    details="expected 200, got 500",
-                ),
-            )
-
-    class SingleActionStrategy:
-        def plan(
-            self,
-            *,
-            repo_full_name: str,
-            pr_number: int,
-            title: str,
-            impact: BehaviourImpact,
-            ci_feedback: CIFeedbackContext | None = None,
-        ) -> StrategyResult:
-            return StrategyResult(actions=(action,), reasoning="verify API contract", confidence=1.0)
-
-    result = PRWorkflowOrchestrator(strategy_engine=SingleActionStrategy(), validator=FailingValidator()).run(event)
-
-    assert isinstance(result.review_payload, PRReviewPayload)
-    assert "**FAIL** `GET /health`: expected 200, got 500" in result.review_payload.body
-    assert result.review_payload.comments == ()
+    assert "**FAIL** `GET /health`: expected 200, got 500" in review.body
+    assert review.comments == ()
 
 
 def test_event_orchestrator_dispatches_ci_to_ci_sub_orchestrator():

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -131,19 +131,19 @@ def _pr_reviewed_event() -> PRReviewed:
     )
 
 
-def _review_output_event() -> PROpened:
+def _review_output_event(*, pr_number: int = 101, head_sha: str = "review-head-sha") -> PROpened:
     return PROpened(
         meta=_event_meta("evt-review-output", EventType.PR_OPENED, "corr-review-output"),
-        repo_full_name="Kimcheolhui/qaestro",
-        pr_number=31,
+        repo_full_name="owner/repo",
+        pr_number=pr_number,
         title="feat: add validation",
         body="",
-        author="Kimcheolhui",
+        author="review-author",
         base_branch="main",
         head_branch="feat/review-output",
-        diff_url="https://github.com/Kimcheolhui/qaestro/pull/31.diff",
+        diff_url=f"https://example.test/owner/repo/pull/{pr_number}.diff",
         files_changed=(FileChange(path="src/app.py", status="modified", additions=8),),
-        head_sha="abc123",
+        head_sha=head_sha,
     )
 
 
@@ -220,9 +220,9 @@ def test_pr_workflow_orchestrator_sets_basic_official_review_payload_fields() ->
         ValidationResult(action=action, outcome=ValidationOutcome.PASS, details="probe passed")
     )
 
-    assert review.repo_full_name == "Kimcheolhui/qaestro"
-    assert review.pr_number == 31
-    assert review.head_sha == "abc123"
+    assert review.repo_full_name == "owner/repo"
+    assert review.pr_number == 101
+    assert review.head_sha == "review-head-sha"
     assert review.event == "COMMENT"
     assert "Correlation ID: `corr-review-output`" in review.body
     assert "Runtime Validation Review" in review.body

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -524,16 +524,6 @@ class TestStrategyResult:
         assert sr.knowledge_refs == ()
 
 
-class TestValidationLocation:
-    """ValidationLocation construction and defaults."""
-
-    def test_defaults(self):
-        location = ValidationLocation(path="src/app.py", line=12)
-        assert location.path == "src/app.py"
-        assert location.line == 12
-        assert location.start_line is None
-
-
 class TestValidationResult:
     """ValidationResult defaults."""
 
@@ -545,7 +535,7 @@ class TestValidationResult:
         assert vr.artifacts == ()
         assert vr.locations == ()
 
-    def test_locations_can_be_attached_to_validation_failures(self):
+    def test_can_carry_explicit_review_location(self):
         action = StrategyAction(action_type=ActionType.VERIFY_API_CONTRACT, description="d", target="GET /health")
         location = ValidationLocation(path="src/app.py", line=12, start_line=10)
         vr = ValidationResult(action=action, outcome=ValidationOutcome.FAIL, locations=(location,))

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -19,6 +19,7 @@ from src.core.contracts.domain import (
     RiskLevel,
     StrategyAction,
     StrategyResult,
+    ValidationLocation,
     ValidationOutcome,
     ValidationResult,
 )
@@ -523,6 +524,16 @@ class TestStrategyResult:
         assert sr.knowledge_refs == ()
 
 
+class TestValidationLocation:
+    """ValidationLocation construction and defaults."""
+
+    def test_defaults(self):
+        location = ValidationLocation(path="src/app.py", line=12)
+        assert location.path == "src/app.py"
+        assert location.line == 12
+        assert location.start_line is None
+
+
 class TestValidationResult:
     """ValidationResult defaults."""
 
@@ -532,6 +543,13 @@ class TestValidationResult:
         assert vr.details == ""
         assert vr.duration_seconds == 0.0
         assert vr.artifacts == ()
+        assert vr.locations == ()
+
+    def test_locations_can_be_attached_to_validation_failures(self):
+        action = StrategyAction(action_type=ActionType.VERIFY_API_CONTRACT, description="d", target="GET /health")
+        location = ValidationLocation(path="src/app.py", line=12, start_line=10)
+        vr = ValidationResult(action=action, outcome=ValidationOutcome.FAIL, locations=(location,))
+        assert vr.locations == (location,)
 
 
 class TestQAReport:


### PR DESCRIPTION
## Summary
- runtime validation `PASS` / `SKIPPED` 결과가 official review inline comment로 생성되지 않도록 정리했습니다.
- validation `FAIL`은 `ValidationLocation`으로 명시된 file/line/range가 있을 때만 inline review comment로 생성되게 했습니다.
- mapped location이 없는 validation failure/evidence는 기존 review body의 Validation Evidence에 남고, `primary_file` / `primary_line` fallback으로 임의 inline 처리하지 않도록 했습니다.

Closes #93

---
Co-worked by Hermes Agent
