### PR TITLE
test(runtime): PR aggregate current-head lifecycle replay 보강

### DIFF
--- a/docs/notes/PR_REVIEW_LIFECYCLE.md
+++ b/docs/notes/PR_REVIEW_LIFECYCLE.md
@@ -4,7 +4,8 @@ Step 4 논의 과정에서 정리된 PR/CI/ChatOps 통합 모델이다. Step 6 �
 
 - PR, CI, GitHub comment/review, ChatOps mention은 event source별로 따로 수신하되, 판단은 PR 단위 `PRAggregateState`로 모은다.
 - `PRAggregateState` 내부에는 current PR metadata와 대화 history를 두고, head commit별 `PRRevisionState(head_sha)`와 여러 `ReviewRun`을 둔다.
-- 새 commit이 올라오면 새 revision을 만들고 이전 revision은 stale/superseded로 표시한다. 이전 CI 실패와 분석 결과는 historical evidence로 참고할 수 있지만, current verdict의 source of truth는 current `head_sha`의 diff와 CI/check 결과다.
-- 자동 final review는 CI/check 완료를 기다리는 deferred unified review를 기본으로 한다. `workflow_run completed` 이벤트는 특정 workflow run 하나의 완료 신호이므로, final review 직전에는 current head의 check/workflow snapshot을 조회해 pending/queued/in-progress 항목을 확인해야 한다.
-- 사용자가 GitHub comment나 channel에서 명시적으로 `@qaestro review`를 요청하면 manual-trigger first 흐름으로 처리한다. 이때는 조용히 기다리지 말고 current aggregate state 기준 interim response를 즉시 제공하되, 남은 CI/check와 최종 판단 보류를 명시한다.
+- 새 commit이 올라오면 새 revision을 만들고 이전 revision은 stale/superseded로 표시한다. 이전 CI 실패와 분석 결과는 historical evidence로 참고할 수 있지만, current verdict의 source of truth는 current `head_sha`의 diff와 CI/check 결과다. 이전에 current였던 revision의 CI run도 새 head가 들어오면 historical evidence로 재분류되어야 한다.
+- 자동 final review는 CI/check 완료를 기다리는 deferred unified review를 기본으로 한다. `workflow_run completed` 이벤트는 특정 workflow run 하나의 완료 신호이므로, final review 직전에는 current head의 check/workflow snapshot을 조회해 pending/queued/in-progress 항목을 확인해야 한다. Pending check가 남아 있으면 managed summary comment에는 interim 상태를 남길 수 있지만, official GitHub review payload는 아직 만들지 않는다.
+- 사용자가 GitHub comment나 channel에서 명시적으로 `@qaestro review`를 요청하면 manual-trigger first 흐름으로 처리한다. 이때는 조용히 기다리지 말고 current aggregate state 기준 interim response를 즉시 제공하되, 남은 CI/check와 최종 판단 보류를 명시한다. Manual trigger는 해당 시점의 current head에 묶인 `ReviewRun`으로 기록한다.
 - PR-level managed summary comment와 GitHub review/inline comment는 다른 output surface다. summary comment는 stable marker로 create/update하고, line/range comment는 final unified review 시점에 batch로 작성한다.
+- 현재 `InMemoryPRAggregateStore`는 worker process 안에서만 유지되는 foundation seam이다. Step 7 ChatOps가 재시작 이후 aggregate state를 신뢰해야 하는 범위까지 확장되면 persistent aggregate store가 필요하며, 그 전까지는 replay tests가 current-head/stale-history semantics를 고정하는 기준선 역할을 한다.

--- a/src/runtime/orchestrator/pr_aggregate.py
+++ b/src/runtime/orchestrator/pr_aggregate.py
@@ -108,6 +108,11 @@ class CIWorkflowRunRecord:
             is_current_head=event.commit_sha == current_head_sha,
         )
 
+    def as_historical(self) -> CIWorkflowRunRecord:
+        if not self.is_current_head:
+            return self
+        return replace(self, is_current_head=False)
+
 
 @dataclass(frozen=True)
 class PRRevisionState:
@@ -126,9 +131,13 @@ class PRRevisionState:
         return replace(self, ci_runs=(*self.ci_runs, record))
 
     def supersede(self) -> PRRevisionState:
-        if self.status is PRRevisionStatus.SUPERSEDED:
+        if self.status is PRRevisionStatus.SUPERSEDED and all(not record.is_current_head for record in self.ci_runs):
             return self
-        return replace(self, status=PRRevisionStatus.SUPERSEDED)
+        return replace(
+            self,
+            status=PRRevisionStatus.SUPERSEDED,
+            ci_runs=tuple(record.as_historical() for record in self.ci_runs),
+        )
 
 
 @dataclass(frozen=True)
