### PR TITLE
test(security): add secret redaction boundaries

### DIFF
--- a/src/adapters/renderers/pr_comment.py
+++ b/src/adapters/renderers/pr_comment.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.adapters.connectors.github import ReviewCommentInput
 from src.core.contracts import CIFeedbackContext, CIHistoricalEvidence, CIObservation, QAReport, ValidationResult
+from src.shared.redaction import SecretRedactor, redact_text, redact_value
 
 if TYPE_CHECKING:
     from src.runtime.orchestrator.pr_triage import PRWorkflowTriage
@@ -79,10 +80,12 @@ class PRReviewPayload:
 
     def prepared_for_submission(self) -> PRReviewPayload:
         mapped = tuple(
-            _validated_review_comment(comment).with_attribution() for comment in self.comments if comment.is_mapped
+            _validated_review_comment(_redacted_review_comment(comment)).with_attribution()
+            for comment in self.comments
+            if comment.is_mapped
         )
-        unmapped = tuple(comment for comment in self.comments if not comment.is_mapped)
-        body = self.body
+        unmapped = tuple(_redacted_review_comment(comment) for comment in self.comments if not comment.is_mapped)
+        body = _redact_external_text(self.body, redact_urls=True)
         if unmapped:
             body = _append_unmapped_findings(body, unmapped)
         return replace(self, body=_with_attribution(body), event="COMMENT", comments=mapped)
@@ -95,6 +98,14 @@ class PRReviewPayload:
         if marker in self.body:
             return self
         return replace(self, body=f"{self.body.strip()}\n\n{marker}" if self.body.strip() else marker)
+
+
+def _redact_external_text(text: str, *, redact_urls: bool = False) -> str:
+    return SecretRedactor(redact_urls=redact_urls).redact_text(text)
+
+
+def _redacted_review_comment(comment: PRReviewComment) -> PRReviewComment:
+    return replace(comment, body=_redact_external_text(comment.body, redact_urls=True))
 
 
 class GitHubPRCommentRenderer:
@@ -151,7 +162,7 @@ class GitHubPRCommentRenderer:
         return PRCommentPayload(
             repo_full_name=report.repo_full_name,
             pr_number=report.pr_number,
-            body=body,
+            body=_redact_external_text(body),
         )
 
 
@@ -393,10 +404,12 @@ def _validation_result_lines(result: ValidationResult) -> list[str]:
     ]
     if result.duration_seconds > 0:
         lines.append(f"  - Duration: {_inline_code_span(f'{result.duration_seconds:.3f}s')}")
-    detail = result.details or action.rationale
+    detail = redact_text(result.details or action.rationale, redact_urls=True)
     if detail:
         lines.append(f"  - Details: {detail}")
     if result.artifacts:
-        links = ", ".join(f"[artifact {index}]({artifact})" for index, artifact in enumerate(result.artifacts, start=1))
+        redacted_artifacts = redact_value(result.artifacts, redact_urls=True)
+        artifacts = redacted_artifacts if isinstance(redacted_artifacts, tuple) else ()
+        links = ", ".join(f"[artifact {index}]({artifact})" for index, artifact in enumerate(artifacts, start=1))
         lines.append(f"  - Artifacts: {links}")
     return lines

--- a/src/app/worker/types.py
+++ b/src/app/worker/types.py
@@ -7,6 +7,7 @@ from enum import Enum, unique
 from typing import Any
 
 from src.runtime.orchestrator import CIWorkflowResult, PRWorkflowResult
+from src.shared.redaction import redact_text
 
 
 @unique
@@ -42,3 +43,7 @@ class WorkerExecution:
     attempts: int
     result: PRWorkflowResult | CIWorkflowResult | None = None
     error: str = ""
+
+    def __post_init__(self) -> None:
+        if self.error:
+            object.__setattr__(self, "error", redact_text(self.error, redact_urls=True))

--- a/src/runtime/agent/azure_openai.py
+++ b/src/runtime/agent/azure_openai.py
@@ -14,6 +14,7 @@ from src.runtime.agent.health import LiveSmokeProbeStatus
 from src.runtime.agent.types import AgentRunInput, AgentRunResult, AgentRunStatus, AgentSessionHandle, AgentSessionScope
 from src.runtime.stages import WorkflowStage
 from src.shared.config import AgentRuntimeConfig
+from src.shared.redaction import redact_text
 
 
 @dataclass(frozen=True)
@@ -228,6 +229,4 @@ def _extract_output_text(payload: object) -> str:
 
 
 def _redact_secret(value: str, secret: str) -> str:
-    if not secret:
-        return value
-    return value.replace(secret, "<redacted>")
+    return redact_text(value, explicit_secrets=(secret,), redact_urls=True)

--- a/src/runtime/agent/manager.py
+++ b/src/runtime/agent/manager.py
@@ -15,6 +15,7 @@ from src.runtime.agent.types import (
     AgentSessionStatus,
     AgentSessionTurn,
 )
+from src.shared.redaction import redact_text
 
 
 class AgentSessionNotFoundError(RuntimeError):
@@ -70,7 +71,7 @@ class WorkflowAgentSessionManager:
             correlation_id=run_input.correlation_id,
             status=result.status,
             allowed_tool_names=run_input.allowed_tool_names,
-            error=result.error,
+            error=redact_text(result.error, redact_urls=True),
         )
         self._records[handle.session_id] = replace(record, turns=(*record.turns, turn))
         return result

--- a/src/runtime/agent/openai_compatible.py
+++ b/src/runtime/agent/openai_compatible.py
@@ -12,6 +12,7 @@ from src.runtime.agent.fake import FakeAgentRunner
 from src.runtime.agent.health import AgentRuntimeHealthStatus, check_agent_runtime_health
 from src.runtime.agent.types import AgentRunInput, AgentRunner, AgentRunResult, AgentRunStatus, AgentSessionHandle
 from src.shared.config import AgentRuntimeConfig, AgentRuntimeProvider
