### PR TITLE
fix(worker): durable queue operational semantics 보강

### DIFF
--- a/docs/TECH_DECISIONS.md
+++ b/docs/TECH_DECISIONS.md
@@ -88,9 +88,11 @@ Step 2의 기본 local/test 구현은 `InMemoryJobQueue`를 유지한다. 단일
 
 - gateway는 normalized `EventJob`을 stream에 `XADD`한다.
 - worker는 consumer group으로 job을 읽고, 처리 후 `XACK`한다.
-- worker 재시작/장애 후에는 stale pending message를 claim해서 재처리할 수 있다. 기본 claim idle은 300000ms(5분)로 두며, 운영에서는 정상 처리 중인 long-running job이 중복 claim되지 않도록 최대 처리 시간보다 크게 잡는다.
+- worker 재시작/장애 후에는 stale pending message를 claim해서 재처리할 수 있다. 기본 claim idle은 300000ms(5분)로 두며, 운영에서는 정상 처리 중인 long-running job이 중복 claim되지 않도록 최대 처리 시간보다 크게 잡는다. Queue construction은 `redis_claim_idle_ms >= redis_read_block_ms`를 요구해 정상 blocking read보다 짧은 pending reclaim 설정을 막는다. 실제 LLM/provider validation 시간이 더 긴 환경에서는 timeout/processing budget보다 충분히 큰 claim idle을 운영 설정으로 둬야 한다.
 - Step 2에서는 worker process를 long-lived consumer로 실행한다. `memory` backend만 local drain-and-exit 모드로 동작한다.
-- 실패 job은 retry가 모두 끝난 뒤 ack하고 `correlation_id`, `delivery_id`, `attempts`, `error`를 포함한 structured error log를 남긴다. dead-letter 저장소와 운영 모니터링은 Step 10 운영 안정화에서 확장한다. 단, output write 이후 ack, duplicate delivery idempotency, malformed payload 처리처럼 Step 7 전에 필요한 최소 worker hardening은 Step 6.5에서 별도 점검한다.
+- 성공 job은 orchestrator와 output poster가 모두 완료된 뒤 ack한다. output write가 실패하면 worker는 configured attempt 내에서 재시도하고, terminal failure가 된 뒤에야 실패 log를 남기고 ack한다. 이렇게 하면 Redis pending entry가 output 실패를 성공 처리로 오인해 사라지지 않는다.
+- 실패 job은 retry가 모두 끝난 뒤 ack하고, ack 직전 `correlation_id`, `delivery_id`, `attempts`, `error`, `job_type`을 포함한 structured error log를 남긴다. Malformed payload도 `MalformedEventJob`으로 변환해 동일하게 terminal failure로 기록/ack한다. dead-letter 저장소, metrics, heartbeat/liveness status는 Step 10 운영 안정화 영역으로 남긴다. Step 6.5에서는 ack/write ordering, malformed-message terminal handling, Redis timing guardrail, managed comment/review idempotency marker를 최소 foundation으로 고정한다.
+- Duplicate delivery나 retry가 발생해도 managed summary comment는 stable marker(`Repository`/`Pull request`) 기반 create-or-update로 수렴하고, official review는 current head + correlation marker로 duplicate lookup을 수행한다. 완전한 cross-process aggregate persistence와 heartbeat 기반 in-flight observability는 Step 7 이후 ChatOps가 aggregate state를 의존하기 전 별도 persistence/operability work에서 확장한다.
 
 Redis Streams를 우선 선택한 이유는 Step 2 목표인 gateway/worker process 분리를 가장 낮은 운영 부담으로 검증할 수 있고, NATS JetStream보다 현재 self-hosted MVP의 도입면이 작기 때문이다. NATS JetStream은 이벤트 버스 중심 구조가 커질 때 다시 검토한다.
 

--- a/src/app/jobs.py
+++ b/src/app/jobs.py
@@ -154,6 +154,7 @@ class RedisStreamsJobQueue:
         self._claim_idle_ms = claim_idle_ms
         self._busy_group_error = busy_group_error
         self._claim_start_id = "0-0"