@@ -306,6 +315,19 @@ class InMemoryPRAggregateStore:
         if existing is None:
             return None
         return self.save(existing.record_ci_completed(event))
+
+    def start_review_run(
+        self,
+        *,
+        repo_full_name: str,
+        pr_number: int,
+        trigger: ReviewRunTrigger,
+        requested_by: str = "",
+    ) -> PRAggregateState | None:
+        existing = self.get(repo_full_name, pr_number)
+        if existing is None:
+            return None
+        return self.save(existing.start_review_run(trigger=trigger, requested_by=requested_by))
 
 
 def _head_sha_for(event: PREvent) -> str:

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -10,6 +10,7 @@ from src.core.analyzer import PRAnalysisContext, RuleBasedPRBehaviourAnalyzer
 from src.core.contracts import (
     BehaviourImpact,
     CIFeedbackContext,
+    CIReadinessState,
     PREvent,
     QAReport,
     RiskLevel,
@@ -135,7 +136,7 @@ class PRWorkflowOrchestrator:
         stage_order = (*stages, WorkflowStage.RENDERER)
         draft = PRWorkflowDraft(event=event, report=report, triage=triage, stage_order=stage_order)
         comment_payload = self._renderer.render(draft)
-        review_payload = _review_payload_for_draft(draft)
+        review_payload = _review_payload_for_draft(draft) if _can_publish_official_review(ci_feedback) else None
         return PRWorkflowResult(
             event=event,
             report=report,
@@ -144,6 +145,10 @@ class PRWorkflowOrchestrator:
             review_payload=review_payload,
             stage_order=stage_order,
         )
+
+
+def _can_publish_official_review(ci_feedback: CIFeedbackContext | None) -> bool:
+    return ci_feedback is None or ci_feedback.readiness is not CIReadinessState.WAITING_FOR_CHECKS
 
 
 def _review_payload_for_draft(draft: PRWorkflowDraft) -> PRReviewPayload | None:

--- a/tests/replay/test_ci_feedback_loop_replay.py
+++ b/tests/replay/test_ci_feedback_loop_replay.py
@@ -7,7 +7,7 @@ import hmac
 import json
 from pathlib import Path
 
-from src.adapters.renderers import PRCommentPayload
+from src.adapters.renderers import PRCommentPayload, PRReviewPayload
 from src.app.gateway import GitHubWebhookGateway, WebhookRequest
 from src.app.jobs import InMemoryJobQueue
 from src.app.worker import Worker, WorkerStatus
@@ -33,10 +33,20 @@ CURRENT_HEAD_SHA = "fed321cba987654"
 class RecordingOutputPoster:
     def __init__(self) -> None:
         self.payloads: list[PRCommentPayload] = []
+        self.review_payloads: list[PRReviewPayload | None] = []
         self.correlation_ids: list[str] = []
 
     def post_comment(self, payload: PRCommentPayload, *, correlation_id: str) -> object:
         self.payloads.append(payload)
+        self.review_payloads.append(None)
+        self.correlation_ids.append(correlation_id)
+        return correlation_id
+
+    def post_outputs(
+        self, payload: PRCommentPayload, *, review_payload: PRReviewPayload | None, correlation_id: str
+    ) -> object:
+        self.payloads.append(payload)
+        self.review_payloads.append(review_payload)
         self.correlation_ids.append(correlation_id)
         return correlation_id
 
@@ -221,6 +231,8 @@ def test_ci_feedback_loop_replay_separates_pending_current_head_and_stale_histor
     assert pending_executions[1].result is not None
     assert pending_executions[1].result.comment_payload is None
     assert poster.correlation_ids == ["delivery-pr-open", "delivery-pr-sync-pending"]
+    assert poster.review_payloads[0] is not None
+    assert poster.review_payloads[1] is None
     assert check_provider.calls == [
         ("acme-corp/web-api", OLD_HEAD_SHA, "delivery-pr-open"),
         ("acme-corp/web-api", CURRENT_HEAD_SHA, "delivery-pr-sync-pending"),
@@ -257,6 +269,9 @@ def test_ci_feedback_loop_replay_separates_pending_current_head_and_stale_histor
     assert final_executions[0].result is not None
     assert final_executions[0].result.comment_payload is None
     assert poster.correlation_ids == ["delivery-pr-open", "delivery-pr-sync-pending", "delivery-pr-sync-final"]
+    assert poster.review_payloads[0] is not None
+    assert poster.review_payloads[1] is None
+    assert poster.review_payloads[-1] is not None
     assert check_provider.calls == [
         ("acme-corp/web-api", OLD_HEAD_SHA, "delivery-pr-open"),
         ("acme-corp/web-api", CURRENT_HEAD_SHA, "delivery-pr-sync-pending"),

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -228,6 +228,22 @@ def test_pr_workflow_orchestrator_sets_basic_official_review_payload_fields() ->
     assert "Runtime Validation Review" in review.body
 
 
+def test_pr_workflow_orchestrator_holds_final_review_payload_while_current_head_checks_are_pending() -> None:
+    def pending_ci_feedback(event: PREvent) -> CIFeedbackContext:
+        return CIFeedbackContext(
+            current_head_sha=event.head_sha,
+            readiness=CIReadinessState.WAITING_FOR_CHECKS,
+            pending_checks=("CI Pipeline",),
+        )
+
+    result = PRWorkflowOrchestrator(ci_feedback_provider=pending_ci_feedback).run(_review_output_event())
+
+    assert result.comment_payload is not None
+    assert "Readiness: **WAITING FOR CHECKS**" in result.comment_payload.body
+    assert "Pending checks: `CI Pipeline`" in result.comment_payload.body
+    assert result.review_payload is None
+
+
 def test_pr_workflow_orchestrator_keeps_passing_validation_evidence_out_of_inline_comments() -> None:
     action = _validation_action()
     review = _review_payload_for_validations(

--- a/tests/runtime/test_pr_aggregate.py
+++ b/tests/runtime/test_pr_aggregate.py
@@ -17,6 +17,7 @@ from src.core.contracts import (
 from src.runtime.orchestrator import (
     CheckRunSnapshot,
     CheckRunStatus,
+    InMemoryPRAggregateStore,
     PRAggregateState,
     PRRevisionStatus,
     ReviewReadinessState,
@@ -110,6 +111,47 @@ def test_new_pr_head_supersedes_previous_revision_but_keeps_historical_evidence(
     assert aggregate.current_revision.head_sha == "sha-2"
     assert aggregate.current_revision.ci_runs == ()
     assert aggregate.current_revision.status is PRRevisionStatus.CURRENT
+
+
+def test_superseded_revision_relabels_previous_current_ci_runs_as_historical() -> None:
+    aggregate = PRAggregateState.from_pr_event(_pr_event(head_sha="sha-1"))
+    aggregate = aggregate.record_ci_completed(
+        _ci_event(event_id="ci-current", commit_sha="sha-1", conclusion="success")
+    )
+    assert aggregate.revisions["sha-1"].ci_runs[0].is_current_head is True
+
+    aggregate = aggregate.apply_pr_event(_pr_update(head_sha="sha-2"))
+
+    assert aggregate.revisions["sha-1"].status is PRRevisionStatus.SUPERSEDED
+    assert aggregate.revisions["sha-1"].ci_runs[0].is_current_head is False
+
+
+def test_store_records_manual_review_trigger_for_existing_aggregate_only() -> None:
+    store = InMemoryPRAggregateStore()
+
+    assert (
+        store.start_review_run(
+            repo_full_name="Kimcheolhui/qaestro",
+            pr_number=54,
+            trigger=ReviewRunTrigger.MANUAL,
+            requested_by="Kimcheolhui",
+        )
+        is None
+    )
+
+    store.apply_pr_event(_pr_event(head_sha="sha-1"))
+    aggregate = store.start_review_run(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=54,
+        trigger=ReviewRunTrigger.MANUAL,
+        requested_by="Kimcheolhui",
+    )
+
+    assert aggregate is not None
+    assert aggregate.review_runs[-1].head_sha == "sha-1"
+    assert aggregate.review_runs[-1].trigger is ReviewRunTrigger.MANUAL
+    assert aggregate.review_runs[-1].requested_by == "Kimcheolhui"
+    assert store.get("Kimcheolhui/qaestro", 54) == aggregate
 
 
 def test_stale_ci_result_is_recorded_without_affecting_current_readiness() -> None:


### PR DESCRIPTION
## Summary

PR aggregate의 current-head lifecycle replay를 보강합니다.

이번 변경은 superseded head의 CI evidence가 current verdict에 섞이지 않도록 historical evidence로 재분류하고, manual review trigger가 현재 head 기준 `ReviewRun`으로 기록되는 store seam을 추가합니다. 또한 current head check가 아직 pending인 경우 managed summary comment에는 interim 상태를 남기되, official GitHub review payload는 생성하지 않도록 했습니다.

Closes #94

---
Co-worked by Hermes Agent