+from src.shared.redaction import redact_text
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,4 @@ def build_agent_runner(
 
 
 def _redact_secret(value: str, secret: str) -> str:
-    if not secret:
-        return value
-    return value.replace(secret, "<redacted>")
+    return redact_text(value, explicit_secrets=(secret,), redact_urls=True)

--- a/src/runtime/orchestrator/pr_workflow.py
+++ b/src/runtime/orchestrator/pr_workflow.py
@@ -20,6 +20,7 @@ from src.core.contracts import (
 )
 from src.core.strategy import RuleBasedPRStrategyEngine
 from src.runtime.stages import WorkflowStage
+from src.shared.redaction import redact_text
 
 from .pr_context import EventPRContextProvider, PRContextProvider
 from .pr_triage import PRWorkflowDepth, PRWorkflowTriage, RuleBasedPRWorkflowTriageClassifier
@@ -188,7 +189,7 @@ def _review_inline_comments(draft: PRWorkflowDraft) -> tuple[PRReviewComment, ..
             if not location.path.strip() or location.line <= 0:
                 continue
             target = result.action.target or result.action.description
-            detail = result.details or result.action.rationale
+            detail = redact_text(result.details or result.action.rationale, redact_urls=True)
             suffix = f": {detail}" if detail else ""
             comments.append(
                 PRReviewComment(
@@ -206,7 +207,7 @@ def _review_validation_lines(validations: tuple[ValidationResult, ...]) -> list[
     for result in validations:
         status = result.outcome.value.upper()
         target = result.action.target or result.action.description
-        detail = result.details or result.action.rationale
+        detail = redact_text(result.details or result.action.rationale, redact_urls=True)
         suffix = f": {detail}" if detail else ""
         lines.append(f"- **{status}** `{target}`{suffix}")
     return lines

--- a/src/runtime/orchestrator/tool_output.py
+++ b/src/runtime/orchestrator/tool_output.py
@@ -8,6 +8,7 @@ from src.adapters.connectors.github import CommentResult, PRMeta, ReviewResult
 from src.adapters.renderers import PRCommentPayload, PRReviewPayload
 from src.runtime.stages import WorkflowStage
 from src.runtime.tools import ToolCall, ToolRuntime
+from src.shared.redaction import redact_text
 
 
 @dataclass(frozen=True)
@@ -143,7 +144,7 @@ class ToolRuntimePRCommentPoster:
                 input={
                     "repo_full_name": payload.repo_full_name,
                     "pr_number": payload.pr_number,
-                    "body": payload.body,
+                    "body": redact_text(payload.body, redact_urls=True),
                     "marker": _qaestro_comment_marker(payload.repo_full_name, payload.pr_number),
                 },
                 correlation_id=correlation_id,

--- a/src/runtime/prompts/catalog/validation-api-contract-probe-selection.md
+++ b/src/runtime/prompts/catalog/validation-api-contract-probe-selection.md
@@ -1,5 +1,6 @@
 Select qaestro's validation.api_contract.probe tool for API contract validation only.
 Do not perform destructive or live external API calls unless a configured probe executor does so.
+Do not include secrets, tokens, credentials, private keys, raw provider errors, or credential-bearing URLs in your output. Replace any such value with [REDACTED].
 Action type: {action_type}
 Target: {target}
 Description: {description}

--- a/src/runtime/tools/github.py
+++ b/src/runtime/tools/github.py
@@ -14,6 +14,7 @@ from src.adapters.connectors.github import (
     ReviewResult,
 )
 from src.adapters.renderers import PRReviewPayload
+from src.shared.redaction import redact_text
 
 from . import ToolCall, ToolCapability, ToolDefinition
 
@@ -137,7 +138,7 @@ def _list_check_runs_for_ref(client: GitHubPRToolClient, call: ToolCall) -> tupl
 
 def _create_or_update_comment(client: GitHubPRToolClient, call: ToolCall) -> CommentResult:
     owner, repo, pr_number = _repo_pr_input(call)
-    body = str(call.input.get("body", ""))
+    body = redact_text(str(call.input.get("body", "")), redact_urls=True)
     marker = str(call.input.get("marker", "")).strip()
     persisted_body = _persisted_comment_body(body, marker)
     for comment in client.list_issue_comments(owner, repo, pr_number):

--- a/src/runtime/tools/runtime.py
+++ b/src/runtime/tools/runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from src.shared.redaction import redact_text
+
 from .policy import StageToolPolicy
 from .types import ToolAuditEntry, ToolCall, ToolDefinition, ToolResult
 
@@ -41,7 +43,7 @@ class RegisteredToolRuntime:
         try:
             output = definition.handler(call)
         except Exception as exc:
-            error = str(exc)
+            error = redact_text(str(exc), redact_urls=True)
             self._audit_log.append(
                 ToolAuditEntry(
                     stage=call.stage,

--- a/src/runtime/validator/agent_runtime.py
+++ b/src/runtime/validator/agent_runtime.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from time import monotonic
 from typing import Protocol
@@ -28,6 +27,7 @@ from src.runtime.tools import (
     ToolCapability,
     ToolDefinition,
 )
+from src.shared.redaction import redact_text, redact_value
 
 _VALIDATION_API_CONTRACT_PROBE = "validation.api_contract.probe"
 _SUPPORTED_API_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"})
@@ -299,7 +299,7 @@ class AgentRuntimePRValidator:
             outcome=result.outcome,
             details=_sanitize_pr_facing_details(result.details),
             duration_seconds=result.duration_seconds or elapsed,
-            artifacts=result.artifacts,
+            artifacts=_sanitize_pr_facing_artifacts(result.artifacts),
         )
 
 
@@ -405,17 +405,16 @@ def _agent_runner_status_details(status: AgentRunStatus) -> str:
     return f"agent_runner: Agent Runtime validation ended with status {status.name}."
 
 
-_SECRET_ASSIGNMENT_PATTERN = re.compile(r"(?i)\b(token|password|secret|api[_-]?key|credential)\s*=\s*[^\s,;]+")
-_URL_PATTERN = re.compile(r"https?://[^\s,;)]+")
-
-
 def _sanitize_pr_facing_details(details: str) -> str:
-    """Remove common credential and endpoint fragments from PR-facing details."""
-    sanitized = _SECRET_ASSIGNMENT_PATTERN.sub(
-        lambda match: f"{match.group(1)}=<redacted>",
-        details,
-    )
-    return _URL_PATTERN.sub("<redacted-url>", sanitized)
+    """Remove credential and endpoint fragments from PR-facing details."""
+    return redact_text(details, redact_urls=True)
+
+
+def _sanitize_pr_facing_artifacts(artifacts: tuple[str, ...]) -> tuple[str, ...]:
+    redacted = redact_value(artifacts, redact_urls=True)
+    if not isinstance(redacted, tuple):
+        return ()
+    return tuple(str(item) for item in redacted)
 
 
 def _api_contract_probe_request(

--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -7,16 +7,20 @@ Re-exports the public API so consumers can do::
 
 from .config import AgentRuntimeConfig, AgentRuntimeProvider, AppConfig, load_config
 from .logging import get_logger, setup_logging
+from .redaction import SecretRedactor, redact_text, redact_value
 from .tracing import get_correlation_id, new_correlation_id, set_correlation_id
 
 __all__ = [
     "AgentRuntimeConfig",
     "AgentRuntimeProvider",
     "AppConfig",
+    "SecretRedactor",
     "get_correlation_id",
     "get_logger",
     "load_config",
     "new_correlation_id",
+    "redact_text",
+    "redact_value",
     "set_correlation_id",
     "setup_logging",
 ]

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from .redaction import redact_text
+
 
 class AgentRuntimeProvider(StrEnum):
     """Supported Agent Runtime provider families.
@@ -125,7 +127,7 @@ class AppConfig:
             f"github_app_private_key_path={self.github_app_private_key_path!r}",
             f"worker_concurrency={self.worker_concurrency!r}",
             f"queue_backend={self.queue_backend!r}",
-            f"redis_url={self.redis_url!r}",
+            f"redis_url={redact_text(self.redis_url)!r}",
             f"redis_stream={self.redis_stream!r}",
             f"redis_consumer_group={self.redis_consumer_group!r}",
             f"redis_consumer={self.redis_consumer!r}",

--- a/src/shared/logging.py
+++ b/src/shared/logging.py
@@ -13,6 +13,8 @@ import sys
 from datetime import UTC, datetime
 from typing import Any
 
+from .redaction import redact_text, redact_value
+
 
 class _JsonFormatter(logging.Formatter):
     """Format log records as single-line JSON objects."""
@@ -22,10 +24,10 @@ class _JsonFormatter(logging.Formatter):
             "ts": datetime.now(tz=UTC).isoformat(),
             "level": record.levelname,
             "logger": record.name,
-            "msg": record.getMessage(),
+            "msg": redact_text(record.getMessage(), redact_urls=True),
         }
         if record.exc_info and record.exc_info[1] is not None:
-            payload["exception"] = self.formatException(record.exc_info)
+            payload["exception"] = redact_text(self.formatException(record.exc_info), redact_urls=True)
         # Merge extra fields attached via ``logger.info("msg", extra={...})``.
         # Keep the whitelist explicit so logs stay predictable and don't leak
         # arbitrary objects.
@@ -43,7 +45,7 @@ class _JsonFormatter(logging.Formatter):
         ):
             value = getattr(record, key, None)
             if value is not None:
-                payload[key] = value
+                payload[key] = redact_value(value, redact_urls=True)
         return json.dumps(payload, default=str)
 
 
@@ -54,6 +56,9 @@ class _TextFormatter(logging.Formatter):
 
     def __init__(self) -> None:
         super().__init__(fmt=self.FMT, datefmt="%H:%M:%S")
+
+    def format(self, record: logging.LogRecord) -> str:
+        return redact_text(super().format(record), redact_urls=True)
 
 
 def setup_logging(

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -1,0 +1,156 @@
+"""Centralized redaction helpers for secret-safe logs and PR-facing output."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+_REDACTED = "<redacted>"
+_REDACTED_URL = "<redacted-url>"
+_USERINFO_REDACTED = "<redacted-userinfo>"
+
+_SECRET_KEYWORDS = (
+    "authorization",
+    "api_key",
+    "apikey",
+    "api-key",
+    "credential",
+    "password",
+    "private_key",
+    "not-a-real-key-material",
+    "secret",
+    "token",
+)
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(?P<key>[A-Za-z0-9_.-]*"
+    r"(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)[A-Za-z0-9_.-]*)\b"
+    r"(?P<sep>\s*[:=]\s*)"
+    r"(?P<quote>['\"]?)"
+    r"(?P<value>[^'\"\s,;]+)"
+    r"(?P=quote)"
+)
+_QUOTED_SECRET_FIELD_PATTERN = re.compile(
+    r"(?i)(?P<keyquote>['\"])(?P<key>[A-Za-z0-9_.-]*"
+    r"(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)[A-Za-z0-9_.-]*)"
+    r"(?P=keyquote)"
+    r"(?P<sep>\s*:\s*)"
+    r"(?P<valuequote>['\"])(?P<value>.*?)(?P=valuequote)"
+)
+_BEARER_PATTERN = re.compile(r"(?i)\b(Bearer)\s+([^\s,;]+)")
+_AUTHORIZATION_HEADER_PATTERN = re.compile(
+    r"(?i)\b(Authorization\s*:\s*)(?:(?:Bearer|Basic|Token|ApiKey|Api-Key)\s+)?([^\s,;]+)"
+)
+_AUTHORIZATION_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(?P<key>authorization)(?P<sep>\s*=\s*)"
+    r"(?P<quote>['\"]?)(?:(?:Bearer|Basic|Token|ApiKey|Api-Key)\s+)?(?P<value>[^'\"\s,;]+)(?P=quote)"
+)
+_URL_PATTERN = re.compile(r"https?://[^\s,;)]+")
+_URL_USERINFO_PASSWORD_PATTERN = re.compile(
+    r"(?P<scheme>[A-Za-z][A-Za-z0-9+.-]*://(?:[^\s/@:]+)?:)(?P<password>[^\s/@]+)(?=@)"
+)
+_PEM_BLOCK_PATTERN = re.compile(
+    r"-----BEGIN [^-]+PRIVATE KEY-----.*?-----END [^-]+PRIVATE KEY-----",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class SecretRedactor:
+    """Redact secret-shaped strings at output boundaries.
+
+    The redactor is intentionally centralized so callsites do not accumulate
+    one-off ``if 'token' in ...`` style checks. Callers can add runtime-known
+    secret values while the generic patterns cover common credential shapes in
+    provider errors, logs, and validation details.
+    """
+
+    explicit_secrets: tuple[str, ...] = ()
+    redact_urls: bool = False
+
+    def redact_text(self, value: str) -> str:
+        redacted = value
+        for secret in sorted((item for item in self.explicit_secrets if item), key=len, reverse=True):
+            redacted = redacted.replace(secret, _REDACTED)
+        redacted = _PEM_BLOCK_PATTERN.sub(_REDACTED, redacted)
+        redacted = _AUTHORIZATION_HEADER_PATTERN.sub(lambda match: f"{match.group(1)}{_REDACTED}", redacted)
+        redacted = _AUTHORIZATION_ASSIGNMENT_PATTERN.sub(_redacted_assignment, redacted)
+        redacted = _BEARER_PATTERN.sub(lambda match: f"{match.group(1)} {_REDACTED}", redacted)
+        redacted = _URL_USERINFO_PASSWORD_PATTERN.sub(_redacted_url_userinfo, redacted)
+        redacted = _QUOTED_SECRET_FIELD_PATTERN.sub(_redacted_quoted_field, redacted)
+        redacted = _SECRET_ASSIGNMENT_PATTERN.sub(_redacted_assignment, redacted)
+        if self.redact_urls:
+            redacted = _URL_PATTERN.sub(_REDACTED_URL, redacted)
+        return redacted
+
+    def redact_value(self, value: object) -> object:
+        if isinstance(value, str):
+            return self.redact_text(value)
+        if isinstance(value, Mapping):
+            return {
+                key: self.redact_secret_value(item) if _is_secret_key(str(key)) else self.redact_value(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, tuple):
+            return tuple(self.redact_value(item) for item in value)
+        if isinstance(value, list):
+            return [self.redact_value(item) for item in value]
+        if isinstance(value, set):
+            return {self.redact_value(item) for item in value}
+        return value
+
+    def redact_secret_value(self, value: object) -> object:
+        if isinstance(value, str):
+            return _REDACTED
+        if isinstance(value, Mapping):
+            return {key: self.redact_secret_value(item) for key, item in value.items()}
+        if isinstance(value, tuple):
+            return tuple(self.redact_secret_value(item) for item in value)
+        if isinstance(value, list):
+            return [self.redact_secret_value(item) for item in value]
+        if isinstance(value, set):
+            return {self.redact_secret_value(item) for item in value}
+        return _REDACTED
+
+
+def redact_text(value: str, *, explicit_secrets: Sequence[str] = (), redact_urls: bool = False) -> str:
+    """Redact secret-shaped text with optional runtime-known secret values."""
+
+    return SecretRedactor(tuple(explicit_secrets), redact_urls=redact_urls).redact_text(value)
+
+
+def redact_value(value: object, *, explicit_secrets: Sequence[str] = (), redact_urls: bool = False) -> object:
+    """Redact nested JSON-serializable values at logging/output boundaries."""
+
+    return SecretRedactor(tuple(explicit_secrets), redact_urls=redact_urls).redact_value(value)
+
+
+def _redacted_assignment(match: re.Match[str]) -> str:
+    key = match.group("key")
+    sep = match.group("sep")
+    quote = match.group("quote")
+    return f"{key}{sep}{quote}{_REDACTED}{quote}"
+
+
+def _redacted_quoted_field(match: re.Match[str]) -> str:
+    keyquote = match.group("keyquote")
+    key = match.group("key")
+    sep = match.group("sep")
+    valuequote = match.group("valuequote")
+    return f"{keyquote}{key}{keyquote}{sep}{valuequote}{_REDACTED}{valuequote}"
+
+
+def _is_secret_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_").replace(".", "_")
+    return any(
+        keyword.replace("-", "_") in normalized or normalized.endswith(keyword.replace("-", "_") + "_key")
+        for keyword in _SECRET_KEYWORDS
+    )
+
+
+def _redacted_url_userinfo(match: re.Match[str]) -> str:
+    prefix = match.group("scheme")
+    protocol = prefix.split("://", 1)[0] + "://"
+    if prefix == f"{protocol}:":
+        return f"{protocol}:{_REDACTED}"
+    return f"{protocol}{_USERINFO_REDACTED}"

--- a/tests/adapters/connectors/test_github_auth.py
+++ b/tests/adapters/connectors/test_github_auth.py
@@ -49,7 +49,7 @@ def public_key(private_key: str) -> str:
     )
 
 
-def _make_token_response(token: str = "ghs_abc123", expires_in_seconds: int = 3600) -> FakeResponse:
+def _make_token_response(token: str = "opaque-installation-token", expires_in_seconds: int = 3600) -> FakeResponse:
     # GitHub returns expires_at as ISO-8601 Z. Build one offset from a fixed
     # reference matching ManualClock's start time.
     from datetime import datetime, timedelta
@@ -85,7 +85,7 @@ def test_app_jwt_is_signed_with_rs256_and_decodable(private_key, public_key):
 def test_installation_token_exchange_succeeds(private_key):
     clock = ManualClock()
     transport = FakeTransport()
-    transport.route("POST", TOKEN_URL, _make_token_response("ghs_first"))
+    transport.route("POST", TOKEN_URL, _make_token_response("opaque-installation-token-first"))
     auth = GitHubAppAuth(
         app_id=APP_ID,
         private_key=private_key,
@@ -93,7 +93,7 @@ def test_installation_token_exchange_succeeds(private_key):
         transport=transport,
         clock=clock,
     )
-    assert auth.installation_token() == "ghs_first"
+    assert auth.installation_token() == "opaque-installation-token-first"
     assert len(transport.calls) == 1
     call = transport.calls[0]
     assert call.method == "POST"
@@ -104,7 +104,7 @@ def test_installation_token_exchange_succeeds(private_key):
 def test_installation_token_is_cached(private_key):
     clock = ManualClock()
     transport = FakeTransport()
-    transport.enqueue(_make_token_response("ghs_first", expires_in_seconds=3600))
+    transport.enqueue(_make_token_response("opaque-installation-token-first", expires_in_seconds=3600))
     auth = GitHubAppAuth(
         app_id=APP_ID,
         private_key=private_key,
@@ -112,18 +112,18 @@ def test_installation_token_is_cached(private_key):
         transport=transport,
         clock=clock,
     )
-    assert auth.installation_token() == "ghs_first"
+    assert auth.installation_token() == "opaque-installation-token-first"
     # 30 minutes later — still well within the cache window
     clock.advance(1800)
-    assert auth.installation_token() == "ghs_first"
+    assert auth.installation_token() == "opaque-installation-token-first"
     assert len(transport.calls) == 1  # no second exchange
 
 
 def test_installation_token_refreshes_within_skew_window(private_key):
     clock = ManualClock()
     transport = FakeTransport()
-    transport.enqueue(_make_token_response("ghs_first", expires_in_seconds=3600))
-    transport.enqueue(_make_token_response("ghs_second", expires_in_seconds=3600))
+    transport.enqueue(_make_token_response("opaque-installation-token-first", expires_in_seconds=3600))
+    transport.enqueue(_make_token_response("opaque-installation-token-second", expires_in_seconds=3600))
     auth = GitHubAppAuth(
         app_id=APP_ID,
         private_key=private_key,
@@ -134,7 +134,7 @@ def test_installation_token_refreshes_within_skew_window(private_key):
     auth.installation_token()
     # Jump to 30 s before expiry (well inside the 60 s safety margin)
     clock.advance(3600 - 30)
-    assert auth.installation_token() == "ghs_second"
+    assert auth.installation_token() == "opaque-installation-token-second"
     assert len(transport.calls) == 2
 
 
@@ -144,7 +144,7 @@ def test_installation_token_concurrent_refresh_serialised(private_key):
     transport = FakeTransport()
     # Enqueue more responses than we expect to use — assert only 1 is consumed.
     for i in range(8):
-        transport.enqueue(_make_token_response(f"ghs_{i}", expires_in_seconds=3600))
+        transport.enqueue(_make_token_response(f"opaque-installation-token-{i}", expires_in_seconds=3600))
     auth = GitHubAppAuth(
         app_id=APP_ID,
         private_key=private_key,

--- a/tests/adapters/connectors/test_github_client.py
+++ b/tests/adapters/connectors/test_github_client.py
@@ -40,7 +40,9 @@ class ManualClock:
 def _token_response() -> FakeResponse:
     base = datetime.fromtimestamp(1_700_000_000.0, tz=UTC)
     expires = base + timedelta(seconds=3600)
-    body = json.dumps({"token": "ghs_test", "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ")}).encode()
+    body = json.dumps(
+        {"token": "opaque-installation-token", "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ")}
+    ).encode()
     return FakeResponse(status=201, body=body)
 
 
@@ -111,7 +113,7 @@ def test_get_pull_request_sets_required_headers(client, transport):
     client.get_pull_request(OWNER, REPO, PR_NUM)
     # First call is the token exchange, second is the actual API call.
     api_call = next(c for c in transport.calls if "/pulls/" in c.url)
-    assert api_call.headers["Authorization"] == "Bearer ghs_test"
+    assert api_call.headers["Authorization"] == "Bearer opaque-installation-token"
     assert api_call.headers["Accept"] == "application/vnd.github+json"
     assert api_call.headers["X-GitHub-Api-Version"] == "2022-11-28"
     assert api_call.headers["User-Agent"] == "qaestro"

--- a/tests/adapters/renderers/test_pr_comment.py
+++ b/tests/adapters/renderers/test_pr_comment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from src.adapters.renderers import GitHubPRCommentRenderer, PRCommentPayload
+from src.adapters.renderers import GitHubPRCommentRenderer, PRCommentPayload, PRReviewComment, PRReviewPayload
 from src.core.contracts import (
     ActionType,
     BehaviourImpact,
@@ -254,6 +254,64 @@ def test_github_pr_comment_renderer_omits_ci_feedback_section_when_absent() -> N
     assert "### CI / Check Feedback" not in payload.body
 
 
+def test_github_pr_comment_renderer_redacts_secret_like_validation_details() -> None:
+    report = _qa_report()
+    action = StrategyAction(
+        action_type=ActionType.VERIFY_API_CONTRACT,
+        description="Probe read-only endpoint",
+        target="GET /health",
+        priority=2,
+        rationale="Runtime validation selected.",
+    )
+    report = QAReport(
+        event_id=report.event_id,
+        repo_full_name=report.repo_full_name,
+        pr_number=report.pr_number,
+        impact=report.impact,
+        strategy=StrategyResult(actions=(action,), reasoning="Runtime validation selected.", confidence=0.4),
+        validations=(
+            ValidationResult(
+                action=action,
+                outcome=ValidationOutcome.ERROR,
+                details="provider failed token=validation-secret at https://private.example.test/v1",
+            ),
+        ),
+        summary_markdown=report.summary_markdown,
+    )
+
+    payload = GitHubPRCommentRenderer().render(report, correlation_id="corr-secret-validation")
+
+    assert "validation-secret" not in payload.body
+    assert "private.example.test" not in payload.body
+    assert "Details: provider failed token=<redacted> at <redacted-url>" in payload.body
+
+
+def test_official_review_payload_redacts_secret_like_body_and_inline_comments_before_submission() -> None:
+    payload = PRReviewPayload(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        head_sha="abc123",
+        body="review body token=review-secret at https://private.example.test/v1",
+        comments=(
+            PRReviewComment(
+                path="src/app.py",
+                body="inline body password=inline-secret at https://private.example.test/inline",
+                line=12,
+            ),
+        ),
+    )
+
+    prepared = payload.prepared_for_submission()
+    rendered = f"{prepared.body}\n{prepared.comments[0].body}"
+
+    assert "review-secret" not in rendered
+    assert "inline-secret" not in rendered
+    assert "private.example.test" not in rendered
+    assert "token=<redacted>" in prepared.body
+    assert "password=<redacted>" in prepared.comments[0].body
+    assert "<redacted-url>" in rendered
+
+
 def test_github_pr_comment_renderer_escapes_ci_feedback_markdown_text() -> None:
     ci_feedback = CIFeedbackContext(
         current_head_sha="sha`with`tick",
@@ -319,4 +377,4 @@ def test_pr_comment_renderer_includes_structured_validation_evidence() -> None:
     assert "Outcome: **PASS**" in payload.body
     assert "Duration: `1.234s`" in payload.body
     assert "Details: contract_ok: response schema matched" in payload.body
-    assert "Artifacts: [artifact 1](https://example.test/artifacts/validation.json)" in payload.body
+    assert "Artifacts: [artifact 1](<redacted-url>)" in payload.body

--- a/tests/app/test_worker_agent_runtime_health.py
+++ b/tests/app/test_worker_agent_runtime_health.py
@@ -27,11 +27,11 @@ def test_worker_agent_runtime_health_fails_closed_for_unsupported_config() -> No
     )
 
     try:
-        check_worker_agent_runtime_health(cfg, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+        check_worker_agent_runtime_health(cfg, environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"})
     except AgentRuntimeUnavailableError as exc:
         message = str(exc)
     else:  # pragma: no cover - assertion clarity
         raise AssertionError("unsupported Agent Runtime config should fail closed")
 
     assert "tool calling is required" in message
-    assert "super-secret-token" not in message
+    assert "opaque-runtime-credential" not in message

--- a/tests/app/worker/test_worker.py
+++ b/tests/app/worker/test_worker.py
@@ -217,6 +217,23 @@ def test_worker_reports_failure_after_retries_exhausted() -> None:
     assert poster.payloads == []
 
 
+def test_worker_execution_error_is_redacted_at_result_boundary() -> None:
+    event = _event()
+
+    class FailingOrchestrator:
+        def run(self, event: Event) -> PRWorkflowResult:
+            raise RuntimeError("provider failed token=worker-secret-token at https://private.example.test/v1")
+
+    worker = Worker(orchestrator=FailingOrchestrator(), max_attempts=1)
+
+    execution = worker.process(EventJob(event=event, correlation_id=event.meta.correlation_id))
+
+    assert execution.status is WorkerStatus.FAILED
+    assert "worker-secret-token" not in execution.error
+    assert "private.example.test" not in execution.error
+    assert execution.error == "provider failed token=<redacted> at <redacted-url>"
+
+
 def test_worker_enforces_timeout_per_attempt() -> None:
     event = _event()
 

--- a/tests/app/worker/test_worker_factory.py
+++ b/tests/app/worker/test_worker_factory.py
@@ -46,7 +46,7 @@ def test_build_worker_rejects_durable_queue_without_github_app_id() -> None:
 
 def test_build_worker_rejects_durable_queue_without_installation_id(tmp_path: Path) -> None:
     key_path = tmp_path / "app.pem"
-    key_path.write_text("private-key", encoding="utf-8")
+    key_path.write_text("not-a-real-key-material", encoding="utf-8")
     cfg = AppConfig(
         queue_backend="redis-streams",
         github_app_id=1,
@@ -76,7 +76,7 @@ def test_build_worker_rejects_durable_queue_without_private_key_path() -> None:
 
 def test_build_worker_wires_github_tool_runtime_for_durable_queue(tmp_path: Path) -> None:
     key_path = tmp_path / "app.pem"
-    key_path.write_text("private-key", encoding="utf-8")
+    key_path.write_text("not-a-real-key-material", encoding="utf-8")
     cfg = AppConfig(
         queue_backend="redis-streams",
         github_app_id=1,

--- a/tests/runtime/test_agent_runtime.py
+++ b/tests/runtime/test_agent_runtime.py
@@ -64,7 +64,6 @@ def test_session_manager_reuses_workflow_session_without_widening_stage_tools() 
         trigger="manual",
         correlation_id="corr-session",
     )
-
     manager.run_stage(
         session.handle,
         AgentRunInput(
@@ -96,6 +95,38 @@ def test_session_manager_reuses_workflow_session_without_widening_stage_tools() 
     assert [turn.stage for turn in turns] == [WorkflowStage.ANALYZER, WorkflowStage.VALIDATOR]
     assert turns[0].allowed_tool_names == ("github.pr.diff",)
     assert turns[1].allowed_tool_names == ()
+
+
+def test_session_manager_redacts_turn_error_metadata() -> None:
+    class FailingRunner(FakeAgentRunner):
+        def run(self, *, session, run_input):  # type: ignore[no-untyped-def]
+            result = super().run(session=session, run_input=run_input)
+            return type(result)(
+                session=result.session,
+                stage=result.stage,
+                status=AgentRunStatus.FAILED,
+                error="provider failed token=session-secret at https://private.example.test/v1",
+                allowed_tool_names=result.allowed_tool_names,
+            )
+
+    manager = WorkflowAgentSessionManager(runner=FailingRunner(response="ignored"))
+    session = manager.start_workflow_session(
+        repo_full_name="Kimcheolhui/qaestro",
+        pr_number=42,
+        head_sha="abc123",
+        trigger="manual",
+        correlation_id="corr-session",
+    )
+
+    manager.run_stage(
+        session.handle,
+        AgentRunInput(stage=WorkflowStage.VALIDATOR, prompt="Validate", correlation_id="corr-session"),
+    )
+
+    turn = manager.turns_for_session(session.handle.session_id)[0]
+    assert "session-secret" not in turn.error
+    assert "private.example.test" not in turn.error
+    assert turn.error == "provider failed token=<redacted> at <redacted-url>"
 
 
 def test_session_manager_cancels_superseded_head_and_closes_pr_sessions() -> None:

--- a/tests/runtime/test_agent_runtime_config.py
+++ b/tests/runtime/test_agent_runtime_config.py
@@ -84,3 +84,17 @@ class TestAgentRuntimeConfig:
         )
 
         assert "SECRET_ENV_NAME" not in repr(cfg)
+
+    def test_app_config_repr_redacts_secret_values_in_urls_and_webhook_secret(self) -> None:
+        webhook_value = "opaque-webhook-value"
+        cfg = AppConfig(
+            github_webhook_secret=webhook_value,
+            redis_url="redis://:redis-secret-password@redis.example.test:6379/0",
+        )
+
+        rendered = repr(cfg)
+
+        assert webhook_value not in rendered
+        assert "redis-secret-password" not in rendered
+        assert "github_webhook_secret=<redacted>" in rendered
+        assert "redis://:<redacted>@redis.example.test:6379/0" in rendered

--- a/tests/runtime/test_agent_runtime_health.py
+++ b/tests/runtime/test_agent_runtime_health.py
@@ -26,14 +26,14 @@ def test_openai_compatible_runtime_requires_tool_calling_and_structured_output()
         context_window_tokens=16_000,
     )
 
-    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"})
 
     assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
     assert result.ok is False
     assert "tool calling is required" in result.actionable_errors
     assert "structured output or schema-constrained responses are required" in result.actionable_errors
-    assert "super-secret-token" not in repr(result)
-    assert "super-secret-token" not in str(result.actionable_errors)
+    assert "opaque-runtime-credential" not in repr(result)
+    assert "opaque-runtime-credential" not in str(result.actionable_errors)
 
 
 def test_azure_openai_runtime_reports_missing_endpoint_deployment_api_version_and_credential() -> None:
@@ -75,7 +75,7 @@ def test_enabled_runtime_requires_declared_context_window() -> None:
         context_window_tokens=0,
     )
 
-    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"})
 
     assert result.status is AgentRuntimeHealthStatus.UNSUPPORTED
     assert result.ok is False
@@ -95,7 +95,7 @@ def test_supported_runtime_can_warn_when_live_smoke_is_not_enabled() -> None:
         context_window_tokens=64_000,
     )
 
-    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"})
 
     assert result.status is AgentRuntimeHealthStatus.SUPPORTED
     assert result.ok is True
@@ -104,7 +104,7 @@ def test_supported_runtime_can_warn_when_live_smoke_is_not_enabled() -> None:
         "Live provider smoke check not executed; set opt_in_live_smoke=True to probe provider connectivity.",
     )
     assert result.live_smoke_probe_status is LiveSmokeProbeStatus.NOT_REQUESTED
-    assert "super-secret-token" not in repr(result)
+    assert "opaque-runtime-credential" not in repr(result)
 
 
 def test_opt_in_live_smoke_is_explicitly_not_implemented_until_provider_adapter_exists() -> None:
@@ -120,14 +120,14 @@ def test_opt_in_live_smoke_is_explicitly_not_implemented_until_provider_adapter_
 
     result = check_agent_runtime_health(
         config,
-        environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"},
+        environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"},
         opt_in_live_smoke=True,
     )
 
     assert result.status is AgentRuntimeHealthStatus.SUPPORTED
     assert result.live_smoke_probe_status is LiveSmokeProbeStatus.NOT_IMPLEMENTED
     assert result.warnings == ("Live provider smoke check was requested but no provider adapter implements it yet.",)
-    assert "super-secret-token" not in repr(result)
+    assert "opaque-runtime-credential" not in repr(result)
 
 
 def test_capability_policy_marks_small_context_window_as_degraded() -> None:
@@ -141,7 +141,7 @@ def test_capability_policy_marks_small_context_window_as_degraded() -> None:
         context_window_tokens=8_000,
     )
 
-    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"})
+    result = check_agent_runtime_health(config, environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"})
 
     assert result.status is AgentRuntimeHealthStatus.DEGRADED
     assert result.ok is True

--- a/tests/runtime/test_api_contract_probe_validator.py
+++ b/tests/runtime/test_api_contract_probe_validator.py
@@ -143,7 +143,9 @@ def test_agent_runner_errors_are_sanitized_before_validation_details() -> None:
     assert "private.example" not in failed_result.details
     assert executor.requests == []
 
-    raising_runner = RaisingAgentRunner(error="transport crashed password=hunter2 endpoint=https://private.example")
+    raising_runner = RaisingAgentRunner(
+        error="transport crashed password=opaque-password-value endpoint=https://private.example"
+    )
     validator = build_agent_runtime_pr_validator(runner=raising_runner, api_contract_probe_executor=executor)
 
     raised_result = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[
@@ -153,7 +155,7 @@ def test_agent_runner_errors_are_sanitized_before_validation_details() -> None:
     assert raised_result.outcome is ValidationOutcome.ERROR
     assert "agent_runner_exception" in raised_result.details
     assert "RuntimeError" in raised_result.details
-    assert "hunter2" not in raised_result.details
+    assert "opaque-password-value" not in raised_result.details
     assert "private.example" not in raised_result.details
 
 
@@ -185,7 +187,7 @@ def test_validation_session_closes_after_runner_failure_and_exception() -> None:
         (failing_runner.started_sessions[0].session_id, "validation stage complete")
     ]
 
-    raising_runner = RaisingAgentRunner(error="transport crashed password=hunter2")
+    raising_runner = RaisingAgentRunner(error="transport crashed password=opaque-password-value")
     raising_validator = build_agent_runtime_pr_validator(runner=raising_runner, api_contract_probe_executor=executor)
     raising_validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))
 
@@ -209,7 +211,7 @@ def test_validation_session_closes_after_executor_timeout_and_exception() -> Non
     exception_runner = FakeAgentRunner(response="agent selected validation.api_contract.probe")
     exception_validator = build_agent_runtime_pr_validator(
         runner=exception_runner,
-        api_contract_probe_executor=RecordingProbeExecutor(RuntimeError("password=hunter2")),
+        api_contract_probe_executor=RecordingProbeExecutor(RuntimeError("password=opaque-password-value")),
     )
     exception_validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))
 
@@ -222,7 +224,11 @@ def test_executor_supplied_details_are_sanitized_before_pr_facing_validation_res
     executor = RecordingProbeExecutor(
         APIContractProbeResult(
             outcome=ValidationOutcome.FAIL,
-            details="probe failed token=secret-token endpoint=https://private.example password=hunter2",
+            details=(
+                "probe failed token=secret-token endpoint=https://private.example password=opaque-password-value "
+                "Authorization: Bearer opaque-bearer-token"
+            ),
+            artifacts=("https://private.example/artifacts?api_key=secret-token",),
         )
     )
     validator = build_agent_runtime_pr_validator(
@@ -231,12 +237,15 @@ def test_executor_supplied_details_are_sanitized_before_pr_facing_validation_res
     )
 
     validation = validator.validate_for_event(event=_pr_opened_event(), strategy=_strategy(_api_contract_action()))[0]
+    rendered = repr(validation)
 
     assert validation.outcome is ValidationOutcome.FAIL
     assert "probe failed" in validation.details
-    assert "secret-token" not in validation.details
-    assert "private.example" not in validation.details
-    assert "hunter2" not in validation.details
+    assert "secret-token" not in rendered
+    assert "private.example" not in rendered
+    assert "opaque-password-value" not in rendered
+    assert "opaque-bearer-token" not in rendered
+    assert validation.artifacts == ("<redacted-url>",)
 
 
 def test_successful_probe_uses_wall_clock_duration_when_executor_duration_is_missing() -> None:
@@ -394,7 +403,9 @@ def test_probe_failures_timeouts_and_partial_failures_are_distinguishable() -> N
     assert "TimeoutError" in timeout.details
     assert "secret-token" not in timeout.details
 
-    exception_executor = RecordingProbeExecutor(RuntimeError("executor transport crashed password=hunter2"))
+    exception_executor = RecordingProbeExecutor(
+        RuntimeError("executor transport crashed password=opaque-password-value")
+    )
     exception_validator = build_agent_runtime_pr_validator(
         runner=FakeAgentRunner(response="agent selected validation.api_contract.probe"),
         api_contract_probe_executor=exception_executor,
@@ -407,7 +418,7 @@ def test_probe_failures_timeouts_and_partial_failures_are_distinguishable() -> N
     assert exception.outcome is ValidationOutcome.ERROR
     assert "exception" in exception.details
     assert "RuntimeError" in exception.details
-    assert "hunter2" not in exception.details
+    assert "opaque-password-value" not in exception.details
 
 
 def test_probe_requires_stage_approved_validation_tool_before_executor_runs() -> None:

--- a/tests/runtime/test_azure_openai_provider.py
+++ b/tests/runtime/test_azure_openai_provider.py
@@ -32,7 +32,7 @@ class RecordingAzureOpenAIClient(AzureOpenAIChatClient):
 class FailingAzureOpenAIClient(AzureOpenAIChatClient):
     def complete(self, request: dict[str, object]) -> AzureOpenAIClientResponse:
         _ = request
-        raise TimeoutError("azure timed out with credential super-secret-token")
+        raise TimeoutError("azure timed out with credential opaque-runtime-credential")
 
 
 def _supported_config() -> AgentRuntimeConfig:
@@ -70,7 +70,7 @@ def test_azure_openai_runner_builds_provider_neutral_request_without_secret_valu
     runner = AzureOpenAIAgentRunner(
         config=_supported_config(),
         client=client,
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
     session = runner.start_session(_session())
 
@@ -106,7 +106,7 @@ def test_azure_openai_runner_builds_provider_neutral_request_without_secret_valu
             "credential_present": True,
         }
     ]
-    assert "super-secret-token" not in repr(client.calls[0])
+    assert "opaque-runtime-credential" not in repr(client.calls[0])
 
 
 def test_azure_openai_runner_preserves_explicit_zero_budgets() -> None:
@@ -114,7 +114,7 @@ def test_azure_openai_runner_preserves_explicit_zero_budgets() -> None:
     runner = AzureOpenAIAgentRunner(
         config=_supported_config(),
         client=client,
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
 
     result = runner.run(
@@ -137,12 +137,15 @@ def test_azure_openai_runner_preserves_explicit_zero_budgets() -> None:
 
 def test_azure_openai_runner_normalizes_response_errors_without_secret_value() -> None:
     client = RecordingAzureOpenAIClient(
-        AzureOpenAIClientResponse(output_text="", error="azure unavailable: super-secret-token")
+        AzureOpenAIClientResponse(
+            output_text="",
+            error="azure unavailable: opaque-runtime-credential Authorization: Bearer opaque-bearer-token at https://private.example/v1",
+        )
     )
     runner = AzureOpenAIAgentRunner(
         config=_supported_config(),
         client=client,
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
 
     result = runner.run(
@@ -151,14 +154,14 @@ def test_azure_openai_runner_normalizes_response_errors_without_secret_value() -
     )
 
     assert result.status is AgentRunStatus.FAILED
-    assert result.error == "azure unavailable: <redacted>"
+    assert result.error == "azure unavailable: <redacted> Authorization: <redacted> at <redacted-url>"
 
 
 def test_azure_openai_runner_normalizes_client_exceptions_without_secret_value() -> None:
     runner = AzureOpenAIAgentRunner(
         config=_supported_config(),
         client=FailingAzureOpenAIClient(),
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
 
     result = runner.run(
@@ -173,7 +176,7 @@ def test_azure_openai_runner_normalizes_client_exceptions_without_secret_value()
 def test_agent_runner_factory_builds_azure_openai_runner_from_env() -> None:
     runner = build_agent_runner(
         _supported_config(),
-        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "opaque-runtime-credential"},
         azure_openai_client=RecordingAzureOpenAIClient(AzureOpenAIClientResponse(output_text="ok")),
     )
 
@@ -181,7 +184,7 @@ def test_agent_runner_factory_builds_azure_openai_runner_from_env() -> None:
 
 
 def test_agent_runner_factory_builds_live_azure_openai_runner_from_env() -> None:
-    runner = build_agent_runner(_supported_config(), environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"})
+    runner = build_agent_runner(_supported_config(), environ={"QAESTRO_AZURE_OPENAI_KEY": "opaque-runtime-credential"})
 
     assert isinstance(runner, AzureOpenAIAgentRunner)
 
@@ -191,7 +194,7 @@ def test_azure_openai_live_smoke_is_not_requested_by_default() -> None:
 
     result = run_azure_openai_live_smoke(
         _supported_config(),
-        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "opaque-runtime-credential"},
         client=client,
         opt_in_live_smoke=False,
     )
@@ -206,7 +209,7 @@ def test_azure_openai_live_smoke_executes_only_when_opted_in_without_leaking_sec
 
     result = run_azure_openai_live_smoke(
         _supported_config(),
-        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "opaque-runtime-credential"},
         client=client,
         opt_in_live_smoke=True,
     )
@@ -215,14 +218,14 @@ def test_azure_openai_live_smoke_executes_only_when_opted_in_without_leaking_sec
     assert client.calls[0]["prompt"] == "Respond with exactly: qaestro-live-smoke-ok"
     assert client.calls[0]["max_turns"] == 1
     assert client.calls[0]["max_tool_calls"] == 0
-    assert "super-secret-token" not in repr(client.calls[0])
-    assert "super-secret-token" not in repr(result)
+    assert "opaque-runtime-credential" not in repr(client.calls[0])
+    assert "opaque-runtime-credential" not in repr(result)
 
 
 def test_azure_openai_live_smoke_normalizes_failures_without_secret_value() -> None:
     result = run_azure_openai_live_smoke(
         _supported_config(),
-        environ={"QAESTRO_AZURE_OPENAI_KEY": "super-secret-token"},
+        environ={"QAESTRO_AZURE_OPENAI_KEY": "opaque-runtime-credential"},
         client=FailingAzureOpenAIClient(),
         opt_in_live_smoke=True,
     )

--- a/tests/runtime/test_github_tools.py
+++ b/tests/runtime/test_github_tools.py
@@ -341,6 +341,30 @@ def test_github_pr_comment_tool_posts_rendered_body() -> None:
     ]
 
 
+def test_github_pr_comment_tool_redacts_secret_like_rendered_body() -> None:
+    client = RecordingGitHubClient()
+    runtime = _runtime(client)
+
+    result = runtime.execute(
+        ToolCall(
+            stage=WorkflowStage.OUTPUT,
+            name="github.pr.comment.create_or_update",
+            input={
+                "repo_full_name": "octocat/hello-world",
+                "pr_number": 42,
+                "body": "Behaviour Impact Report token=tool-secret at https://private.example.test/v1",
+            },
+            correlation_id="corr-output",
+        )
+    )
+
+    assert result.ok is True
+    created_body = str(client.calls[-1][4])
+    assert "tool-secret" not in created_body
+    assert "private.example.test" not in created_body
+    assert created_body == "Behaviour Impact Report token=<redacted> at <redacted-url>"
+
+
 def test_github_pr_comment_tool_persists_marker_when_creating_comment() -> None:
     client = RecordingGitHubClient()
     runtime = _runtime(client)

--- a/tests/runtime/test_openai_compatible_provider.py
+++ b/tests/runtime/test_openai_compatible_provider.py
@@ -30,7 +30,7 @@ class RecordingOpenAICompatibleClient(OpenAICompatibleChatClient):
 class FailingOpenAICompatibleClient(OpenAICompatibleChatClient):
     def complete(self, request: dict[str, object]) -> OpenAICompatibleClientResponse:
         _ = request
-        raise TimeoutError("provider timed out with credential super-secret-token")
+        raise TimeoutError("provider timed out with credential opaque-runtime-credential")
 
 
 def _supported_config() -> AgentRuntimeConfig:
@@ -66,7 +66,7 @@ def test_openai_compatible_runner_builds_provider_neutral_request_without_secret
     runner = OpenAICompatibleAgentRunner(
         config=_supported_config(),
         client=client,
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
     session = runner.start_session(_session())
 
@@ -100,17 +100,20 @@ def test_openai_compatible_runner_builds_provider_neutral_request_without_secret
             "credential_present": True,
         }
     ]
-    assert "super-secret-token" not in repr(client.calls[0])
+    assert "opaque-runtime-credential" not in repr(client.calls[0])
 
 
 def test_openai_compatible_runner_normalizes_client_errors_without_secret_value() -> None:
     client = RecordingOpenAICompatibleClient(
-        OpenAICompatibleClientResponse(output_text="", error="provider unavailable: super-secret-token")
+        OpenAICompatibleClientResponse(
+            output_text="",
+            error="provider unavailable: opaque-runtime-credential Authorization: Bearer opaque-bearer-token at https://private.example/v1",
+        )
     )
     runner = OpenAICompatibleAgentRunner(
         config=_supported_config(),
         client=client,
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
 
     result = runner.run(
@@ -119,7 +122,7 @@ def test_openai_compatible_runner_normalizes_client_errors_without_secret_value(
     )
 
     assert result.status is AgentRunStatus.FAILED
-    assert result.error == "provider unavailable: <redacted>"
+    assert result.error == "provider unavailable: <redacted> Authorization: <redacted> at <redacted-url>"
 
 
 def test_openai_compatible_runner_preserves_explicit_zero_budgets() -> None:
@@ -127,7 +130,7 @@ def test_openai_compatible_runner_preserves_explicit_zero_budgets() -> None:
     runner = OpenAICompatibleAgentRunner(
         config=_supported_config(),
         client=client,
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
 
     result = runner.run(
@@ -152,7 +155,7 @@ def test_openai_compatible_runner_normalizes_client_exceptions_without_secret_va
     runner = OpenAICompatibleAgentRunner(
         config=_supported_config(),
         client=FailingOpenAICompatibleClient(),
-        credential="super-secret-token",
+        credential="opaque-runtime-credential",
     )
 
     result = runner.run(
@@ -173,7 +176,7 @@ def test_agent_runner_factory_builds_fake_runner_for_disabled_runtime() -> None:
 def test_agent_runner_factory_builds_openai_compatible_runner_from_env() -> None:
     runner = build_agent_runner(
         _supported_config(),
-        environ={"QAESTRO_AGENT_API_KEY": "super-secret-token"},
+        environ={"QAESTRO_AGENT_API_KEY": "opaque-runtime-credential"},
         openai_compatible_client=RecordingOpenAICompatibleClient(OpenAICompatibleClientResponse(output_text="ok")),
     )
 
@@ -191,11 +194,11 @@ def test_agent_runner_factory_rejects_github_copilot_as_unsupported_provider() -
     )
 
     try:
-        build_agent_runner(config, environ={"QAESTRO_COPILOT_TOKEN": "super-secret-token"})
+        build_agent_runner(config, environ={"QAESTRO_COPILOT_TOKEN": "opaque-runtime-credential"})
     except ValueError as exc:
         message = str(exc)
     else:  # pragma: no cover - assertion clarity
         raise AssertionError("GitHub Copilot provider should be unsupported for non-interactive runtime")
 
     assert "GitHub Copilot is not supported as a non-interactive Agent Runtime provider yet." in message
-    assert "super-secret-token" not in message
+    assert "opaque-runtime-credential" not in message

--- a/tests/runtime/test_orchestrator.py
+++ b/tests/runtime/test_orchestrator.py
@@ -292,6 +292,24 @@ def test_pr_workflow_orchestrator_degrades_unmapped_validation_failure_into_revi
     assert review.comments == ()
 
 
+def test_pr_workflow_orchestrator_redacts_secret_like_validation_details_from_review_output() -> None:
+    action = _validation_action()
+    review = _review_payload_for_validations(
+        ValidationResult(
+            action=action,
+            outcome=ValidationOutcome.FAIL,
+            details="provider failed token=review-secret at https://private.example.test/v1",
+            locations=(ValidationLocation(path="src/app.py", line=12),),
+        )
+    )
+    rendered = f"{review.body}\n{review.comments[0].body}"
+
+    assert "review-secret" not in rendered
+    assert "private.example.test" not in rendered
+    assert "token=<redacted>" in rendered
+    assert "<redacted-url>" in rendered
+
+
 def test_event_orchestrator_dispatches_ci_to_ci_sub_orchestrator():
     event = _ci_completed_event()
     orchestrator = EventOrchestrator(ci_orchestrator=CIWorkflowOrchestrator())

--- a/tests/runtime/test_prompt_catalog.py
+++ b/tests/runtime/test_prompt_catalog.py
@@ -32,6 +32,19 @@ def test_prompt_catalog_renders_runtime_variables_explicitly() -> None:
     assert "Rationale: API contract changed" in prompt_text
 
 
+def test_validation_prompt_contains_secret_safety_instruction() -> None:
+    prompt_text = render_prompt(
+        PromptId.VALIDATION_API_CONTRACT_PROBE_SELECTION,
+        action_type="verify_api_contract",
+        target="GET /health",
+        description="Check health endpoint",
+        rationale="API contract changed",
+    )
+
+    assert "Do not include secrets, tokens, credentials, private keys, raw provider errors" in prompt_text
+    assert "[REDACTED]" in prompt_text
+
+
 def test_prompt_catalog_rejects_missing_template_variables() -> None:
     with pytest.raises(PromptCatalogError, match="missing template variable"):
         render_prompt(

--- a/tests/runtime/test_tool_pr_adapters.py
+++ b/tests/runtime/test_tool_pr_adapters.py
@@ -155,3 +155,20 @@ def test_tool_runtime_pr_comment_poster_posts_via_output_stage_tool() -> None:
             "corr-tools",
         )
     ]
+
+
+def test_tool_runtime_pr_comment_poster_redacts_body_before_output_stage_tool() -> None:
+    runtime = RecordingRuntime()
+    payload = PRCommentPayload(
+        repo_full_name="octocat/hello-world",
+        pr_number=77,
+        body="report token=comment-secret at https://private.example.test/v1",
+    )
+
+    ToolRuntimePRCommentPoster(runtime).post_comment(payload, correlation_id="corr-tools")
+
+    call = runtime.calls[0]
+    body = call.input["body"]
+    assert "comment-secret" not in body
+    assert "private.example.test" not in body
+    assert body == "report token=<redacted> at <redacted-url>"

--- a/tests/runtime/test_tools.py
+++ b/tests/runtime/test_tools.py
@@ -44,6 +44,41 @@ def test_registered_tool_runtime_executes_allowed_tool_and_records_audit_log() -
     ]
 
 
+def test_registered_tool_runtime_redacts_handler_errors_in_result_and_audit_log() -> None:
+    def raise_secret_error(call: ToolCall) -> object:
+        _ = call
+        raise RuntimeError(
+            "transport failed access_token=runtime-token client_secret=runtime-client-secret "
+            "Authorization: Basic runtime-basic-token at https://private.example.test/v1"
+        )
+
+    runtime = RegisteredToolRuntime(
+        tools=(
+            ToolDefinition(
+                name="demo.read",
+                capabilities=(ToolCapability.READ,),
+                handler=raise_secret_error,
+            ),
+        ),
+        policy=StageToolPolicy({WorkflowStage.CONTEXT: ("demo.read",)}),
+    )
+
+    result = runtime.execute(
+        ToolCall(stage=WorkflowStage.CONTEXT, name="demo.read", input={}, correlation_id="corr-secret-error")
+    )
+
+    rendered = f"{result.error}\n{runtime.audit_log[0].error}"
+    assert result.ok is False
+    assert "runtime-token" not in rendered
+    assert "runtime-client-secret" not in rendered
+    assert "runtime-basic-token" not in rendered
+    assert "private.example.test" not in rendered
+    assert "access_token=<redacted>" in rendered
+    assert "client_secret=<redacted>" in rendered
+    assert "Authorization: <redacted>" in rendered
+    assert "<redacted-url>" in rendered
+
+
 def test_registered_tool_runtime_rejects_tools_not_allowed_for_stage() -> None:
     runtime = RegisteredToolRuntime(
         tools=(

--- a/tests/smoke/llm_pr_review_e2e.py
+++ b/tests/smoke/llm_pr_review_e2e.py
@@ -78,7 +78,7 @@ class SmokeGitHubAuth:
 
     This is intentionally not used by production worker construction. It lets the
     smoke exercise the same GitHubClient/ToolRuntime boundaries with a temporary
-    token when GitHub App private-key material is unavailable in a local or VM
+    token when GitHub App key material is unavailable in a local or VM
     verification environment.
     """
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -26,3 +26,45 @@ def test_json_formatter_includes_agent_runtime_health_fields_without_credentials
     assert payload["agent_runtime_provider"] == "openai-compatible"
     assert payload["agent_runtime_status"] == "supported"
     assert payload["agent_runtime_warnings"] == ["Live provider smoke check not executed"]
+
+
+def test_json_formatter_redacts_secret_values_from_message_and_allowlisted_extra_fields() -> None:
+    stream = io.StringIO()
+    setup_logging(fmt="json", stream=stream)
+
+    get_logger("tests.logging").error(
+        "worker failed token=qaestro-secret-token",
+        extra={
+            "error": "provider failed with password=opaque-password-value at https://private.example.test/v1",
+            "agent_runtime_warnings": [
+                {
+                    "client_secret": "structured-client-value",
+                    "safe": "visible",
+                }
+            ],
+            "correlation_id": "corr-secret-redaction",
+        },
+    )
+
+    payload = json.loads(stream.getvalue())
+    rendered = json.dumps(payload)
+
+    assert "qaestro-secret-token" not in rendered
+    assert "opaque-password-value" not in rendered
+    assert "structured-client-value" not in rendered
+    assert "private.example.test" not in rendered
+    assert payload["msg"] == "worker failed token=<redacted>"
+    assert payload["error"] == "provider failed with password=<redacted> at <redacted-url>"
+    assert payload["agent_runtime_warnings"] == [{"client_secret": "<redacted>", "safe": "visible"}]
+
+
+def test_text_formatter_redacts_secret_values_from_messages() -> None:
+    stream = io.StringIO()
+    setup_logging(fmt="text", stream=stream)
+
+    get_logger("tests.logging").error("worker failed token=qaestro-secret-token at https://private.example.test/v1")
+
+    rendered = stream.getvalue()
+    assert "qaestro-secret-token" not in rendered
+    assert "private.example.test" not in rendered
+    assert "worker failed token=<redacted> at <redacted-url>" in rendered

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,102 @@
+"""Tests for centralized secret redaction."""
+
+from __future__ import annotations
+
+from src.shared.redaction import SecretRedactor, redact_text
+
+
+def test_redact_text_removes_common_secret_shapes_without_manual_callsite_patterns() -> None:
+    raw = "token=qaestro-secret-token password:opaque-password-value api_key='opaque-api-token' Authorization: Bearer opaque...ken"
+
+    redacted = redact_text(raw)
+
+    assert "qaestro-secret-token" not in redacted
+    assert "opaque-password-value" not in redacted
+    assert "opaque-api-token" not in redacted
+    assert "opaque...ken" not in redacted
+    assert redacted.count("<redacted>") >= 4
+
+
+def test_secret_redactor_can_redact_explicit_runtime_secret_and_urls_for_external_output() -> None:
+    redactor = SecretRedactor(explicit_secrets=("runtime-secret-value",), redact_urls=True)
+
+    redacted = redactor.redact_text(
+        "provider failed at https://private.example.test/v1 with runtime-secret-value and credential=abc123"
+    )
+
+    assert "runtime-secret-value" not in redacted
+    assert "private.example.test" not in redacted
+    assert "abc123" not in redacted
+    assert "<redacted-url>" in redacted
+
+
+def test_redact_text_redacts_url_userinfo_password_without_hiding_host() -> None:
+    redacted = redact_text("redis://:redis-secret-password@redis.example.test:6379/0")
+
+    assert redacted == "redis://:<redacted>@redis.example.test:6379/0"
+    assert "redis-secret-password" not in redacted
+
+
+def test_redact_text_redacts_url_userinfo_username_with_password_without_hiding_host() -> None:
+    redacted = redact_text("postgres://db-user:db-secret-password@db.example.test:5432/app")
+
+    assert redacted == "postgres://<redacted-userinfo>@db.example.test:5432/app"
+    assert "db-user" not in redacted
+    assert "db-secret-password" not in redacted
+
+
+def test_secret_redactor_recurses_through_serializable_structures() -> None:
+    redactor = SecretRedactor(explicit_secrets=("runtime-secret-value",), redact_urls=True)
+
+    redacted = redactor.redact_value(
+        {
+            "error": "token=runtime-secret-value",
+            "nested": ["password=opaque-password-value", {"url": "https://private.example.test/path"}],
+        }
+    )
+
+    rendered = repr(redacted)
+    assert "runtime-secret-value" not in rendered
+    assert "opaque-password-value" not in rendered
+    assert "private.example.test" not in rendered
+
+
+def test_redact_text_redacts_json_and_dict_style_secret_fields() -> None:
+    raw = (
+        '{"client_secret":"json-client-value", "AWS_SECRET_ACCESS_KEY":"aws-secret-value", '
+        "'password': 'dict-password-value', 'Authorization': 'Basic quoted-auth-value'}"
+    )
+
+    redacted = redact_text(raw)
+
+    assert "json-client-value" not in redacted
+    assert "aws-secret-value" not in redacted
+    assert "dict-password-value" not in redacted
+    assert "quoted-auth-value" not in redacted
+    assert '"client_secret":"<redacted>"' in redacted
+    assert "'password': '<redacted>'" in redacted
+
+
+def test_redact_text_redacts_authorization_assignment_forms() -> None:
+    redacted = redact_text("Authorization=Basic assignment-basic-token AUTHORIZATION=Bearer assignment-bearer-token")
+
+    assert "assignment-basic-token" not in redacted
+    assert "assignment-bearer-token" not in redacted
+    assert redacted == "Authorization=<redacted> AUTHORIZATION=<redacted>"
+
+
+def test_secret_redactor_redacts_values_when_mapping_keys_are_secret_like() -> None:
+    redactor = SecretRedactor(redact_urls=True)
+
+    redacted = redactor.redact_value(
+        {
+            "client_secret": "structured-client-value",
+            "headers": {"Authorization": "Basic structured-auth-value"},
+            "safe": "visible",
+        }
+    )
+
+    rendered = repr(redacted)
+    assert "structured-client-value" not in rendered
+    assert "structured-auth-value" not in rendered
+    assert "visible" in rendered


### PR DESCRIPTION
## 요약
Secret safety 회귀 검증을 중앙 redaction 경계 기준으로 정리했습니다. 개별 callsite마다 수동 조건을 늘리는 대신 `SecretRedactor`를 shared utility로 두고, credential-shaped 문자열과 structured mapping 값을 한 곳에서 처리하도록 했습니다.

로그, provider/runtime error, worker execution result, Agent Runtime session turn, validation details/artifacts, managed PR comment, official review/inline comment, GitHub output tool/poster 경계가 redaction을 거치도록 보강했습니다. JSON/dict-style secret field, Authorization header/assignment, URL userinfo password, Redis URL, structured logging extra, fake fixture 문자열도 회귀 테스트에 포함했습니다.

Closes #96

---
Co-worked by Hermes Agent