+        _validate_redis_timing(read_block_ms=read_block_ms, claim_idle_ms=claim_idle_ms)
         self._ensure_group()
 
     @classmethod
@@ -205,6 +206,10 @@ class RedisStreamsJobQueue:
         if job.delivery_id:
             self._redis.xack(self._stream, self._group, job.delivery_id)
 
+    @staticmethod
+    def validate_timing(*, read_block_ms: int, claim_idle_ms: int) -> None:
+        _validate_redis_timing(read_block_ms=read_block_ms, claim_idle_ms=claim_idle_ms)
+
     def _ensure_group(self) -> None:
         try:
             self._redis.xgroup_create(self._stream, self._group, "0", mkstream=True)
@@ -233,6 +238,17 @@ class RedisStreamsJobQueue:
         if not messages:
             return None
         return _job_from_message(messages[0])
+
+
+def _validate_redis_timing(*, read_block_ms: int, claim_idle_ms: int) -> None:
+    if read_block_ms < 0:
+        raise ValueError("read_block_ms must be >= 0")
+    if claim_idle_ms < 0:
+        raise ValueError("claim_idle_ms must be >= 0")
+    if read_block_ms > 0 and claim_idle_ms < read_block_ms:
+        raise ValueError(
+            "redis_claim_idle_ms/claim_idle_ms must be >= redis_read_block_ms/read_block_ms to avoid reclaiming normal blocking reads"
+        )
 
 
 def _job_from_message(message: tuple[Any, Mapping[Any, Any]]) -> QueuedJob:

--- a/src/app/queue_factory.py
+++ b/src/app/queue_factory.py
@@ -16,6 +16,10 @@ def build_job_queue(cfg: AppConfig, *, consumer: str | None = None) -> JobQueue:
     if cfg.queue_backend == "memory":
         return InMemoryJobQueue()
     if cfg.queue_backend == "redis-streams":
+        RedisStreamsJobQueue.validate_timing(
+            read_block_ms=cfg.redis_read_block_ms,
+            claim_idle_ms=cfg.redis_claim_idle_ms,
+        )
         return RedisStreamsJobQueue.from_url(
             cfg.redis_url,
             stream=cfg.redis_stream,

--- a/src/app/worker/runner.py
+++ b/src/app/worker/runner.py
@@ -127,6 +127,8 @@ class Worker:
         while (job := queue.dequeue()) is not None:
             execution = self.process(job)
             results.append(execution)
+            if execution.status is WorkerStatus.FAILED:
+                self._log_failed_execution(job, execution)
             queue.ack(job)
         return tuple(results)
 

--- a/tests/app/test_queue_factory.py
+++ b/tests/app/test_queue_factory.py
@@ -21,6 +21,10 @@ def test_build_job_queue_uses_redis_stream_settings(monkeypatch: pytest.MonkeyPa
     calls: list[dict[str, Any]] = []
 
     class FakeRedisStreamsQueue:
+        @staticmethod
+        def validate_timing(*, read_block_ms: int, claim_idle_ms: int) -> None:
+            assert read_block_ms <= claim_idle_ms
+
         @classmethod
         def from_url(cls, redis_url: str, **kwargs: Any) -> FakeRedisStreamsQueue:
             calls.append({"redis_url": redis_url, **kwargs})
@@ -50,6 +54,13 @@ def test_build_job_queue_uses_redis_stream_settings(monkeypatch: pytest.MonkeyPa
             "claim_idle_ms": 60000,
         }
     ]
+
+
+def test_build_job_queue_rejects_unsafe_redis_claim_idle() -> None:
+    cfg = AppConfig(queue_backend="redis-streams", redis_read_block_ms=6000, redis_claim_idle_ms=5000)
+
+    with pytest.raises(ValueError, match="redis_claim_idle_ms"):
+        build_job_queue(cfg)
 
 
 def test_build_job_queue_rejects_unknown_backend() -> None:

--- a/tests/app/worker/test_redis_queue.py
+++ b/tests/app/worker/test_redis_queue.py
@@ -28,6 +28,8 @@ class FakeRedis:
         self.claimed_messages: list[tuple[bytes, dict[bytes, bytes]]] = []
         self.acked: list[tuple[str, str, str]] = []
         self.claim_start_ids: list[str] = []
+        self.expected_read_block_ms = 0
+        self.expected_claim_idle_ms = 5000
         self.xgroup_create_error: Exception | None = None
 
     def xgroup_create(self, stream: str, group: str, id: str, mkstream: bool) -> None:
@@ -52,7 +54,7 @@ class FakeRedis:
         assert consumername == "worker-1"
         assert streams == {"qaestro:jobs": ">"}
         assert count == 1
-        assert block == 0
+        assert block == self.expected_read_block_ms
         if not self.new_messages:
             return []
         return [(b"qaestro:jobs", [self.new_messages.pop(0)])]
@@ -69,7 +71,7 @@ class FakeRedis:
         assert name == "qaestro:jobs"
         assert groupname == "qaestro-workers"
         assert consumername == "worker-1"
-        assert min_idle_time == 5000
+        assert min_idle_time == self.expected_claim_idle_ms
         assert count == 1
         self.claim_start_ids.append(start_id)
         if not self.claimed_messages:
@@ -168,16 +170,54 @@ def _stored_job_payload(redis: FakeRedis) -> dict[bytes, bytes]:
     return {b"job": fields["job"].encode("utf-8")}
 
 
-def _queue(redis: FakeRedis, *, busy_group_error: type[Exception] = Exception) -> RedisStreamsJobQueue:
+def _queue(
+    redis: FakeRedis,
+    *,
+    read_block_ms: int = 0,
+    claim_idle_ms: int = 5000,
+    busy_group_error: type[Exception] = Exception,
+) -> RedisStreamsJobQueue:
+    redis.expected_read_block_ms = read_block_ms
+    redis.expected_claim_idle_ms = claim_idle_ms
     return RedisStreamsJobQueue(
         redis_client=redis,  # type: ignore[arg-type]
         stream="qaestro:jobs",
         group="qaestro-workers",
         consumer="worker-1",
-        read_block_ms=0,
-        claim_idle_ms=5000,
+        read_block_ms=read_block_ms,
+        claim_idle_ms=claim_idle_ms,
         busy_group_error=busy_group_error,
     )
+
+
+def test_redis_streams_queue_rejects_negative_timing_values() -> None:
+    redis = FakeRedis()
+
+    try:
+        _queue(redis, read_block_ms=-1)
+    except ValueError as exc:
+        assert "read_block_ms" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("negative read_block_ms was accepted")
+
+    try:
+        _queue(redis, claim_idle_ms=-1)
+    except ValueError as exc:
+        assert "claim_idle_ms" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("negative claim_idle_ms was accepted")
+
+
+def test_redis_streams_queue_rejects_claim_idle_shorter_than_read_block() -> None:
+    redis = FakeRedis()
+
+    try:
+        _queue(redis, read_block_ms=6000, claim_idle_ms=5000)
+    except ValueError as exc:
+        assert "claim_idle_ms" in str(exc)
+        assert "read_block_ms" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("unsafe claim_idle_ms/read_block_ms combination was accepted")
 
 
 def test_redis_streams_queue_ignores_existing_consumer_group_error() -> None:
@@ -296,6 +336,15 @@ def test_redis_streams_queue_acks_delivered_messages() -> None:
     queue.ack(EventJob(event=_pr_opened(), correlation_id="corr-pr_opened", delivery_id="1700000000000-0"))
 
     assert redis.acked == [("qaestro:jobs", "qaestro-workers", "1700000000000-0")]
+
+
+def test_redis_streams_queue_ack_malformed_jobs_by_delivery_id() -> None:
+    redis = FakeRedis()
+    queue = _queue(redis)
+
+    queue.ack(MalformedEventJob(delivery_id="1700000000007-0", error="bad payload"))
+
+    assert redis.acked == [("qaestro:jobs", "qaestro-workers", "1700000000007-0")]
 
 
 def test_redis_streams_queue_ignores_ack_without_delivery_id() -> None:

--- a/tests/app/worker/test_worker.py
+++ b/tests/app/worker/test_worker.py
@@ -288,6 +288,81 @@ def test_worker_acks_failed_queue_jobs_after_retries_are_exhausted() -> None:
     assert queue.acked == [job]
 
 
+def test_worker_run_until_empty_logs_terminal_failure_before_ack(caplog: pytest.LogCaptureFixture) -> None:
+    event = _event()
+    job = EventJob(event=event, correlation_id="failed-drain", delivery_id="1700000000007-0")
+
+    class FailingOrchestrator:
+        def run(self, event: Event) -> PRWorkflowResult:
+            raise RuntimeError("terminal drain failure")
+
+    class AckRecordingQueue(InMemoryJobQueue):
+        def __init__(self) -> None:
+            super().__init__([job])
+            self.acked: list[EventJob] = []
+
+        def ack(self, job: EventJob | MalformedEventJob) -> None:
+            assert isinstance(job, EventJob)
+            assert len(caplog.records) == 1
+            self.acked.append(job)
+
+    queue = AckRecordingQueue()
+    worker = Worker(orchestrator=FailingOrchestrator(), max_attempts=1)
+
+    with caplog.at_level(logging.ERROR, logger="qaestro.src.app.worker.runner"):
+        executions = worker.run_until_empty(queue)
+
+    assert executions[0].status == WorkerStatus.FAILED
+    assert queue.acked == [job]
+    record = cast(Any, caplog.records[0])
+    assert record.message == "worker job failed"
+    assert record.correlation_id == "failed-drain"
+    assert record.delivery_id == "1700000000007-0"
+    assert record.attempts == 1
+    assert record.error == "terminal drain failure"
+
+
+def test_worker_run_until_empty_retries_output_failures_before_ack() -> None:
+    event = _event()
+    job = EventJob(event=event, correlation_id="output-failed", delivery_id="1700000000008-0")
+    workflow_result = _result(event)
+
+    class FailingPoster:
+        def __init__(self) -> None:
+            self.events: list[str] = []
+
+        def post_comment(self, payload: PRCommentPayload, *, correlation_id: str) -> object:
+            self.events.append(f"post:{correlation_id}:{payload.pr_number}")
+            raise RuntimeError("post failed")
+
+    class AckRecordingQueue(InMemoryJobQueue):
+        def __init__(self, poster: FailingPoster) -> None:
+            super().__init__([job])
+            self._poster = poster
+            self.acked: list[EventJob] = []
+
+        def ack(self, job: EventJob | MalformedEventJob) -> None:
+            assert isinstance(job, EventJob)
+            self._poster.events.append("ack")
+            self.acked.append(job)
+
+    poster = FailingPoster()
+    queue = AckRecordingQueue(poster)
+    worker = Worker(
+        orchestrator=RecordingOrchestrator(workflow_result),
+        output_poster=poster,
+        max_attempts=2,
+    )
+
+    executions = worker.run_until_empty(queue)
+
+    assert executions[0].status == WorkerStatus.FAILED
+    assert executions[0].attempts == 2
+    assert executions[0].error == "post failed"
+    assert queue.acked == [job]
+    assert poster.events == ["post:output-failed:32", "post:output-failed:32", "ack"]
+
+
 def test_worker_run_forever_sleeps_when_queue_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     class EmptyThenStopQueue:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

Durable worker/queue operational semantics를 Step 6.5 foundation 범위에서 보강합니다.

이번 변경은 worker가 terminal failure를 ack하기 전에 structured failure log를 남기도록 local drain path를 맞추고, output write failure가 성공 ack로 처리되지 않도록 retry/ack 순서를 회귀 테스트로 고정합니다. Redis Streams queue는 malformed payload도 delivery id 기준으로 ack할 수 있음을 명시적으로 검증하고, `redis_claim_idle_ms`가 `redis_read_block_ms`보다 짧은 unsafe 설정을 거부하도록 했습니다.

Closes #95

---
Co-worked by Hermes Agent
